### PR TITLE
[CI/CD] Update GitHub Windows action: windows-latest label will migrate from Windows Server 2022 to Windows Server 2025

### DIFF
--- a/.github/workflows/playwright_pr_manual.yml
+++ b/.github/workflows/playwright_pr_manual.yml
@@ -26,7 +26,7 @@ jobs:
         shell: bash
     environment: PRE
     timeout-minutes: 280
-    runs-on: windows-latest
+    runs-on: windows-2022
     env:
       TZ: Europe/Madrid
     steps:

--- a/.github/workflows/playwright_pre_daily.yml
+++ b/.github/workflows/playwright_pre_daily.yml
@@ -21,7 +21,7 @@ jobs:
         shell: bash
     environment: PRE
     timeout-minutes: 400
-    runs-on: windows-latest
+    runs-on: windows-2022
     env:
       TZ: Europe/Madrid
     steps:

--- a/.github/workflows/playwright_pre_firefox.yml
+++ b/.github/workflows/playwright_pre_firefox.yml
@@ -22,7 +22,7 @@ jobs:
         shell: bash
     environment: PRE
     timeout-minutes: 400
-    runs-on: windows-latest
+    runs-on: windows-2022
     env:
       TZ: Europe/Madrid
 


### PR DESCRIPTION
# Done Definition Checks

Taiga Ticket: [https://tree.taiga.io/project/kaleidos-qa/us/393](https://tree.taiga.io/project/kaleidos-qa/us/393 )

## Description

This pull request updates the GitHub Actions workflow configurations to use a specific Windows runner version. The change ensures that all relevant Playwright test workflows now run on windows-2022 instead of the more generic windows-latest. This guarantees that workflows execute on the most stable version currently available, preventing automatic changes when GitHub migrates windows-latest to Windows Server 2025 starting September 2025, which improves consistency and predictability in the CI environment.

## Solution

**Workflow runner updates:**

* Updated the `runs-on` parameter from `windows-latest` to `windows-2022` in the following workflows:
  - `.github/workflows/playwright_pr_manual.yml`
  - `.github/workflows/playwright_pre_daily.yml`
  - `.github/workflows/playwright_pre_firefox.yml`

## How to test

- [x] Check the code
- [x] Update the Automation Status field in Qase
- [x] It complies with the test conventions
- [x] There are no missing snapshots for win32 (x3 browsers)
- [x] The tests run OK

## Screenshots 📸 (optional)

<img width="905" height="232" alt="image" src="https://github.com/user-attachments/assets/3bc94b72-2f62-4240-8cad-71d935a4d0a7" />

This error is going to be fixed :muscle: 
