### PR TITLE
feature(test): add subscriptions tests

### DIFF
--- a/.github/workflows/playwright_pr_manual.yml
+++ b/.github/workflows/playwright_pr_manual.yml
@@ -40,6 +40,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.run_all_tests }}" = "true" ]; then
             echo "Running all tests..."

--- a/.github/workflows/playwright_pre_assets_colors.yml
+++ b/.github/workflows/playwright_pre_assets_colors.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/assets/assets-color.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_assets_shortcuts_panel.yml
+++ b/.github/workflows/playwright_pre_assets_shortcuts_panel.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/assets/assets-shortcuts-panel.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_assets_typographies.yml
+++ b/.github/workflows/playwright_pre_assets_typographies.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/assets/assets-typographies.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_color.yml
+++ b/.github/workflows/playwright_pre_color.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/color/color-picker.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_componens.yml
+++ b/.github/workflows/playwright_pre_componens.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/components
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_component_grid_layout.yml
+++ b/.github/workflows/playwright_pre_component_grid_layout.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/components/main-components/component-grid-layout.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_composition_board.yml
+++ b/.github/workflows/playwright_pre_composition_board.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/composition/composition-board.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_composition_comments.yml
+++ b/.github/workflows/playwright_pre_composition_comments.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/composition/composition-comments.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_composition_curve.yml
+++ b/.github/workflows/playwright_pre_composition_curve.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/composition/composition-curve.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_composition_ellipse.yml
+++ b/.github/workflows/playwright_pre_composition_ellipse.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/composition/composition-ellipse.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_composition_flex_layout.yml
+++ b/.github/workflows/playwright_pre_composition_flex_layout.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/composition/composition-flex-layout.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_composition_grid_layout.yml
+++ b/.github/workflows/playwright_pre_composition_grid_layout.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/composition/composition-grid-layout.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_composition_image.yml
+++ b/.github/workflows/playwright_pre_composition_image.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/composition/composition-image.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_composition_path.yml
+++ b/.github/workflows/playwright_pre_composition_path.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/composition/composition-path.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_composition_path_node_panel.yml
+++ b/.github/workflows/playwright_pre_composition_path_node_panel.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/composition/composition-path-node-panel.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_composition_rectangle.yml
+++ b/.github/workflows/playwright_pre_composition_rectangle.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/composition/composition-rectangle.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_composition_text.yml
+++ b/.github/workflows/playwright_pre_composition_text.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/composition/composition-text.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_daily.yml
+++ b/.github/workflows/playwright_pre_daily.yml
@@ -29,6 +29,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF'
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_dashboard_files.yml
+++ b/.github/workflows/playwright_pre_dashboard_files.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/dashboard/dashboard-files.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_dashboard_fonts.yml
+++ b/.github/workflows/playwright_pre_dashboard_fonts.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/dashboard/dashboard-fonts.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_dashboard_libraries.yml
+++ b/.github/workflows/playwright_pre_dashboard_libraries.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/dashboard/dashboard-libraries.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_dashboard_teams.yml
+++ b/.github/workflows/playwright_pre_dashboard_teams.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/dashboard/dashboard-teams.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_firefox.yml
+++ b/.github/workflows/playwright_pre_firefox.yml
@@ -37,6 +37,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=firefox -gv 'PERF'
 
       - name: Upload Playwright Report

--- a/.github/workflows/playwright_pre_flex_layout.yml
+++ b/.github/workflows/playwright_pre_flex_layout.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/components/main-components/flext-layout-cases.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_forgot_password.yml
+++ b/.github/workflows/playwright_pre_forgot_password.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/forgot-password.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_library_backup_page.yml
+++ b/.github/workflows/playwright_pre_library_backup_page.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/assets/library-backup-page.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_login.yml
+++ b/.github/workflows/playwright_pre_login.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/login.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_panels_features_export.yml
+++ b/.github/workflows/playwright_pre_panels_features_export.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/panels-features/panels-features-export.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_panels_features_fill.yml
+++ b/.github/workflows/playwright_pre_panels_features_fill.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/panels-features/panels-features-fill.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_panels_features_grid.yml
+++ b/.github/workflows/playwright_pre_panels_features_grid.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/panels-features/panels-features-grid.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_panels_features_history_panel.yml
+++ b/.github/workflows/playwright_pre_panels_features_history_panel.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/panels-features/panels-features-history-panel.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_panels_features_main_menu.yml
+++ b/.github/workflows/playwright_pre_panels_features_main_menu.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/panels-features/panels-features-main-menu.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_panels_features_pages.yml
+++ b/.github/workflows/playwright_pre_panels_features_pages.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/panels-features/panels-features-pages.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_panels_features_prototype.yml
+++ b/.github/workflows/playwright_pre_panels_features_prototype.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/panels-features/panels-features-prototype.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_panels_features_zoom.yml
+++ b/.github/workflows/playwright_pre_panels_features_zoom.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/panels-features/panels-features-zoom.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_profile.yml
+++ b/.github/workflows/playwright_pre_profile.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/profile.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_qase.yml
+++ b/.github/workflows/playwright_pre_qase.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF'
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_shared-libraries.yml
+++ b/.github/workflows/playwright_pre_shared-libraries.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/assets/shared-libraries.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_signup.yml
+++ b/.github/workflows/playwright_pre_signup.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/signup.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_ui_theme_light_mode.yml
+++ b/.github/workflows/playwright_pre_ui_theme_light_mode.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/ui-theme/ui-theme-features-light-mode.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_update_main_componens.yml
+++ b/.github/workflows/playwright_pre_update_main_componens.yml
@@ -53,6 +53,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=chrome -gv 'PERF' ./tests/components/main-components/update-main-components.spec.js
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright_pre_webkit.yml
+++ b/.github/workflows/playwright_pre_webkit.yml
@@ -37,6 +37,7 @@ jobs:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
+          STRIPE_SK: ${{ secrets.STRIPE_SK }}
         run: npx playwright test --project=webkit -gv 'PERF'
 
       - name: Upload Playwright Report

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Prerequisites for local run:
   - `REFRESH_TOKEN` (Token for email access)
   - `CLIENT_ID` (for email access)
   - `CLIENT_SECRET` (for email access)
+  - `STRIPE_SK` (for Stripe API access)
 
 **2. Test run - main notes.**
 

--- a/helpers/stripe.js
+++ b/helpers/stripe.js
@@ -1,0 +1,211 @@
+const Stripe = require('stripe');
+const axios = require('axios');
+const stripe = Stripe(process.env.STRIPE_SK);
+
+const { expect } = require('@playwright/test');
+
+async function getSubscriptionsByCustomerId(customerId) {
+  try {
+    const subscriptions = await stripe.subscriptions.list({
+      customer: customerId,
+      limit: 10,
+    });
+    return subscriptions.data;
+  } catch (error) {
+    console.error(
+      `Error receiving subscriptions for the client ${customerId}:`,
+      error,
+    );
+  }
+}
+
+async function findCustomersByEmail(email) {
+  try {
+    const customers = await stripe.customers.search({
+      query: `email:"${email}"`,
+    });
+    return customers.data;
+  } catch (error) {
+    console.error(`Error when searching for clients by email "${email}":`, error);
+  }
+}
+
+async function updateSubscription(subscriptionId, body) {
+  try {
+    return await stripe.subscriptions.update(subscriptionId, body);
+  } catch (error) {
+    console.error(
+      `Error when updating subscription trial period ${subscriptionId}:`,
+      error,
+    );
+  }
+}
+
+async function getSubscriptionsByCustomerEmail(page, email) {
+  const customersData = await waitCustomersWithEmail(page, email);
+  const customerId = customersData[0].id;
+  return await getSubscriptionsByCustomerId(customerId);
+}
+
+async function updateSubscriptionTrialEnd(
+  page,
+  email,
+  trialEndTime = getTomorrowUnixTimestamp(),
+) {
+  const subscriptions = await getSubscriptionsByCustomerEmail(page, email);
+  const subscriptionId = subscriptions[0].id;
+  const body = { trial_end: trialEndTime };
+  return await updateSubscription(subscriptionId, body);
+}
+
+async function getActualExpirationDate() {
+  const date = new Date();
+  const currentMonth = date.getMonth() + 1;
+  const monthString = String(currentMonth).padStart(2, '0');
+  const futureYear = date.getFullYear() + 3;
+  const yearString = String(futureYear).slice(-2);
+  return `${monthString} ${yearString}`;
+}
+
+function getTomorrowUnixTimestamp() {
+  const today = new Date();
+  today.setDate(today.getDate() + 1);
+  return Math.floor(today.getTime() / 1000);
+}
+
+function getUnixTimestampInDays(days, today = new Date()) {
+  today.setDate(today.getDate() + days);
+  return Math.floor(today.getTime() / 1000);
+}
+
+function getUnixTimestampInMonths(months, today = new Date()) {
+  today.setMonth(today.getMonth() + months);
+  return Math.floor(today.getTime() / 1000);
+}
+
+async function waitCustomersWithEmail(
+  page,
+  email,
+  timeout = 30000,
+  interval = 3000,
+) {
+  const startTime = Date.now();
+  while (Date.now() - startTime < timeout) {
+    const customers = await findCustomersByEmail(email);
+    if (customers && customers.length > 0) {
+      return customers;
+    }
+    await page.waitForTimeout(interval);
+  }
+  console.error(
+    `The timeout for searching for clients by email "${email}" has been exhausted.`,
+  );
+}
+
+async function createCustomerWithTestClock(page, name, email) {
+  const testClock = await createTestClock();
+  const testClockId = testClock.id;
+  const penpotId = await getProfileIdByEmail(email);
+
+  await createCustomer(name, email, testClockId, penpotId);
+  await waitCustomersWithEmail(page, email);
+  return testClockId;
+}
+
+async function createCustomer(name, email, testClockId, penpotId) {
+  try {
+    return await stripe.customers.create({
+      name: name,
+      email: email,
+      test_clock: testClockId,
+      metadata: {
+        penpotId: penpotId,
+      },
+    });
+  } catch (error) {
+    console.error(`Error when creating customer:`, error);
+  }
+}
+
+async function createTestClock() {
+  try {
+    return await stripe.testHelpers.testClocks.create({
+      frozen_time: Math.floor(Date.now() / 1000 - 10),
+    });
+  } catch (error) {
+    console.error(`Error when creating test clock:`, error);
+  }
+}
+
+async function advanceTestClock(testClockId, time) {
+  try {
+    return await stripe.testHelpers.testClocks.advance(testClockId, {
+      frozen_time: time,
+    });
+  } catch (error) {
+    console.error(`Error during accelerated test clock:`, error);
+  }
+}
+
+async function loginInPenpot(email, password) {
+  const url = `${process.env.BASE_URL}api/rpc/command/login-with-password`;
+
+  try {
+    return await axios.post(
+      url,
+      {
+        email: email,
+        password: password,
+      },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+  } catch (error) {
+    if (error.response) {
+      console.error('Login failed with status:', error.response.status);
+      console.error('Response data:', error.response.data);
+    } else if (error.request) {
+      console.error('No response received from the server:', error.request);
+    } else {
+      console.error('Error setting up the request:', error.message);
+    }
+    throw error;
+  }
+}
+
+async function getProfileIdByEmail(email, pass = process.env.LOGIN_PWD) {
+  const cookieString = await loginInPenpot(email, pass);
+  const parts = cookieString.headers['set-cookie'][0].split(';');
+  const authDataPart = parts.find((part) => part.trim().startsWith('auth-data='));
+  const profileId = authDataPart.split('=')[2].slice(0, -1);
+
+  return profileId ? profileId : null;
+}
+
+async function skipSubscriptionByDays(email, testClockId, days, date = new Date()) {
+  const time = getUnixTimestampInDays(days, date);
+  await advanceTestClock(testClockId, time);
+  return new Date(time * 1000);
+}
+
+async function skipSubscriptionByMonths(
+  email,
+  testClockId,
+  months,
+  date = new Date(),
+) {
+  const time = getUnixTimestampInMonths(months, date);
+  await advanceTestClock(testClockId, time);
+  return new Date(time * 1000);
+}
+
+module.exports = {
+  createCustomerWithTestClock,
+  skipSubscriptionByDays,
+  skipSubscriptionByMonths,
+  updateSubscriptionTrialEnd,
+  getActualExpirationDate,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "playwright-qase-reporter": "^2.1.5",
         "prettier": "^3.0.1",
         "qaseio": "^2.4.3",
+        "stripe": "^18.3.0",
         "ts-node": "^10.9.2"
       },
       "devDependencies": {
@@ -1341,6 +1342,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/stripe": {
+      "version": "18.3.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-18.3.0.tgz",
+      "integrity": "sha512-FkxrTUUcWB4CVN2yzgsfF/YHD6WgYHduaa7VmokCy5TLCgl5UNJkwortxcedrxSavQ8Qfa4Ir4JxcbIYiBsyLg==",
+      "license": "MIT",
+      "dependencies": {
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      },
+      "peerDependencies": {
+        "@types/node": ">=12.x.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -2347,6 +2368,14 @@
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "requires": {
         "ansi-regex": "^5.0.1"
+      }
+    },
+    "stripe": {
+      "version": "18.3.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-18.3.0.tgz",
+      "integrity": "sha512-FkxrTUUcWB4CVN2yzgsfF/YHD6WgYHduaa7VmokCy5TLCgl5UNJkwortxcedrxSavQ8Qfa4Ir4JxcbIYiBsyLg==",
+      "requires": {
+        "qs": "^6.11.0"
       }
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "playwright-qase-reporter": "^2.1.5",
     "prettier": "^3.0.1",
     "qaseio": "^2.4.3",
+    "stripe": "^18.3.0",
     "ts-node": "^10.9.2"
   }
 }

--- a/pages/dashboard/dashboard-page.js
+++ b/pages/dashboard/dashboard-page.js
@@ -231,6 +231,7 @@ exports.DashboardPage = class DashboardPage extends BasePage {
       'Marked all notifications as read',
       { exact: true },
     );
+    this.subscriptionName = page.getByTestId('subscription-name');
   }
 
   async createFileViaPlaceholder() {
@@ -1085,5 +1086,9 @@ exports.DashboardPage = class DashboardPage extends BasePage {
 
   async clickOnModalAcceptButton() {
     await this.modalAcceptButton.click();
+  }
+
+  async checkSubscriptionName(name) {
+    await expect(this.subscriptionName).toHaveText(name);
   }
 };

--- a/pages/dashboard/stripe-page.js
+++ b/pages/dashboard/stripe-page.js
@@ -1,0 +1,223 @@
+const { BasePage } = require('../base-page');
+const { expect } = require('@playwright/test');
+const { getActualExpirationDate } = require('../../helpers/stripe');
+
+exports.StripePage = class StripePage extends BasePage {
+  /**
+   * @param {import('@playwright/test').Page} page
+   */
+  constructor(page) {
+    super(page);
+
+    // Teams
+    this.addPaymentMethodButton = page.getByText('Add payment method');
+    this.iframeAddCardModal = page
+      .locator('[class="StripeElement"]')
+      .frameLocator('iframe[role="presentation"]');
+    this.cardNumberImput = this.iframeAddCardModal.locator('input[name="number"]');
+    this.cardExpirationDateImput = this.iframeAddCardModal.locator(
+      'input[name="expiry"]',
+    );
+    this.cardCVCImput = this.iframeAddCardModal.locator('input[name="cvc"]');
+    this.confirmButton = page.getByTestId('confirm');
+    this.returnToPenpotButton = page.getByText('Return to Penpot');
+    this.updateSubscriptionButton = page.getByText('Update subscription');
+    this.cancelSubscriptionButton = page.getByText('Cancel subscription');
+    this.selectButton = page.getByText('Select');
+    this.continueButton = page.getByText('Continue');
+    this.trialEnds = page.getByTestId('trial-ending-badge');
+    this.trialEndsDate = this.trialEnds.locator('span span span');
+    this.cancelsEnds = page.locator(
+      '[data-test="subscription-cancel-at-period-end-badge"]',
+    );
+    this.cancelSubscriptionHeader = page.getByText('Cancel your subscription');
+    this.noLongerNeedItRadioButton = page.getByText('I no longer need it', {
+      exact: true,
+    });
+    this.submitButton = page.getByTestId('cancellation_reason_submit');
+    this.invoiceRow = page.getByTestId('hip-link');
+    this.lastInvoice = this.invoiceRow.first();
+  }
+
+  async clickOnAddPaymentMethodButton() {
+    await this.addPaymentMethodButton.click();
+  }
+
+  async enterCardNumber(number = '4242424242424242') {
+    await this.cardNumberImput.fill(number);
+  }
+
+  async enterCardExpirationDate(date) {
+    await this.cardExpirationDateImput.fill(date);
+  }
+
+  async enterCardCVC(cvc = '123') {
+    await this.cardCVCImput.fill(cvc);
+  }
+
+  async clickOnAddCardButton() {
+    await this.confirmButton.click();
+  }
+
+  async addDefaultCard() {
+    await this.clickOnAddPaymentMethodButton();
+    await this.enterCardNumber();
+    await this.enterCardExpirationDate(await getActualExpirationDate());
+    await this.enterCardCVC();
+    await this.clickOnAddCardButton();
+  }
+
+  async clickOnReturnToPenpotButton() {
+    await this.returnToPenpotButton.click();
+  }
+
+  async isVisaCardAdded(added = true, last4Digits = '4242') {
+    const card = await this.page.getByText(`Visa •••• ${last4Digits}`);
+    added ? await expect(card).toBeVisible() : await expect(card).not.toBeVisible();
+  }
+
+  async clickOnUpdateSubscriptionButton() {
+    await this.updateSubscriptionButton.click();
+  }
+
+  async clickOnSelectButton() {
+    await this.selectButton.click();
+  }
+
+  async clickOnContinueButton() {
+    await this.continueButton.click();
+  }
+
+  async clickOnConfirmButton() {
+    await this.confirmButton.click();
+  }
+
+  async changeSubscription() {
+    await this.clickOnUpdateSubscriptionButton();
+    await this.clickOnSelectButton();
+    await this.clickOnContinueButton();
+    await this.clickOnConfirmButton();
+  }
+
+  async checkCurrentSubscription(subscription = 'Unlimited') {
+    const subscriptionLocator = await this.page.getByText(`Penpot ${subscription}`, {
+      exact: true,
+    });
+    await expect(subscriptionLocator).toBeVisible();
+  }
+
+  async isTrialEndsVisible(visible = true) {
+    visible
+      ? await expect(this.trialEnds).toBeVisible()
+      : await expect(this.trialEnds).not.toBeVisible();
+  }
+
+  async isTrialEndsTomorrow() {
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const tomorrowFormatted = tomorrow.toLocaleDateString('en-US', {
+      month: 'short',
+      day: '2-digit',
+    });
+    await expect(this.trialEndsDate).toHaveText(tomorrowFormatted);
+  }
+
+  async waitTrialEndsDisappear(timeout = 30000, interval = 3000) {
+    const startTime = Date.now();
+    while (Date.now() - startTime < timeout) {
+      const isVisible = await this.trialEnds.isVisible();
+      if (!isVisible) {
+        return;
+      }
+      await this.page.reload();
+      await this.page.waitForTimeout(interval);
+    }
+    console.error(`The timeout for trial completion has expired.`);
+    await expect(
+      this.trialEnds,
+      `The timeout for trial completion has expired.`,
+    ).not.toBeVisible({ timeout: 1000 });
+  }
+
+  async waitCancelsEndsDisappear(timeout = 30000, interval = 3000) {
+    const startTime = Date.now();
+    while (Date.now() - startTime < timeout) {
+      const isVisible = await this.cancelsEnds.isVisible();
+      if (!isVisible) {
+        return;
+      }
+      await this.page.reload();
+      await this.page.waitForTimeout(interval);
+    }
+    console.error(`The timeout for cancels completion has expired.`);
+    await expect(
+      this.cancelsEnds,
+      `The timeout for cancels completion has expired.`,
+    ).not.toBeVisible({ timeout: 1000 });
+  }
+
+  async isCancelsEndsVisible(visible = true) {
+    visible
+      ? await expect(this.cancelsEnds).toBeVisible()
+      : await expect(this.cancelsEnds).not.toBeVisible();
+  }
+
+  async clickOnCancelSubscriptionButton() {
+    await this.cancelSubscriptionButton.click();
+  }
+
+  async clickOnNoLongerNeedItRadioButton() {
+    await this.noLongerNeedItRadioButton.click();
+  }
+
+  async clickOnSubmitButton() {
+    await this.submitButton.click();
+  }
+
+  async isCancelSubscriptionHeaderVisible(visible = true) {
+    visible
+      ? await expect(this.cancelSubscriptionHeader).toBeVisible()
+      : await expect(this.cancelSubscriptionHeader).not.toBeVisible();
+  }
+
+  async cancelSubscription() {
+    await this.clickOnCancelSubscriptionButton();
+    await this.isCancelSubscriptionHeaderVisible();
+    await this.clickOnCancelSubscriptionButton();
+    await this.clickOnNoLongerNeedItRadioButton();
+    await this.clickOnSubmitButton();
+    await this.isCancelsEndsVisible();
+  }
+
+  async checkLastInvoiceName(name) {
+    await expect(await this.lastInvoice.getByText(name)).toBeVisible();
+  }
+
+  async checkLastInvoiceStatus(status) {
+    await expect(await this.lastInvoice.getByText(status)).toBeVisible();
+  }
+
+  async checkLastInvoiceAmount(amount) {
+    await expect(await this.lastInvoice.getByText(amount)).toBeVisible();
+  }
+
+  async checkInvoiceAmountCount(amount, expectedCount) {
+    const amountElements = this.invoiceRow.getByText(amount);
+    await expect(amountElements).toHaveCount(expectedCount);
+  }
+
+  async waitInvoiceAmountCount(amount, expectedCount, retries = 4) {
+    for (let i = 0; i < retries; i++) {
+      try {
+        const amountElements = this.invoiceRow.getByText(amount);
+        await expect(amountElements).toHaveCount(expectedCount);
+        return;
+      } catch (error) {
+        await this.page.reload();
+        await this.page.waitForTimeout(3000);
+      }
+    }
+    const finalElements = this.invoiceRow.getByText(amount);
+    await expect(finalElements).toHaveCount(expectedCount);
+  }
+};

--- a/pages/dashboard/team-page.js
+++ b/pages/dashboard/team-page.js
@@ -130,6 +130,18 @@ exports.TeamPage = class TeamPage extends BasePage {
     this.requestFileAccessDescribe = this.accessDialog.getByText(
       'To access this file, you can ask the team owner.',
     );
+    this.subscriptionIcon = page.getByTestId('subscription-icon').first();
+    this.subscriptionIconInTeamDropdown = page
+      .getByRole('menuitem')
+      .getByTestId('subscription-icon')
+      .first();
+    this.enterpriseIcon = this.subscriptionIcon.locator(
+      'svg[class*="icon-character-e"]',
+    );
+    this.unlimitedIcon = this.subscriptionIcon.locator(
+      'svg[class*="icon-character-u"]',
+    );
+    this.teamPlanName = page.locator('[class*="subscription__team-text"]');
   }
 
   async createTeam(teamName) {
@@ -559,5 +571,27 @@ exports.TeamPage = class TeamPage extends BasePage {
       this.renameTeamMenuItem,
       'Rename team button should not be visible',
     ).not.toBeVisible();
+  }
+
+  async isSubscriptionIconVisible(visible = true, subscription = 'Unlimited') {
+    const icon =
+      subscription.toLowerCase() === 'unlimited'
+        ? this.unlimitedIcon
+        : this.enterpriseIcon;
+
+    visible
+      ? await expect(icon).toBeVisible()
+      : await expect(icon).not.toBeVisible();
+  }
+
+  async isSubscriptionIconVisibleInTeamDropdown(visible = true) {
+    await this.openTeamsListIfClosed();
+    visible
+      ? await expect(this.subscriptionIconInTeamDropdown).toBeVisible()
+      : await expect(this.subscriptionIconInTeamDropdown).not.toBeVisible();
+  }
+
+  async checkSubscriptionName(name) {
+    await expect(this.teamPlanName).toHaveText(name);
   }
 };

--- a/pages/profile-page.js
+++ b/pages/profile-page.js
@@ -71,6 +71,25 @@ exports.ProfilePage = class ProfilePage extends BasePage {
       .filter({ hasText: 'Penpot Light' });
     this.uiThemeDropdown = page.locator('[class*="select-wrapper"] >>nth=1');
     this.updateSettingsButton = page.getByTestId('submit-lang-change');
+
+    //Subscription
+    this.subscriptionMenuButton = page.getByTestId('settings-subscription');
+    this.currentPlanLabel = page
+      .locator('h4[class*="subscription__plan-card-title"]')
+      .first();
+    this.startFreeTrialButton = page.getByRole('button', {
+      name: 'Start free trial',
+    });
+    this.changeSubscriptionModalHeader = page.locator(
+      '[class*="subscription__modal-title"]',
+    );
+    this.addPaymentMethodButton = page.getByRole('button', {
+      name: 'Add a payment method to continue after your trial',
+    });
+    this.membersInput = page.locator('input[name="min-members"]');
+    this.manageSubscriptionButton = page.getByRole('button', {
+      name: 'Manage your subscription',
+    });
   }
 
   async openYourAccountPage() {
@@ -219,7 +238,62 @@ exports.ProfilePage = class ProfilePage extends BasePage {
     await this.settingsMenuButton.click();
   }
 
+  async openSubscriptionTab() {
+    await this.subscriptionMenuButton.click();
+  }
+
+  async checkSubscriptionName(name) {
+    await expect(this.currentPlanLabel).toHaveText(name);
+  }
+
+  async isSubscriptionNameVisible() {
+    await expect(this.currentPlanLabel).toBeVisible();
+  }
+
   async getUserName() {
     return await this.profileMenuButton.textContent();
+  }
+
+  async clickOnTrialButton(plan = 'Unlimited') {
+    const planCardLocator = this.page.locator(
+      `//*[contains(@class, "subscription__plan-card-title")][text()="${plan}"]/../../..`,
+    );
+    await planCardLocator
+      .getByRole('button', { name: 'Try it free for 14 days' })
+      .click();
+  }
+
+  async clickOnStartTrialButton() {
+    await this.startFreeTrialButton.click();
+  }
+
+  async checkSubscriptionModalHeader(name) {
+    await expect(this.changeSubscriptionModalHeader).toHaveText(name);
+  }
+
+  async clickOnAddPaymentMethodButton() {
+    await this.addPaymentMethodButton.click();
+  }
+
+  async clickOnManageSubscriptionButton() {
+    await this.manageSubscriptionButton.click();
+  }
+
+  async enterMembers(number) {
+    await this.membersInput.fill(number);
+  }
+
+  async tryTrialForPlan(plan = 'Unlimited', editors) {
+    await this.openYourAccountPage();
+    await this.openSubscriptionTab();
+    await this.clickOnTrialButton(plan);
+    if (plan === 'Unlimited' && editors !== undefined) {
+      await this.enterMembers(editors);
+    }
+    await this.clickOnStartTrialButton();
+    await this.checkSubscriptionModalHeader(`You are ${plan} (trial)!`);
+    await this.closeModalWindow();
+    await this.checkSubscriptionName(`${plan} (trial)`);
+    await this.backToDashboardFromAccount();
   }
 };

--- a/tests/subscription-plans/end-trial-behavior.spec.js
+++ b/tests/subscription-plans/end-trial-behavior.spec.js
@@ -1,0 +1,151 @@
+const { mainTest } = require('../../fixtures');
+const { expect, test } = require('@playwright/test');
+const { random } = require('../../helpers/string-generator');
+const { TeamPage } = require('../../pages/dashboard/team-page');
+const { DashboardPage } = require('../../pages/dashboard/dashboard-page');
+const { updateTestResults } = require('./../../helpers/saveTestResults.js');
+const { qase } = require('playwright-qase-reporter/playwright');
+const { ProfilePage } = require('../../pages/profile-page');
+const { waitMessage } = require('../../helpers/gmail');
+const { LoginPage } = require('../../pages/login-page');
+const { RegisterPage } = require('../../pages/register-page');
+const { StripePage } = require('../../pages/dashboard/stripe-page');
+const {
+  createCustomerWithTestClock,
+  skipSubscriptionByDays,
+} = require('../../helpers/stripe');
+
+let teamPage, dashboardPage, profilePage, loginPage, registerPage, stripePage;
+const teamName = random().concat('autotest');
+
+test.beforeEach(async ({ page }) => {
+  test.slow();
+  teamPage = new TeamPage(page);
+  dashboardPage = new DashboardPage(page);
+  profilePage = new ProfilePage(page);
+  loginPage = new LoginPage(page);
+  registerPage = new RegisterPage(page);
+  stripePage = new StripePage(page);
+});
+
+test.afterEach(async ({ page }, testInfo) => {
+  await teamPage.deleteTeam(teamName);
+  await updateTestResults(testInfo.status, testInfo.retry);
+});
+
+test(
+  qase([2297, 2344], 'Trial ends, payment method added → switch to Unlimited'),
+  async ({ page }) => {
+    const currentPlan = 'Unlimited';
+    const name = random().concat('autotest');
+    const email = `${process.env.GMAIL_NAME}+${name}@gmail.com`;
+
+    await loginPage.goto();
+    await loginPage.acceptCookie();
+    await loginPage.clickOnCreateAccount();
+    await registerPage.registerAccount(name, email, process.env.LOGIN_PWD);
+    await registerPage.isRegisterEmailCorrect(email);
+    const invite = await waitMessage(page, email, 40);
+    await page.goto(invite.inviteUrl);
+    await dashboardPage.fillOnboardingQuestions();
+    await teamPage.createTeam(teamName);
+    await teamPage.isTeamSelected(teamName);
+
+    const testClockId = await createCustomerWithTestClock(page, name, email);
+
+    await profilePage.tryTrialForPlan(currentPlan);
+    await profilePage.openYourAccountPage();
+    await profilePage.openSubscriptionTab();
+    await profilePage.clickOnAddPaymentMethodButton();
+    await stripePage.addDefaultCard();
+    await stripePage.isVisaCardAdded(true);
+
+    await skipSubscriptionByDays(email, testClockId, 16);
+
+    await stripePage.waitTrialEndsDisappear();
+    await stripePage.checkCurrentSubscription(currentPlan);
+    await stripePage.clickOnReturnToPenpotButton();
+    await profilePage.checkSubscriptionName(currentPlan);
+    await profilePage.backToDashboardFromAccount();
+    await dashboardPage.checkSubscriptionName(currentPlan + ' plan');
+  },
+);
+
+test(
+  qase(
+    2301,
+    'Trial ends, no payment method ever added → switch to Professional (CANCELLED)',
+  ),
+  async ({ page }) => {
+    const currentPlan = 'Unlimited';
+    const defaultPlan = 'Professional';
+    const name = random().concat('autotest');
+    const email = `${process.env.GMAIL_NAME}+${name}@gmail.com`;
+
+    await loginPage.goto();
+    await loginPage.acceptCookie();
+    await loginPage.clickOnCreateAccount();
+    await registerPage.registerAccount(name, email, process.env.LOGIN_PWD);
+    await registerPage.isRegisterEmailCorrect(email);
+    const invite = await waitMessage(page, email, 40);
+    await page.goto(invite.inviteUrl);
+    await dashboardPage.fillOnboardingQuestions();
+    await teamPage.createTeam(teamName);
+    await teamPage.isTeamSelected(teamName);
+
+    const testClockId = await createCustomerWithTestClock(page, name, email);
+
+    await profilePage.tryTrialForPlan(currentPlan);
+    await profilePage.openYourAccountPage();
+    await profilePage.openSubscriptionTab();
+    await profilePage.clickOnManageSubscriptionButton();
+    await stripePage.isTrialEndsVisible();
+    await stripePage.cancelSubscription();
+
+    await skipSubscriptionByDays(email, testClockId, 20);
+
+    await stripePage.waitCancelsEndsDisappear();
+    await stripePage.isCancelsEndsVisible(false);
+    await stripePage.clickOnReturnToPenpotButton();
+
+    await profilePage.checkSubscriptionName(defaultPlan);
+    await profilePage.backToDashboardFromAccount();
+    await dashboardPage.checkSubscriptionName(defaultPlan + ' plan');
+  },
+);
+
+test(
+  qase(2337, 'Trial ends, no payment method → remains in Enterprise Trial (PAUSED)'),
+  async ({ page }) => {
+    const currentPlan = 'Enterprise';
+    const name = random().concat('autotest');
+    const email = `${process.env.GMAIL_NAME}+${name}@gmail.com`;
+
+    await loginPage.goto();
+    await loginPage.acceptCookie();
+    await loginPage.clickOnCreateAccount();
+    await registerPage.registerAccount(name, email, process.env.LOGIN_PWD);
+    await registerPage.isRegisterEmailCorrect(email);
+    const invite = await waitMessage(page, email, 40);
+    await page.goto(invite.inviteUrl);
+    await dashboardPage.fillOnboardingQuestions();
+    await teamPage.createTeam(teamName);
+    await teamPage.isTeamSelected(teamName);
+
+    const testClockId = await createCustomerWithTestClock(page, name, email);
+
+    await profilePage.tryTrialForPlan(currentPlan);
+    await profilePage.openYourAccountPage();
+    await profilePage.openSubscriptionTab();
+    await profilePage.clickOnManageSubscriptionButton();
+    await stripePage.isTrialEndsVisible();
+
+    await skipSubscriptionByDays(email, testClockId, 20);
+
+    await stripePage.waitTrialEndsDisappear();
+    await stripePage.clickOnReturnToPenpotButton();
+    await profilePage.checkSubscriptionName(currentPlan);
+    await profilePage.backToDashboardFromAccount();
+    await dashboardPage.checkSubscriptionName(currentPlan + ' plan');
+  },
+);

--- a/tests/subscription-plans/plan-labels.spec.js
+++ b/tests/subscription-plans/plan-labels.spec.js
@@ -1,0 +1,81 @@
+const { mainTest } = require('../../fixtures');
+const { expect, test } = require('@playwright/test');
+const { random } = require('../../helpers/string-generator');
+const { TeamPage } = require('../../pages/dashboard/team-page');
+const { DashboardPage } = require('../../pages/dashboard/dashboard-page');
+const { updateTestResults } = require('./../../helpers/saveTestResults.js');
+const { qase } = require('playwright-qase-reporter/playwright');
+const { ProfilePage } = require('../../pages/profile-page');
+const { waitMessage } = require('../../helpers/gmail');
+const { LoginPage } = require('../../pages/login-page');
+const { RegisterPage } = require('../../pages/register-page');
+const { StripePage } = require('../../pages/dashboard/stripe-page');
+
+let teamPage, dashboardPage, profilePage, loginPage, registerPage, stripePage;
+const teamName = random().concat('autotest');
+
+test.beforeEach(async ({ page }) => {
+  teamPage = new TeamPage(page);
+  dashboardPage = new DashboardPage(page);
+  profilePage = new ProfilePage(page);
+  loginPage = new LoginPage(page);
+  registerPage = new RegisterPage(page);
+  stripePage = new StripePage(page);
+});
+
+test.afterEach(async ({ page }, testInfo) => {
+  await teamPage.deleteTeam(teamName);
+  await updateTestResults(testInfo.status, testInfo.retry);
+});
+
+test(qase(2281, 'Display & Info for Enterprise Plan'), async ({ page }) => {
+  const currentPlan = 'Enterprise';
+  const name = random().concat('autotest');
+  const email = `${process.env.GMAIL_NAME}+${name}@gmail.com`;
+
+  await loginPage.goto();
+  await loginPage.acceptCookie();
+  await loginPage.clickOnCreateAccount();
+  await registerPage.registerAccount(name, email, process.env.LOGIN_PWD);
+  await registerPage.isRegisterEmailCorrect(email);
+  const invite = await waitMessage(page, email, 40);
+  await page.goto(invite.inviteUrl);
+  await dashboardPage.fillOnboardingQuestions();
+  await teamPage.createTeam(teamName);
+  await teamPage.isTeamSelected(teamName);
+
+  await profilePage.tryTrialForPlan('Unlimited');
+  await profilePage.openYourAccountPage();
+  await profilePage.openSubscriptionTab();
+  await profilePage.clickOnAddPaymentMethodButton();
+  await stripePage.addDefaultCard();
+  await stripePage.isVisaCardAdded(true);
+  await stripePage.changeSubscription();
+  await stripePage.checkCurrentSubscription(currentPlan);
+  await stripePage.clickOnReturnToPenpotButton();
+
+  await profilePage.isSubscriptionNameVisible();
+  await dashboardPage.reloadPage();
+  await profilePage.checkSubscriptionName(currentPlan);
+  await profilePage.backToDashboardFromAccount();
+  await dashboardPage.checkSubscriptionName(currentPlan + ' plan');
+  await teamPage.isSubscriptionIconVisible(true, currentPlan);
+  await teamPage.isSubscriptionIconVisibleInTeamDropdown(true);
+  await teamPage.openTeamSettingsPageViaOptionsMenu();
+  await teamPage.checkSubscriptionName(currentPlan);
+});
+
+mainTest(qase(2283, 'Display & Info for Professional Plan'), async () => {
+  const currentPlan = 'Professional';
+  await teamPage.createTeam(teamName);
+  await teamPage.isTeamSelected(teamName);
+  await profilePage.openYourAccountPage();
+  await profilePage.openSubscriptionTab();
+  await profilePage.checkSubscriptionName(currentPlan);
+  await profilePage.backToDashboardFromAccount();
+  await dashboardPage.checkSubscriptionName(currentPlan + ' plan');
+  await teamPage.isSubscriptionIconVisible(false);
+  await teamPage.isSubscriptionIconVisibleInTeamDropdown(false);
+  await teamPage.openTeamSettingsPageViaOptionsMenu();
+  await teamPage.checkSubscriptionName(currentPlan);
+});

--- a/tests/subscription-plans/plan-switching-logic.spec.js
+++ b/tests/subscription-plans/plan-switching-logic.spec.js
@@ -1,0 +1,154 @@
+const { mainTest } = require('../../fixtures');
+const { expect, test } = require('@playwright/test');
+const { random } = require('../../helpers/string-generator');
+const { TeamPage } = require('../../pages/dashboard/team-page');
+const { DashboardPage } = require('../../pages/dashboard/dashboard-page');
+const { updateTestResults } = require('./../../helpers/saveTestResults.js');
+const { qase } = require('playwright-qase-reporter/playwright');
+const { ProfilePage } = require('../../pages/profile-page');
+const { waitMessage } = require('../../helpers/gmail');
+const { LoginPage } = require('../../pages/login-page');
+const { RegisterPage } = require('../../pages/register-page');
+const { StripePage } = require('../../pages/dashboard/stripe-page');
+const {
+  createCustomerWithTestClock,
+  skipSubscriptionByDays,
+} = require('../../helpers/stripe');
+
+let teamPage, dashboardPage, profilePage, loginPage, registerPage, stripePage;
+const teamName = random().concat('autotest');
+
+test.beforeEach(async ({ page }) => {
+  test.slow();
+  teamPage = new TeamPage(page);
+  dashboardPage = new DashboardPage(page);
+  profilePage = new ProfilePage(page);
+  loginPage = new LoginPage(page);
+  registerPage = new RegisterPage(page);
+  stripePage = new StripePage(page);
+
+  await loginPage.goto();
+  await loginPage.acceptCookie();
+  await loginPage.clickOnCreateAccount();
+});
+
+test.afterEach(async ({ page }, testInfo) => {
+  await teamPage.deleteTeam(teamName);
+  await updateTestResults(testInfo.status, testInfo.retry);
+});
+
+test(qase(2302, 'Switch from Unlimited → Enterprise'), async ({ page }) => {
+  const currentPlan = 'Unlimited';
+  const newPlan = 'Enterprise';
+  const name = random().concat('autotest');
+  const email = `${process.env.GMAIL_NAME}+${name}@gmail.com`;
+  let date = new Date();
+
+  await registerPage.registerAccount(name, email, process.env.LOGIN_PWD);
+  await registerPage.isRegisterEmailCorrect(email);
+  const invite = await waitMessage(page, email, 40);
+  await page.goto(invite.inviteUrl);
+  await dashboardPage.fillOnboardingQuestions();
+  await teamPage.createTeam(teamName);
+  await teamPage.isTeamSelected(teamName);
+
+  const testClockId = await createCustomerWithTestClock(page, name, email);
+
+  await profilePage.tryTrialForPlan(currentPlan);
+  await profilePage.openYourAccountPage();
+  await profilePage.openSubscriptionTab();
+  await profilePage.clickOnAddPaymentMethodButton();
+  await stripePage.addDefaultCard();
+  await stripePage.isVisaCardAdded(true);
+  await skipSubscriptionByDays(email, testClockId, 15, date);
+
+  await stripePage.waitTrialEndsDisappear();
+  await profilePage.reloadPage();
+  await stripePage.checkCurrentSubscription(currentPlan);
+  await stripePage.checkLastInvoiceName(`Penpot ${currentPlan} (per editors)`);
+  await stripePage.checkLastInvoiceAmount(`$7.00`);
+  await stripePage.changeSubscription();
+  await stripePage.checkCurrentSubscription(newPlan);
+  await page.waitForTimeout(1000);
+  await profilePage.reloadPage();
+  await stripePage.checkLastInvoiceName(`Penpot ${newPlan}`);
+  await stripePage.checkLastInvoiceStatus(`Paid`);
+  await stripePage.clickOnReturnToPenpotButton();
+  await profilePage.checkSubscriptionName(newPlan);
+  await profilePage.backToDashboardFromAccount();
+  await dashboardPage.checkSubscriptionName(newPlan + ' plan');
+});
+
+test(qase(2303, 'Switch from Enterprise → Unlimited'), async ({ page }) => {
+  const currentPlan = 'Enterprise';
+  const newPlan = 'Unlimited';
+  const name = random().concat('autotest');
+  const email = `${process.env.GMAIL_NAME}+${name}@gmail.com`;
+
+  await registerPage.registerAccount(name, email, process.env.LOGIN_PWD);
+  await registerPage.isRegisterEmailCorrect(email);
+  const invite = await waitMessage(page, email, 40);
+  await page.goto(invite.inviteUrl);
+  await dashboardPage.fillOnboardingQuestions();
+  await teamPage.createTeam(teamName);
+  await teamPage.isTeamSelected(teamName);
+
+  await profilePage.tryTrialForPlan(newPlan);
+  await profilePage.openYourAccountPage();
+  await profilePage.openSubscriptionTab();
+  await profilePage.clickOnAddPaymentMethodButton();
+  await stripePage.addDefaultCard();
+  await stripePage.isVisaCardAdded(true);
+  await stripePage.changeSubscription();
+  await stripePage.checkCurrentSubscription(currentPlan);
+
+  await stripePage.waitTrialEndsDisappear();
+  await profilePage.reloadPage();
+  await stripePage.changeSubscription();
+  await stripePage.checkCurrentSubscription(newPlan);
+  await stripePage.checkLastInvoiceName(`Penpot ${newPlan}`);
+  await stripePage.checkLastInvoiceAmount(`$0.00`);
+  await stripePage.clickOnReturnToPenpotButton();
+  await profilePage.checkSubscriptionName(newPlan);
+  await profilePage.backToDashboardFromAccount();
+  await dashboardPage.checkSubscriptionName(newPlan + ' plan');
+});
+
+test(qase(2304, 'Switch from Unlimited → Professional'), async ({ page }) => {
+  const currentPlan = 'Unlimited';
+  const defaultPlan = 'Professional';
+  const name = random().concat('autotest');
+  const email = `${process.env.GMAIL_NAME}+${name}@gmail.com`;
+  let date = new Date();
+
+  await registerPage.registerAccount(name, email, process.env.LOGIN_PWD);
+  await registerPage.isRegisterEmailCorrect(email);
+  const invite = await waitMessage(page, email, 40);
+  await page.goto(invite.inviteUrl);
+  await dashboardPage.fillOnboardingQuestions();
+  await teamPage.createTeam(teamName);
+  await teamPage.isTeamSelected(teamName);
+
+  const testClockId = await createCustomerWithTestClock(page, name, email);
+
+  await profilePage.tryTrialForPlan(currentPlan);
+  await profilePage.openYourAccountPage();
+  await profilePage.openSubscriptionTab();
+  await profilePage.clickOnAddPaymentMethodButton();
+  await stripePage.addDefaultCard();
+  await stripePage.isVisaCardAdded(true);
+  await skipSubscriptionByDays(email, testClockId, 15, date);
+
+  await stripePage.waitTrialEndsDisappear();
+  await profilePage.reloadPage();
+
+  await stripePage.cancelSubscription();
+  await skipSubscriptionByDays(email, testClockId, 40, date);
+  await stripePage.waitCancelsEndsDisappear();
+
+  await stripePage.clickOnReturnToPenpotButton();
+
+  await profilePage.checkSubscriptionName(defaultPlan);
+  await profilePage.backToDashboardFromAccount();
+  await dashboardPage.checkSubscriptionName(defaultPlan + ' plan');
+});

