### PR TITLE
ci(config): increase ci workers from 4 to 5 for better parallelism

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,11 +5,6 @@
 _If relevant, include the Taiga URL_
 [Taiga Ticket: NUMBER](https://tree.taiga.io/project/kaleidos-qa/us/NUMBER)
 
-## Automation Status (optional)
-
-_If relevant, include the Automation Status_
-![Automation Status](XXXXXXXXXXXXXXXXXX)
-
 ## Description
 
 This PR resolves ...

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Some settings from _playwright.config.js_ may be useful:
 
 - All tests should be independent for running them in parallel mode
 - For run tests in parallel mode need to update key `workers` in `playwright.config.js` file
-- `workers`: `process.env.CI ? 4 : 3` - by default 3 workers are used for local run and run on CI/CD.
+- `workers`: `process.env.CI ? 5 : 3` - by default 3 workers are used for local run and 5 to run on CI/CD.
 - For disabling parallelism set `workers` to 1.
 
 **5. Tests amount and execution time.**

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -31,7 +31,7 @@ const config = {
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 4 : 3,
+  workers: process.env.CI ? 5 : 3,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: process.env.CI
     ? [


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

[Taiga Ticket: 449](https://tree.taiga.io/project/kaleidos-qa/us/449)

## Description

This PR increases  the number of CI workers from 4 to 5 for better parallelism

## How to test

- [x] Check the code
- [x] Update the Automation Status field in Qase
- [x] It complies with the test conventions
- [x] There are no missing snapshots for win32 (x3 browsers)
- [x] The tests run OK