### PR TITLE
Back CI workers to 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Some settings from _playwright.config.js_ may be useful:
 
 - All tests should be independent for running them in parallel mode
 - For run tests in parallel mode need to update key `workers` in `playwright.config.js` file
-- `workers`: `process.env.CI ? 15 : 3` - by default 3 workers are used for local run and run on CI/CD.
+- `workers`: `process.env.CI ? 4 : 3` - by default 3 workers are used for local run and run on CI/CD.
 - For disabling parallelism set `workers` to 1.
 
 **5. Tests amount and execution time.**

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -31,7 +31,7 @@ const config = {
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 15 : 3,
+  workers: process.env.CI ? 4 : 3,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: process.env.CI
     ? [


### PR DESCRIPTION
# Done Definition Checks

## Description

This pull request updates the Playwright configuration to reduce the number of parallel workers used in CI environments from 15 to 4.

More info here: http://tree.taiga.io/project/kaleidos-qa/us/438

## How to test

- [x] Check the code
- [x] Update the Automation Status field in Qase
- [x] It complies with the test conventions
- [x] There are no missing snapshots for win32 (x3 browsers)
- [x] The tests run OK
