### PR TITLE
Fixes goToAccountPage to read the fomain from env variables

### DIFF
--- a/pages/profile-page.js
+++ b/pages/profile-page.js
@@ -60,7 +60,8 @@ exports.ProfilePage = class ProfilePage extends BasePage {
   }
 
   async goToAccountPage() {
-    await this.page.goto('https://design.penpot.dev/#/settings/profile');
+    const baseUrl = process.env.BASE_URL;
+    await this.page.goto(baseUrl.concat('#/settings/profile'));
   }
 
   async openGiveFeedbackPage() {


### PR DESCRIPTION
Currently the goTo URL it's fixed, so it would just work agains the PRE environment (`design.penpot.dev`). This test will fail, for instance, against `localhost` or `design.penpot.app environment`.

This change will read the URL domain from the `BASE_URL` env variable.

### What to test

- [x] Review the code
- [x] Execute the test 1677 against PRE `design.penpot.dev`
- [x] Execute the test 1677 locally http://localhost:3449/
- [ ] Execute the test 1677 against PRO `design.penpot.app`  (optional)
- [x] Hi five

> `npx playwright test --project=chrome -gv 'PERF' -g '1677'`