### PR TITLE
Increase the worker and check timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Some settings from _playwright.config.js_ may be useful:
 
 - All tests should be independent for running them in parallel mode
 - For run tests in parallel mode need to update key `workers` in `playwright.config.js` file
-- `workers`: `process.env.CI ? 3 : 3` - by default 3 workers are used for local run and run on CI/CD.
+- `workers`: `process.env.CI ? 15 : 3` - by default 3 workers are used for local run and run on CI/CD.
 - For disabling parallelism set `workers` to 1.
 
 **5. Tests amount and execution time.**

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -31,7 +31,7 @@ const config = {
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 6 : 3,
+  workers: process.env.CI ? 15 : 3,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: process.env.CI
     ? [


### PR DESCRIPTION
# Done Definition Checks

## Description

This pull request increases the number of parallel test workers used in Playwright when running in CI environments, aiming to speed up test execution. 

## Solution

Increased the number of workers for CI runs from 6 to 15 in `playwright.config.js`. This allows more tests to run in parallel on CI, potentially reducing total test time.

## How to test

- [x] Check the code
- [x] Update the Automation Status field in Qase
- [x] It complies with the test conventions
- [x] There are no missing snapshots for win32 (x3 browsers)
- [x] The tests run OK
