### PR TITLE
Add Taiga URL ticket to the PR template as optional

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
 ## Taiga URL (optional)
 
 _If relevant, include the Taiga URL_
-![Taiga URL](https://tree.taiga.io/project/kaleidos-qa/us/{NUMBER})
+[Taiga Ticket: NUMBER](https://tree.taiga.io/project/kaleidos-qa/us/NUMBER)
 
 ## Automation Status (optional)
 


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

[Taiga Ticket: 431](https://tree.taiga.io/project/kaleidos-qa/us/431)

## Description

This pull request updates the pull request template to encourage including additional context about the Taiga ticket URL.

## How to test

- [x] Check the code
- [x] Update the Automation Status field in Qase
- [x] It complies with the test conventions
- [x] There are no missing snapshots for win32 (x3 browsers)
- [x] The tests run OK
