### PR TITLE
feat(set tokens): add new tests for rename set

### DIFF
--- a/pages/workspace/tokens-panel-page.js
+++ b/pages/workspace/tokens-panel-page.js
@@ -9,6 +9,8 @@ exports.TokensPanelPage = class TokensPanelPage extends MainPage {
     super(page);
 
     this.tokensTab = page.getByRole('tab', { name: 'tokens' });
+
+    // Sets locators
     this.createOneSetButton = page
       .locator('[class*="empty-sets-wrapper"]')
       .getByText('Create one.');
@@ -16,7 +18,11 @@ exports.TokensPanelPage = class TokensPanelPage extends MainPage {
     this.setsNameInput = page.getByPlaceholder("Enter name (use '/' for groups)");
     this.setName = page.getByTestId('tokens-set-item');
     this.groupSetName = page.getByTestId('tokens-set-group-item');
+    this.renameContextMenuOption = page
+      .getByRole('listitem')
+      .filter({ hasText: 'Rename' });
 
+    // Themes locators
     this.createOneThemeButton = page
       .locator('[class*="empty-theme-wrapper"]')
       .getByText('Create one.');
@@ -27,6 +33,8 @@ exports.TokensPanelPage = class TokensPanelPage extends MainPage {
     this.backToThemeListButton = page.getByRole('button', {
       name: 'Back to theme list',
     });
+
+    // Tokens locators
     this.tokenSections = page
       .getByTestId('tokens-sidebar')
       .locator('[class*="section-name"]');
@@ -110,7 +118,7 @@ exports.TokensPanelPage = class TokensPanelPage extends MainPage {
   }
 
   async checkFirstSetName(text) {
-    await expect(this.setName.first()).toHaveText(text);
+    await expect(this.setName.first(), `First Set Name is ${text}`).toHaveText(text);
   }
 
   async isSetNameVisible(text) {
@@ -478,5 +486,18 @@ exports.TokensPanelPage = class TokensPanelPage extends MainPage {
 
   async checkInvalidTokenCount(count) {
     await expect(this.invalidToken).toHaveCount(count);
+  }
+
+  async renameSetByDoubleClick(newSetName) {
+    await this.setName.first().dblclick();
+    await this.setsNameInput.fill(newSetName);
+    await this.clickOnEnter();
+  }
+
+  async renameSetViaContextMenu(oldSetName, newSetName) {
+    await this.rightClickOnSetByName(oldSetName);
+    await this.renameContextMenuOption.click();
+    await this.setsNameInput.fill(newSetName);
+    await this.clickOnEnter();
   }
 };

--- a/tests/tokens/sets.spec.js
+++ b/tests/tokens/sets.spec.js
@@ -39,6 +39,32 @@ mainTest(qase(2102, 'Create a set via "create one" link'), async () => {
   await tokensPage.checkFirstSetName(name);
 });
 
+mainTest(qase(2127, 'Rename a set'), async () => {
+  const name = 'Mobile';
+  const newName1 = 'Mobile-Updated-Double-Click';
+  const newName2 = 'Mobile-Updated-Context-Menu';
+
+  await mainTest.step('Create a set', async () => {
+    await tokensPage.clickTokensTab();
+    await tokensPage.createSetViaButton(name);
+    await tokensPage.checkFirstSetName(name);
+  });
+
+  await mainTest.step('Create a color token', async () => {
+    await tokensPage.createColorToken('red', '#ef0c0c');
+  });
+
+  await mainTest.step('Rename set double click and assert name', async () => {
+    await tokensPage.renameSetByDoubleClick(newName1);
+    await tokensPage.checkFirstSetName(newName1);
+  });
+
+  await mainTest.step('Rename set via context menu and assert name', async () => {
+    await tokensPage.renameSetViaContextMenu(newName1, newName2);
+    await tokensPage.checkFirstSetName(newName2);
+  });
+});
+
 mainTest(qase(2139, 'Enable and Disable sets'), async () => {
   await tokensPage.createDefaultRectangleByCoordinates(100, 200);
 


### PR DESCRIPTION
# Done Definition Checks

## Description

Add new test for rename a set in Tokens section to cover manual regression test (PENPOT-2127).

## Solution

Added new locators and methods for renaming in tokens-panel-page.js file.
Added a new test in tests/tokens/sets.spec.js file.

## How to test

- [x] Check the code
- [x] Update the Automation Status field in Qase
- [x] It complies with the test conventions
- [x] There are no missing snapshots for win32 (x3 browsers)
- [x] The tests run OK
