### PR TITLE
Fix PENPOT-1686, CO-212, Increase maxDiffPixelRatio for different linux distros

### DIFF
--- a/tests/composition/composition-text.spec.js
+++ b/tests/composition/composition-text.spec.js
@@ -276,12 +276,12 @@ test.describe(() => {
     await designPanelPage.changeTextDirection('RTL');
     await mainPage.waitForChangeIsSaved();
     await expect(mainPage.viewport).toHaveScreenshot('text-rtl.png', {
-      maxDiffPixels: 0,
+      maxDiffPixels: 30,
     });
     await designPanelPage.changeTextDirection('LTR');
     await mainPage.waitForChangeIsSaved();
     await expect(mainPage.viewport).toHaveScreenshot('text-ltr.png', {
-      maxDiffPixels: 0,
+      maxDiffPixels: 40,
     });
   });
 

--- a/tests/ui-theme/ui-theme-features-light-mode.spec.js
+++ b/tests/ui-theme/ui-theme-features-light-mode.spec.js
@@ -127,12 +127,12 @@ test.describe('Settings - UI THEME', () => {
       viewModePage = new ViewModePage(newPage);
       await expect(viewModePage.viewerLoyautSection).toHaveScreenshot(
         'view-mode-page-image.png',
-        { maxDiffPixelRatio: 0 },
+        { maxDiffPixelRatio: 0.0002 },
       );
       await viewModePage.openInspectTab();
       await expect(viewModePage.viewerLoyautSection).toHaveScreenshot(
         'view-mode-inspect-page-image.png',
-        { maxDiffPixelRatio: 0 },
+        { maxDiffPixelRatio: 0.0002 },
       );
     },
   );


### PR DESCRIPTION
This PR allow not to fail two tests executed in other linux distos (different from the ones who originally created the screenshots), relaxing the zero pixel policy. 
The pixel proportion it just increased to the minimum required to make the test pass, without invalidating the original test.

Note: the [pixel discrepances](https://tree.taiga.io/project/kaleidos-qa/task/57) between different linux distros were minimal, mainly focused on how the fonts where rendered.
![image](https://github.com/penpot/penpotqa/assets/4539017/35cba95c-5233-46b3-a5a6-37c77c034087)

### What to test
- [x] Review the code
- [x] Execute the test CO-212. It should pass
- [x] Execute the test CO-212, interchanging the two screenshots (text-rtl.png <--> text-rtl.png). It should fail.
- [x] Execute the test PENPOT-1686. It should pass
There's not an easy way to verify this test (make it to fail), as it always creates a default 100x100px and its always rendered the same in the view-mode.