### PR TITLE
ci(workflows): Add always to the publish new pw report action

### DIFF
--- a/.github/workflows/playwright_pr_manual.yml
+++ b/.github/workflows/playwright_pr_manual.yml
@@ -143,6 +143,7 @@ jobs:
 
   deploy:
     needs: tests_chromium
+    if: always()
     runs-on: ubuntu-latest
     permissions:
       pages: write

--- a/.github/workflows/playwright_pre_daily.yml
+++ b/.github/workflows/playwright_pre_daily.yml
@@ -129,6 +129,7 @@ jobs:
 
   deploy:
     needs: tests_chromium
+    if: always()
     runs-on: ubuntu-latest
     permissions:
       pages: write

--- a/.github/workflows/playwright_pre_firefox.yml
+++ b/.github/workflows/playwright_pre_firefox.yml
@@ -134,6 +134,7 @@ jobs:
 
   deploy:
     needs: tests_firefox
+    if: always()
     runs-on: ubuntu-latest
     permissions:
       pages: write


### PR DESCRIPTION
# Done Definition Checks

## Description

This pull request ensures that the `deploy` job will always run, regardless of the outcome of the preceding test jobs. This helps maintain consistent deployment behavior even if tests fail.

## Solution

Add the always step to several actions. 

## How to test

- [x] Check the code
- [x] Update the Automation Status field in Qase
- [x] It complies with the test conventions
- [x] There are no missing snapshots for win32 (x3 browsers)
- [x] The tests run OK