### PR TITLE
Save the artifacts as .zip on the actions (they are lost ATM)

### DIFF
--- a/.github/actions/upload-reports/action.yml
+++ b/.github/actions/upload-reports/action.yml
@@ -134,6 +134,7 @@ runs:
         name: ${{ inputs.artifact-name }}
         path: playwright-report/
         retention-days: 30
+        if-no-files-found: ignore
 
     - name: Commit and push to gh-pages
       shell: bash


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL

[Taiga Ticket: 450](https://tree.taiga.io/project/kaleidos-qa/us/450)

## Description

The artefacts are missing from the actions in the GitHub page. Check why they disappear and bring them back in case we want to download the zip to check the results locally. 

<img width="2164" height="257" alt="image" src="https://github.com/user-attachments/assets/97ccb82c-2d1b-484c-b966-4f71d90fdf94" />

## How to test

- [x] Check the code
- [x] Update the Automation Status field in Qase
- [x] It complies with the test conventions
- [x] There are no missing snapshots for win32 (x3 browsers)
- [x] The tests run OK