### PR TITLE
Fix Error: No artifacts named "github-pages" were found for this workflow run

### DIFF
--- a/.github/workflows/playwright_pr_manual.yml
+++ b/.github/workflows/playwright_pr_manual.yml
@@ -127,6 +127,7 @@ jobs:
           fi
 
       - name: Upload report to GitHub Pages
+        if: always()
         uses: actions/upload-pages-artifact@v3
         with:
           path: history

--- a/.github/workflows/playwright_pre_daily.yml
+++ b/.github/workflows/playwright_pre_daily.yml
@@ -114,6 +114,7 @@ jobs:
           fi
 
       - name: Upload report to GitHub Pages
+        if: always()
         uses: actions/upload-pages-artifact@v3
         with:
           path: history

--- a/.github/workflows/playwright_pre_firefox.yml
+++ b/.github/workflows/playwright_pre_firefox.yml
@@ -118,6 +118,7 @@ jobs:
           fi
 
       - name: Upload report to GitHub Pages
+        if: always()
         uses: actions/upload-pages-artifact@v3
         with:
           path: history


### PR DESCRIPTION
# Done Definition Checks

## Description

This pull request makes an update to the GitHub Actions workflows for Playwright tests. The change ensures that the "Upload report to GitHub Pages" step always runs, regardless of the outcome of previous steps.

## How to test

- [x] Check the code
- [x] Update the Automation Status field in Qase
- [x] It complies with the test conventions
- [x] There are no missing snapshots for win32 (x3 browsers)
- [x] The tests run OK