### PR TITLE
fix(test): fix flaky 2175 test

### DIFF
--- a/tests/tokens/tokens.spec.js
+++ b/tests/tokens/tokens.spec.js
@@ -163,7 +163,6 @@ mainTest(
     await tokensPage.createRotationToken(tokenName, tokenValue);
     await tokensPage.isTokenVisibleWithName(tokenName);
     await tokensPage.clickOnTokenWithName(tokenName);
-    await tokensPage.waitForChangeIsSaved();
     await tokensPage.isTokenAppliedWithName(tokenName);
     await designPanelPage.checkRotationForLayer(tokenResolvedValue);
     browserName === 'chromium' ? await tokensPage.waitForChangeIsUnsaved() : null;


### PR DESCRIPTION
A small fix for improving the stability of test 2175 — currently the issue exists only on CI for the Chrome browser.
If this fix doesn't help, we might need to add a short time-based wait (50–100 ms) in the future.