### PR TITLE
Increase the default timeout on PRE daily execution.

### DIFF
--- a/.github/workflows/playwright_pre_daily.yml
+++ b/.github/workflows/playwright_pre_daily.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   tests_chromium:
     environment: PRE
-    timeout-minutes: 180
+    timeout-minutes: 400
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/playwright_pre_firefox.yml
+++ b/.github/workflows/playwright_pre_firefox.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   tests_firefox:
     environment: PRE
-    timeout-minutes: 240
+    timeout-minutes: 400
     runs-on: windows-latest
 
     steps:


### PR DESCRIPTION
# Done Definition Checks

## Description

This pull request increases the timeout from 180 to 400, at least, to have results until we can fix all the failures

## Solution

* Increased `timeout-minutes` for the `tests_chromium` job in `.github/workflows/playwright_pre_daily.yml` from 180 to 400 minutes.
* Increased `timeout-minutes` for the `tests_firefox` job in `.github/workflows/playwright_pre_firefox.yml` from 240 to 400 minutes.

## How to test

- [X] Check the code
- [X] Update the Automation Status field in Qase
- [X] It complies with the test conventions
- [X] There are no missing snapshots for win32 (x3 browsers)
- [X] The tests run OK

