### PR TITLE
fix(test): addDefaultCard method fix

### DIFF
--- a/pages/dashboard/stripe-page.js
+++ b/pages/dashboard/stripe-page.js
@@ -25,6 +25,9 @@ exports.StripePage = class StripePage extends BasePage {
     this.cardZipCodeImput = this.iframeAddCardModal.locator(
       'input[name="postalCode"]',
     );
+    this.cardSaveInfoCheckout = this.iframeAddCardModal.locator(
+      '[id="Field-linkOptInCheckbox"]',
+    );
     this.confirmButton = page.getByTestId('confirm');
     this.returnToPenpotButton = page.getByText('Return to Penpot');
     this.updateSubscriptionButton = page.getByText('Update subscription');
@@ -82,6 +85,7 @@ exports.StripePage = class StripePage extends BasePage {
     await this.enterCardCVC();
     await this.selectCardCountry();
     await this.enterCardZipCode();
+    await this.clickOnSaveInfoCheckout();
     await this.clickOnAddCardButton();
   }
 
@@ -237,5 +241,11 @@ exports.StripePage = class StripePage extends BasePage {
     }
     const finalElements = this.invoiceRow.getByText(amount);
     await expect(finalElements).toHaveCount(expectedCount);
+  }
+
+  async clickOnSaveInfoCheckout() {
+    (await this.cardSaveInfoCheckout.isVisible())
+      ? await this.cardSaveInfoCheckout.click()
+      : null;
   }
 };


### PR DESCRIPTION
# Done Definition Checks

## Description

This PR resolves ...

This PR resolves a test failure caused by regional differences in payment forms.

What? I added a step to uncheck the "Save card details" checkbox.
Why? In some regions, this checkbox is present and must be unchecked before the "Add Card" button becomes active. However, in other regions, this checkbox does not exist. This inconsistency was causing the test to fail in the regions where the checkbox was present.
How? I added a check to see if the checkbox exists before attempting to click it. This makes the test work reliably regardless of the user's region.

## Solution

I addressed the issue by:
Adding a conditional step to uncheck the "Save card details" checkbox if it is present.

## How to test

- [ ] Check the code
- [ ] Update the Automation Status field in Qase
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK
