### PR TITLE
chore(prettier) Added automatic Prettier formatting to run before commits

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+prettier $(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g') --write --ignore-unknown
+git update-index --again

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.45.3",
-        "dotenv": "^16.3.1"
+        "dotenv": "^16.3.1",
+        "husky": "^9.1.6"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -734,6 +735,22 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.6.tgz",
+      "integrity": "sha512-sqbjZKK7kf44hfdE94EoX8MZNk0n7HeW37O4YrVGCF4wzgQjp+akPAkfUK5LZ6KuR/6sqeAVuXHji+RzQgOn5A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/is-stream": {
@@ -1650,6 +1667,12 @@
         "agent-base": "^7.0.2",
         "debug": "4"
       }
+    },
+    "husky": {
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.6.tgz",
+      "integrity": "sha512-sqbjZKK7kf44hfdE94EoX8MZNk0n7HeW37O4YrVGCF4wzgQjp+akPAkfUK5LZ6KuR/6sqeAVuXHji+RzQgOn5A==",
+      "dev": true
     },
     "is-stream": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "webkit": "npx playwright test --project=webkit -gv 'PERF'",
     "performance": "npx playwright test --retries=1 --timeout=555550000 --project=chrome -g 'PERF'",
     "performance:debug": "npx playwright test --debug --timeout=555550000 --project=chrome -g 'PERF'",
-    "prettier": "npx prettier --write ."
+    "prettier": "npx prettier --write .",
+    "prepare": "husky"
   },
   "repository": {
     "type": "git",
@@ -26,7 +27,8 @@
   "homepage": "https://github.com/penpot/penpotqa#readme",
   "devDependencies": {
     "@playwright/test": "^1.45.3",
-    "dotenv": "^16.3.1"
+    "dotenv": "^16.3.1",
+    "husky": "^9.1.6"
   },
   "dependencies": {
     "axios": "^1.6.8",


### PR DESCRIPTION
Added automatic Prettier formatting locally before committing.

After pulling these changes, run npm install.
From now on, every time you commit, Prettier will automatically format the code, include those changes in the commit, and then proceed with the commit itself.