### PR TITLE
chore(config): modify playwright config traces collected

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -53,8 +53,8 @@ const config = {
     baseURL: process.env.BASE_URL,
     headless: true,
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: process.env.CI ? 'on-first-retry' : 'on',
-    video: process.env.CI ? 'on-first-retry' : 'on',
+    trace: process.env.CI ? 'retain-on-failure' : 'on',
+    video: process.env.CI ? 'off' : 'on',
   },
   projects: [
     {


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

_If relevant, include the Taiga URL_
[Taiga Ticket: 477](https://tree.taiga.io/project/kaleidos-qa/us/477)

## Description

Optimize the Playwright configuration to reduce artifact size in CI.

Currently, the test reports collect videos and traces for all tests, which generates large files and consumes significant storage. We want to modify the configuration to make reports lighter while still keeping enough information for debugging failures.

## Solution

Update the Playwright configuration to:

- Disable video recording to save storage.
- Collect traces only for failing tests (retain-on-failure) instead of for all tests.
- This approach ensures CI reports are lightweight while preserving the necessary information to debug test failures.
