### PR TITLE
feat(pages): add test for undo delete page functionality

### DIFF
--- a/pages/profile-page.js
+++ b/pages/profile-page.js
@@ -122,7 +122,7 @@ exports.ProfilePage = class ProfilePage extends BasePage {
   }
 
   async isPasswordHidden(passwordInput) {
-    // The type 'password' is the *** displayed on the password when is hidden.
+    // The type 'password' attribute indicates the password field is hidden (displayed as asterisks).
     await expect(passwordInput, 'Password is hidden').toHaveAttribute(
       'type',
       'password',

--- a/tests/panels-features/panels-features-pages.spec.js
+++ b/tests/panels-features/panels-features-pages.spec.js
@@ -128,7 +128,7 @@ mainTest(qase(837, 'PF-119 Delete page'), async () => {
 });
 
 mainTest(
-  qase(839, 'Create 3 page, delete 2nd page, undo delete (CTRL Z)'),
+  qase(839, 'Create 3 pages, delete 2nd page, undo delete (CTRL Z)'),
   async ({ browserName }) => {
     await mainPage.clickAddPageButton();
     await mainPage.clickAddPageButton();


### PR DESCRIPTION
# Done Definition Checks

## Description

This PR adds a new test to the project: Create 3 pages, delete the 2nd page, undo delete (CTRL Z)

_What problem are you trying to solve?_

Create 3 pages, delete the 2nd page, undo delete (CTRL Z)

## Solution

Adding a new test on the panels-features-pages.

## How to test

- [x] Check the code
- [x] Update the Automation Status field in Qase
- [x] It complies with the test conventions
- [x] There are no missing snapshots for win32 (x3 browsers)
- [x] The tests run OK
