### PR TITLE
fix(test): fix 874, 1930

### DIFF
--- a/pages/base-page.js
+++ b/pages/base-page.js
@@ -18,7 +18,7 @@ exports.BasePage = class BasePage {
     this.wrapperMessage = page.getByTestId('actionable');
     this.moveButton = page.getByRole('button', { name: 'Move (V)' });
     this.savedChangesIcon = page.locator('div[title="Saved"]');
-    this.unsavedChangesIcon = page.locator('div[title="Saving"]');
+    this.unSavedChangesIcon = page.locator('div[title="Saving"]');
     this.viewport = page.locator('div[class*="viewport"] >> nth=0');
     this.resizeHandler = page.locator('[class="resize-handler"]');
 
@@ -282,7 +282,7 @@ exports.BasePage = class BasePage {
   }
 
   async waitForChangeIsUnsaved() {
-    await this.unsavedChangesIcon.waitFor({ state: 'visible' });
+    await this.unSavedChangesIcon.waitFor({ state: 'visible' });
   }
 
   async waitForResizeHandlerVisible() {

--- a/pages/base-page.js
+++ b/pages/base-page.js
@@ -17,8 +17,8 @@ exports.BasePage = class BasePage {
     this.infoMessage = page.locator('div[class*="main_ui_messages__banner"]');
     this.wrapperMessage = page.getByTestId('actionable');
     this.moveButton = page.getByRole('button', { name: 'Move (V)' });
-    this.savedChangesIcon = page.locator('div[title="Saved"]');
-    this.unSavedChangesIcon = page.locator('div[title="Saving"]');
+    this.savedChangesIcon = page.getByTitle('Saved', { exact: true });
+    this.unSavedChangesIcon = page.getByTitle('Saving', { exact: true });
     this.viewport = page.locator('div[class*="viewport"] >> nth=0');
     this.resizeHandler = page.locator('[class="resize-handler"]');
 

--- a/pages/workspace/history-panel-page.js
+++ b/pages/workspace/history-panel-page.js
@@ -168,7 +168,7 @@ exports.HistoryPanelPage = class HistoryPanelPage extends MainPage {
     }
   }
 
-  async clickShortcutAltH() {
-    await this.page.keyboard.press('Alt+Z');
+  async clickShortcutCtrlAltH() {
+    await this.page.keyboard.press('Control+Alt+H');
   }
 };

--- a/pages/workspace/main-page.js
+++ b/pages/workspace/main-page.js
@@ -197,7 +197,6 @@ exports.MainPage = class MainPage extends BasePage {
     this.workspaceMenu = page.locator('*[class*="workspace-context-menu"]');
 
     //Header
-    this.unSavedChangesIcon = page.getByTitle('Unsaved changes', { exact: true });
     this.usersSection = page.locator('div[class*="users-section"]');
     this.projectNameSpan = page.locator('div[class*="project-name"]');
     this.fileNameSpan = page.locator('div[class*="file-name"]');

--- a/tests/panels-features/panels-features-history-panel.spec.js
+++ b/tests/panels-features/panels-features-history-panel.spec.js
@@ -65,13 +65,10 @@ mainTest(qase(1931, 'Open history version panel (via main menu)'), async () => {
   await historyPage.isVersionListEmpty();
 });
 
-// mainTest(
-//   qase(1930, 'Open history version panel (shortcut Alt+H)'),
-//   async ({ page }) => {
-//     await historyPage.clickShortcutAltH();
-//     await historyPage.isVersionListEmpty();
-//   },
-// );
+mainTest(qase(1930, 'Open history version panel (shortcut Alt+H)'), async () => {
+  await historyPage.clickShortcutCtrlAltH();
+  await historyPage.isVersionListEmpty();
+});
 
 mainTest.describe(() => {
   const versionName = 'test version';

--- a/tests/panels-features/panels-features-history-panel.spec.js
+++ b/tests/panels-features/panels-features-history-panel.spec.js
@@ -42,14 +42,14 @@ test.afterEach(async ({ page }, testInfo) => {
   await updateTestResults(testInfo.status, testInfo.retry);
 });
 
-mainTest(qase(874, 'PF-156 Perform a change and check the status'), async () => {
+mainTest(qase(874, 'Perform a change and check the status'), async () => {
   await mainPage.clickCreateEllipseButton();
   await mainPage.clickViewportTwice();
   await mainPage.isUnSavedChangesDisplayed();
   await mainPage.waitForChangeIsSaved();
 });
 
-mainTest(qase(890, 'PF-172 Open history panel with recent changes'), async () => {
+mainTest(qase(890, 'Open history panel with recent changes'), async () => {
   await mainPage.clickCreateBoardButton();
   await mainPage.clickViewportTwice();
   await mainPage.waitForChangeIsSaved();


### PR DESCRIPTION
# Done Definition Checks

## Description

This PR resolves issues with a broken test and a disabled test.
What? I fixed test 874 and restored test 1930.
Why? Test 874 was failing due to an outdated locator. Test 1930 was commented out for a long time because of a bug with a non-working shortcut. Now that the shortcut has been changed and the bug has been fixed, test 1930 is now functional and has been re-enabled.
How? I updated the locator in test 874 and uncommented test 1930 to restore it.

## Solution

Fixing test 874 by updating its locator.
Restoring test 1930 after the related shortcut bug was resolved.

## How to test

- [ ] Check the code
- [ ] Update the Automation Status field in Qase
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK