### PR TITLE
fix(test): fix addDefaultCard

### DIFF
--- a/pages/dashboard/stripe-page.js
+++ b/pages/dashboard/stripe-page.js
@@ -19,6 +19,12 @@ exports.StripePage = class StripePage extends BasePage {
       'input[name="expiry"]',
     );
     this.cardCVCImput = this.iframeAddCardModal.locator('input[name="cvc"]');
+    this.cardCountryDropdown = this.iframeAddCardModal.locator(
+      'select[name="country"]',
+    );
+    this.cardZipCodeImput = this.iframeAddCardModal.locator(
+      'input[name="postalCode"]',
+    );
     this.confirmButton = page.getByTestId('confirm');
     this.returnToPenpotButton = page.getByText('Return to Penpot');
     this.updateSubscriptionButton = page.getByText('Update subscription');
@@ -55,6 +61,16 @@ exports.StripePage = class StripePage extends BasePage {
     await this.cardCVCImput.fill(cvc);
   }
 
+  async enterCardZipCode(zip = '12345') {
+    (await this.cardZipCodeImput.isVisible())
+      ? await this.cardZipCodeImput.fill(zip)
+      : null;
+  }
+
+  async selectCardCountry(country = 'US') {
+    await this.cardCountryDropdown.selectOption(country);
+  }
+
   async clickOnAddCardButton() {
     await this.confirmButton.click();
   }
@@ -64,6 +80,8 @@ exports.StripePage = class StripePage extends BasePage {
     await this.enterCardNumber();
     await this.enterCardExpirationDate(await getActualExpirationDate());
     await this.enterCardCVC();
+    await this.selectCardCountry();
+    await this.enterCardZipCode();
     await this.clickOnAddCardButton();
   }
 


### PR DESCRIPTION
# Done Definition Checks

## Description

This PR resolves a test instability issue in the CI pipeline.

What? I fixed the addDefaultCard method.

Why? Previously, the method was not working correctly in the CI environment because it was dependent on the country where the test was executed. The problem was that certain fields were required for a specific country (like the US) which were not being filled in.

How? I updated the addDefaultCard method to explicitly select the US country and fill in all the necessary fields for it. This ensures the test now works regardless of the country from which it is launched.

## Solution

Updating the addDefaultCard method to specifically handle the US country, ensuring all required fields are populated.

## How to test

- [ ] Check the code
- [ ] Update the Automation Status field in Qase
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