--- a/tests/subscription-plans/stripe-specific-tests.spec.js
+++ b/tests/subscription-plans/stripe-specific-tests.spec.js
@@ -1,0 +1,269 @@
+const { mainTest } = require('../../fixtures');
+const { expect, test } = require('@playwright/test');
+const { random } = require('../../helpers/string-generator');
+const { TeamPage } = require('../../pages/dashboard/team-page');
+const { DashboardPage } = require('../../pages/dashboard/dashboard-page');
+const { updateTestResults } = require('./../../helpers/saveTestResults.js');
+const { qase } = require('playwright-qase-reporter/playwright');
+const { ProfilePage } = require('../../pages/profile-page');
+const {
+  waitMessage,
+  waitSecondMessage,
+  getRegisterMessage,
+} = require('../../helpers/gmail');
+const { LoginPage } = require('../../pages/login-page');
+const { RegisterPage } = require('../../pages/register-page');
+const { StripePage } = require('../../pages/dashboard/stripe-page');
+const {
+  createCustomerWithTestClock,
+  skipSubscriptionByDays,
+  skipSubscriptionByMonths,
+} = require('../../helpers/stripe');
+
+let teamPage, dashboardPage, profilePage, loginPage, registerPage, stripePage;
+const teamName = random().concat('autotest');
+
+test.beforeEach(async ({ page }) => {
+  test.slow();
+  teamPage = new TeamPage(page);
+  dashboardPage = new DashboardPage(page);
+  profilePage = new ProfilePage(page);
+  loginPage = new LoginPage(page);
+  registerPage = new RegisterPage(page);
+  stripePage = new StripePage(page);
+});
+
+test.afterEach(async ({ page }, testInfo) => {
+  await updateTestResults(testInfo.status, testInfo.retry);
+});
+
+test.describe(() => {
+  test.afterEach(async () => {
+    await stripePage.clickOnReturnToPenpotButton();
+    await profilePage.backToDashboardFromAccount();
+    await teamPage.deleteTeam(teamName);
+  });
+
+  test(qase(2346, 'Invoices capped at $7 (Unlimited)'), async ({ page }) => {
+    const currentPlan = 'Unlimited';
+    const name = random().concat('autotest');
+    const email = `${process.env.GMAIL_NAME}+${name}@gmail.com`;
+    let date = new Date();
+
+    await loginPage.goto();
+    await loginPage.acceptCookie();
+    await loginPage.clickOnCreateAccount();
+    await registerPage.registerAccount(name, email, process.env.LOGIN_PWD);
+    await registerPage.isRegisterEmailCorrect(email);
+    const invite = await waitMessage(page, email, 40);
+    await page.goto(invite.inviteUrl);
+    await dashboardPage.fillOnboardingQuestions();
+    await teamPage.createTeam(teamName);
+    await teamPage.isTeamSelected(teamName);
+
+    const testClockId = await createCustomerWithTestClock(page, name, email);
+
+    await profilePage.tryTrialForPlan(currentPlan);
+    await profilePage.openYourAccountPage();
+    await profilePage.openSubscriptionTab();
+    await profilePage.clickOnAddPaymentMethodButton();
+    await stripePage.addDefaultCard();
+    await stripePage.isVisaCardAdded(true);
+    await skipSubscriptionByDays(email, testClockId, 15, date);
+
+    await stripePage.waitTrialEndsDisappear();
+    await profilePage.reloadPage();
+    await stripePage.checkCurrentSubscription(currentPlan);
+    await stripePage.checkLastInvoiceName(`Penpot ${currentPlan} (per editors)`);
+    await stripePage.checkLastInvoiceAmount(`$7.00`);
+
+    await skipSubscriptionByMonths(email, testClockId, 1, date);
+    await profilePage.reloadPage();
+
+    await skipSubscriptionByMonths(email, testClockId, 1, date);
+    await profilePage.reloadPage();
+
+    await stripePage.checkLastInvoiceStatus(`Paid`);
+    await stripePage.waitInvoiceAmountCount(`$7.00`, 3);
+  });
+
+  test(qase(2347, 'Invoices capped at  $950 (Enterprise)'), async ({ page }) => {
+    const currentPlan = 'Enterprise';
+    const name = random().concat('autotest');
+    const email = `${process.env.GMAIL_NAME}+${name}@gmail.com`;
+    let date = new Date();
+
+    await loginPage.goto();
+    await loginPage.acceptCookie();
+    await loginPage.clickOnCreateAccount();
+    await registerPage.registerAccount(name, email, process.env.LOGIN_PWD);
+    await registerPage.isRegisterEmailCorrect(email);
+    const invite = await waitMessage(page, email, 40);
+    await page.goto(invite.inviteUrl);
+    await dashboardPage.fillOnboardingQuestions();
+    await teamPage.createTeam(teamName);
+    await teamPage.isTeamSelected(teamName);
+
+    const testClockId = await createCustomerWithTestClock(page, name, email);
+
+    await profilePage.tryTrialForPlan(currentPlan);
+    await profilePage.openYourAccountPage();
+    await profilePage.openSubscriptionTab();
+    await profilePage.clickOnAddPaymentMethodButton();
+    await stripePage.addDefaultCard();
+    await stripePage.isVisaCardAdded(true);
+    await skipSubscriptionByDays(email, testClockId, 15, date);
+
+    await stripePage.waitTrialEndsDisappear();
+    await profilePage.reloadPage();
+    await stripePage.checkCurrentSubscription(currentPlan);
+    await stripePage.checkLastInvoiceName(`Penpot ${currentPlan} (per editors)`);
+    await stripePage.checkLastInvoiceAmount(`$950.00`);
+
+    await skipSubscriptionByMonths(email, testClockId, 1, date);
+    await profilePage.reloadPage();
+    await skipSubscriptionByMonths(email, testClockId, 1, date);
+    await profilePage.reloadPage();
+
+    await stripePage.checkLastInvoiceStatus(`Paid`);
+    await stripePage.waitInvoiceAmountCount(`$950.00`, 3);
+  });
+
+  test(qase(2514, 'Maximum billing $175 (Unlimited)'), async ({ page }) => {
+    const currentPlan = 'Unlimited';
+    const name = random().concat('autotest');
+    const email = `${process.env.GMAIL_NAME}+${name}@gmail.com`;
+    let date = new Date();
+
+    await loginPage.goto();
+    await loginPage.acceptCookie();
+    await loginPage.clickOnCreateAccount();
+    await registerPage.registerAccount(name, email, process.env.LOGIN_PWD);
+    await registerPage.isRegisterEmailCorrect(email);
+    const invite = await waitMessage(page, email, 40);
+    await page.goto(invite.inviteUrl);
+    await dashboardPage.fillOnboardingQuestions();
+    await teamPage.createTeam(teamName);
+    await teamPage.isTeamSelected(teamName);
+
+    const testClockId = await createCustomerWithTestClock(page, name, email);
+
+    await profilePage.tryTrialForPlan(currentPlan, '100');
+    await profilePage.openYourAccountPage();
+    await profilePage.openSubscriptionTab();
+    await profilePage.clickOnAddPaymentMethodButton();
+    await stripePage.addDefaultCard();
+    await stripePage.isVisaCardAdded(true);
+    await skipSubscriptionByDays(email, testClockId, 15, date);
+
+    await stripePage.waitTrialEndsDisappear();
+    await profilePage.reloadPage();
+    await stripePage.checkCurrentSubscription(currentPlan);
+    await stripePage.checkLastInvoiceName(`Penpot ${currentPlan} (per editors)`);
+    await stripePage.checkLastInvoiceAmount(`$175.00`);
+
+    await skipSubscriptionByMonths(email, testClockId, 1, date);
+    await profilePage.reloadPage();
+    await skipSubscriptionByMonths(email, testClockId, 1, date);
+    await profilePage.reloadPage();
+
+    await stripePage.checkLastInvoiceStatus(`Paid`);
+    await stripePage.waitInvoiceAmountCount(`$175.00`, 3);
+  });
+});
+
+test(
+  qase(2324, 'Owner of team changes Enterprise to Professional'),
+  async ({ page }) => {
+    const currentPlan = 'Enterprise';
+    const firstOwner = random().concat('autotest');
+    const firstEmail = `${process.env.GMAIL_NAME}+${firstOwner}@gmail.com`;
+    const secondAdmin = random().concat('autotest');
+    const secondEmail = `${process.env.GMAIL_NAME}+${secondAdmin}@gmail.com`;
+
+    await loginPage.goto();
+    await loginPage.acceptCookie();
+    await loginPage.clickOnCreateAccount();
+    await registerPage.registerAccount(
+      secondAdmin,
+      secondEmail,
+      process.env.LOGIN_PWD,
+    );
+    await registerPage.isRegisterEmailCorrect(secondEmail);
+    const register = await waitMessage(page, secondEmail, 40);
+    await page.goto(register.inviteUrl);
+    await dashboardPage.fillOnboardingQuestions();
+
+    await profilePage.logout();
+    await loginPage.isLoginPageOpened();
+    await loginPage.clickOnCreateAccount();
+    await registerPage.registerAccount(
+      firstOwner,
+      firstEmail,
+      process.env.LOGIN_PWD,
+    );
+    await registerPage.isRegisterEmailCorrect(firstEmail);
+    const register2 = await waitMessage(page, firstEmail, 40);
+    await page.goto(register2.inviteUrl);
+    await dashboardPage.fillOnboardingQuestions();
+
+    await dashboardPage.isDashboardOpenedAfterLogin();
+    await teamPage.createTeam(teamName);
+    await teamPage.isTeamSelected(teamName);
+
+    await profilePage.tryTrialForPlan('Unlimited');
+    await profilePage.openYourAccountPage();
+    await profilePage.openSubscriptionTab();
+    await profilePage.clickOnAddPaymentMethodButton();
+    await stripePage.addDefaultCard();
+    await stripePage.isVisaCardAdded(true);
+    await stripePage.changeSubscription();
+    await stripePage.checkCurrentSubscription(currentPlan);
+    await stripePage.clickOnReturnToPenpotButton();
+    await profilePage.backToDashboardFromAccount();
+
+    await teamPage.openInvitationsPageViaOptionsMenu();
+    await teamPage.clickInviteMembersToTeamButton();
+    await teamPage.enterEmailToInviteMembersPopUp(secondEmail);
+    await teamPage.clickSendInvitationButton();
+    await profilePage.logout();
+    await loginPage.isLoginPageOpened();
+    await loginPage.enterEmail(secondEmail);
+    await loginPage.enterPwd(process.env.LOGIN_PWD);
+    await loginPage.clickLoginButton();
+    await dashboardPage.isDashboardOpenedAfterLogin();
+    await waitSecondMessage(page, secondEmail, 40);
+    const invite = await getRegisterMessage(secondEmail);
+    await page.goto(invite.inviteUrl);
+    await teamPage.switchTeam(teamName);
+    await teamPage.isTeamSelected(teamName);
+
+    await profilePage.logout();
+    await loginPage.isLoginPageOpened();
+    await loginPage.enterEmail(firstEmail);
+    await loginPage.enterPwd(process.env.LOGIN_PWD);
+    await loginPage.clickLoginButton();
+    await dashboardPage.isDashboardOpenedAfterLogin();
+    await teamPage.switchTeam(teamName);
+    await teamPage.isTeamSelected(teamName);
+    await teamPage.openMembersPageViaOptionsMenu();
+    await teamPage.selectMemberRoleInPopUp(secondAdmin, 'Owner');
+    await teamPage.clickOnTransferOwnershipButton();
+    await teamPage.isMultipleMemberRecordDisplayed(
+      secondAdmin,
+      secondEmail,
+      'Owner',
+    );
+    await profilePage.logout();
+    await loginPage.isLoginPageOpened();
+    await loginPage.enterEmail(secondEmail);
+    await loginPage.enterPwd(process.env.LOGIN_PWD);
+    await loginPage.clickLoginButton();
+    await dashboardPage.isDashboardOpenedAfterLogin();
+    await teamPage.switchTeam(teamName);
+    await teamPage.isTeamSelected(teamName);
+    await teamPage.isSubscriptionIconVisible(false, currentPlan);
+
+    await teamPage.deleteTeam(teamName);
+  },
+);

