### PR TITLE
fix PENPOT-1686 removing the timeout dependancy

### DIFF
--- a/pages/workspace/view-mode-page.js
+++ b/pages/workspace/view-mode-page.js
@@ -16,12 +16,9 @@ exports.ViewModePage = class ViewModePage extends BasePage {
   }
 
   async clickViewModeButton() {
+    const popupPromise = this.page.waitForEvent('popup');
     await this.viewModeButton.click();
-    const [newPage] = await Promise.all([
-      this.page.context().waitForEvent('page'),
-      this.page.waitForTimeout(300),
-    ]);
-    return newPage;
+    return popupPromise;
   }
 
   async openInspectTab() {


### PR DESCRIPTION
Fixes the `PENPOT-1686 Check Inspect tab' + 'PENPOT-1687 Check Interactions tab` test by refactoring the method `clickViewModeButton method` in the `view-mode-page.js` POM.

![giphy](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbWFvMzZjcW8xeWVia2FvdWRoeTM1dTFqYWtyMGRzamN0MmdpOHpuOSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l2JefhuLRZWPnxF1m/giphy.gif)