--- a/tests/subscription-plans/trial-activation.spec.js
+++ b/tests/subscription-plans/trial-activation.spec.js
@@ -1,0 +1,90 @@
+const { mainTest } = require('../../fixtures');
+const { expect, test } = require('@playwright/test');
+const { random } = require('../../helpers/string-generator');
+const { TeamPage } = require('../../pages/dashboard/team-page');
+const { DashboardPage } = require('../../pages/dashboard/dashboard-page');
+const { updateTestResults } = require('./../../helpers/saveTestResults.js');
+const { qase } = require('playwright-qase-reporter/playwright');
+const { ProfilePage } = require('../../pages/profile-page');
+const { waitMessage } = require('../../helpers/gmail');
+const { LoginPage } = require('../../pages/login-page');
+const { RegisterPage } = require('../../pages/register-page');
+const { StripePage } = require('../../pages/dashboard/stripe-page');
+const { updateSubscriptionTrialEnd } = require('../../helpers/stripe');
+
+let teamPage, dashboardPage, profilePage, loginPage, registerPage, stripePage;
+const teamName = random().concat('autotest');
+
+test.beforeEach(async ({ page }) => {
+  teamPage = new TeamPage(page);
+  dashboardPage = new DashboardPage(page);
+  profilePage = new ProfilePage(page);
+  loginPage = new LoginPage(page);
+  registerPage = new RegisterPage(page);
+  stripePage = new StripePage(page);
+});
+
+test.afterEach(async ({ page }, testInfo) => {
+  await teamPage.deleteTeam(teamName);
+  await updateTestResults(testInfo.status, testInfo.retry);
+});
+
+test(qase(2289, 'Try it free for 14 days for Unlimited plan'), async ({ page }) => {
+  const currentPlan = 'Unlimited';
+  const name = random().concat('autotest');
+  const email = `${process.env.GMAIL_NAME}+${name}@gmail.com`;
+
+  await loginPage.goto();
+  await loginPage.acceptCookie();
+  await loginPage.clickOnCreateAccount();
+  await registerPage.registerAccount(name, email, process.env.LOGIN_PWD);
+  await registerPage.isRegisterEmailCorrect(email);
+  const invite = await waitMessage(page, email, 40);
+  await page.goto(invite.inviteUrl);
+  await dashboardPage.fillOnboardingQuestions();
+  await teamPage.createTeam(teamName);
+  await teamPage.isTeamSelected(teamName);
+
+  await profilePage.tryTrialForPlan(currentPlan, '5');
+  await profilePage.openYourAccountPage();
+  await profilePage.openSubscriptionTab();
+  await profilePage.checkSubscriptionName(currentPlan + ' (trial)');
+  await profilePage.backToDashboardFromAccount();
+  await dashboardPage.checkSubscriptionName(currentPlan + ' plan (trial)');
+});
+
+test(
+  qase(2294, 'Verify Trial Label Behavior (for the Enterprise plan)'),
+  async ({ page }) => {
+    const currentPlan = 'Enterprise';
+    const name = random().concat('autotest');
+    const email = `${process.env.GMAIL_NAME}+${name}@gmail.com`;
+
+    await loginPage.goto();
+    await loginPage.acceptCookie();
+    await loginPage.clickOnCreateAccount();
+    await registerPage.registerAccount(name, email, process.env.LOGIN_PWD);
+    await registerPage.isRegisterEmailCorrect(email);
+    const invite = await waitMessage(page, email, 40);
+    await page.goto(invite.inviteUrl);
+    await dashboardPage.fillOnboardingQuestions();
+    await teamPage.createTeam(teamName);
+    await teamPage.isTeamSelected(teamName);
+
+    await profilePage.tryTrialForPlan(currentPlan, '5');
+    await profilePage.openYourAccountPage();
+    await profilePage.openSubscriptionTab();
+    await profilePage.checkSubscriptionName(currentPlan + ' (trial)');
+    await updateSubscriptionTrialEnd(page, email);
+    await profilePage.backToDashboardFromAccount();
+    await dashboardPage.checkSubscriptionName(currentPlan + ' plan (trial)');
+    await profilePage.openYourAccountPage();
+    await profilePage.openSubscriptionTab();
+    await profilePage.checkSubscriptionName(currentPlan + ' (trial)');
+    await profilePage.clickOnManageSubscriptionButton();
+    await stripePage.isTrialEndsVisible();
+    await stripePage.isTrialEndsTomorrow();
+    await stripePage.clickOnReturnToPenpotButton();
+    await profilePage.backToDashboardFromAccount();
+  },
+);


### PR DESCRIPTION
# Done Definition Checks

## Description

This PR resolves a gap in test coverage for the subscriptions feature.

What? I added new tests for the subscriptions feature.

Why? The new tests are necessary to ensure proper coverage for the subscriptions functionality, which helps prevent regressions and maintain stability as the feature is developed.

How? This was done by creating and implementing new test cases specifically for the subscriptions feature.

## Solution

Adding new tests: 2281, 2283, 2289, 2513, 2294, 2297, 2337, 2301, 2302, 2303, 2304, 2344, 2346, 2347, 2514, 2324.

## How to test

- [ ] Check the code
- [ ] Update the Automation Status field in Qase
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Anything Else? (optional)

I'll preemptively address a few points that may lead to questions.

Waiting Functions
Functions like `waitCancelsEndsDisappear` are necessary because after accelerating time, the results don't immediately appear in the Stripe UI. Based on my observations, this can take from 3.5 to 18 seconds. Therefore, these functions are needed to not just wait for a result, but to periodically refresh the page.

Stripe API Logic
The following construction is used:
```
await skipSubscriptionByMonths(email, testClockId, 1, date);
await profilePage.reloadPage();
await skipSubscriptionByMonths(email, testClockId, 1, date);
await profilePage.reloadPage();
```
This is used instead of a single `await skipSubscriptionByMonths(email, testClockId, 2, date);` because the Stripe API for monthly subscriptions does not allow skipping more than one month at a time.

Test Stability
In test `2302`, a 1-second delay is required for stability. Without it, the test doesn't detect the locator for the line "Penpot Enterprise" even though it is visually displayed.

I also encountered an issue with Stripe lagging. Sometimes information from Stripe isn't pulled into Penpot. This occurred for me in approximately 1 out of every 10 runs, and I was also able to reproduce this issue manually, so I have created a bug report: https://tree.taiga.io/project/penpot/issue/11793.
