### PR TITLE
fix(tests): add test for Editing token path creates missing groups in UI and moves token accordingly (Qase: 2736)

### DIFF
--- a/pages/workspace/tokens/token-components/tokens-base-component.ts
+++ b/pages/workspace/tokens/token-components/tokens-base-component.ts
@@ -46,6 +46,12 @@ export interface TokenGroupData extends BasicTokenData {
   parent?: TokenGroupData;
 }
 
+/**
+ * Builds the full dot-separated path for a token or group segment using the name, parent and TokensGroupData.
+ */
+export const buildTokenPath = (name: string, parent?: TokenGroupData): string =>
+  parent ? `${buildTokenPath(parent.name, parent.parent)}.${name}` : name;
+
 export class TokensComponent {
   readonly page: Page;
   readonly baseComp: BaseComponent;

--- a/pages/workspace/tokens/token-components/tokens-base-component.ts
+++ b/pages/workspace/tokens/token-components/tokens-base-component.ts
@@ -404,6 +404,7 @@ export class TokensComponent {
       name: group.name,
       exact: true,
     });
+    await expect(groupButton).toHaveAttribute('aria-controls', /.+/);
     const childrenContainerId = await groupButton.getAttribute('aria-controls');
     const token = this.page
       .locator(`[id="${childrenContainerId}"]`)
@@ -422,6 +423,7 @@ export class TokensComponent {
       name: group.name,
       exact: true,
     });
+    await expect(groupButton).toHaveAttribute('aria-controls', /.+/);
     const childrenContainerId = await groupButton.getAttribute('aria-controls');
     const lastSegment = this.page
       .locator(`[id="${childrenContainerId}"]`)

--- a/pages/workspace/tokens/token-components/tokens-base-component.ts
+++ b/pages/workspace/tokens/token-components/tokens-base-component.ts
@@ -47,7 +47,8 @@ export interface TokenGroupData extends BasicTokenData {
 }
 
 /**
- * Builds the full dot-separated path for a token or group segment using the name, parent and TokensGroupData.
+ * Builds the full dot-separated path for a token or group segment from the provided
+ * `name` and the `TokenGroupData` parent chain.
  */
 export const buildTokenPath = (name: string, parent?: TokenGroupData): string =>
   parent ? `${buildTokenPath(parent.name, parent.parent)}.${name}` : name;

--- a/pages/workspace/tokens/token-components/tokens-base-component.ts
+++ b/pages/workspace/tokens/token-components/tokens-base-component.ts
@@ -406,7 +406,7 @@ export class TokensComponent {
     });
     const childrenContainerId = await groupButton.getAttribute('aria-controls');
     const token = this.page
-      .locator(`#${childrenContainerId}`)
+      .locator(`[id="${childrenContainerId}"]`)
       .getByRole('button', { name: tokenName });
     visible
       ? await expect(token).toBeVisible()
@@ -418,8 +418,13 @@ export class TokensComponent {
     segment: string,
     visible = true,
   ) {
+    const groupButton = this.page.getByRole('button', {
+      name: group.name,
+      exact: true,
+    });
+    const childrenContainerId = await groupButton.getAttribute('aria-controls');
     const lastSegment = this.page
-      .locator(`#folder-children-${group.name}`)
+      .locator(`[id="${childrenContainerId}"]`)
       .locator('span[class*="last-name-wrapper"]')
       .filter({ hasText: segment });
     visible

--- a/tests/tokens/token-group.spec.ts
+++ b/tests/tokens/token-group.spec.ts
@@ -7,7 +7,10 @@ import { TeamPage } from '@pages/dashboard/team-page';
 import { DashboardPage } from '@pages/dashboard/dashboard-page';
 import { TokensPage } from '@pages/workspace/tokens/tokens-base-page';
 import { MainToken } from '@pages/workspace/tokens/token-components/main-tokens-component';
-import { TokenClass } from '@pages/workspace/tokens/token-components/tokens-base-component';
+import {
+  TokenClass,
+  buildTokenPath,
+} from '@pages/workspace/tokens/token-components/tokens-base-component';
 
 const teamName = random().concat('autotest');
 
@@ -320,9 +323,21 @@ mainTest.describe(() => {
         value: '16',
         parent: { name: 'primary' },
       };
-      const newGroupData = { name: 'newgroup' };
-      const subGroupData = { name: 'subgroup' };
-      const renamedTokenName = 'newgroup.subgroup.big';
+      const renamedToken: MainToken<TokenClass> = {
+        class: TokenClass.BorderRadius,
+        name: 'big',
+        value: '16',
+        parent: {
+          name: 'subgroup',
+          parent: { name: 'newgroup' },
+        },
+      };
+      const renamedTokenFullPath = buildTokenPath(
+        renamedToken.name,
+        renamedToken.parent,
+      );
+      const subGroup = renamedToken.parent!;
+      const newGroup = subGroup.parent!;
 
       await mainTest.step('Open Tokens panel', async () => {
         await tokensPage.clickTokensTab();
@@ -343,41 +358,41 @@ mainTest.describe(() => {
           await tokensPage.tokensComp.isTokenGroupVisible(primaryBigToken.parent!);
           await tokensPage.tokensComp.isLastSegmentVisibleInGroup(
             primaryBigToken.parent!,
-            'big',
+            renamedToken.name,
           );
         },
       );
 
       await mainTest.step(
-        `Edit "${primaryBigToken.name}" and rename it to "${renamedTokenName}"`,
+        `Edit "${primaryBigToken.name}" and rename it to "${renamedTokenFullPath}"`,
         async () => {
           await tokensPage.tokensComp.clickEditToken(primaryBigToken);
-          await tokensPage.tokensComp.tokenNameInput.fill(renamedTokenName);
+          await tokensPage.tokensComp.tokenNameInput.fill(renamedTokenFullPath);
           await tokensPage.tokensComp.baseComp.modalSaveButton.click();
           await mainPage.waitForChangeIsSaved();
         },
       );
 
       await mainTest.step(
-        `Verify new groups "${newGroupData.name}" and "${subGroupData.name}" are created and automatically unfolded`,
+        `Verify new groups "${newGroup.name}" and "${subGroup.name}" are created and automatically unfolded`,
         async () => {
-          await tokensPage.tokensComp.isTokenGroupVisible(newGroupData);
-          await tokensPage.tokensComp.isTokenGroupExpanded(newGroupData);
-          await tokensPage.tokensComp.isTokenGroupVisible(subGroupData);
-          await tokensPage.tokensComp.isTokenGroupExpanded(subGroupData);
+          await tokensPage.tokensComp.isTokenGroupVisible(newGroup);
+          await tokensPage.tokensComp.isTokenGroupExpanded(newGroup);
+          await tokensPage.tokensComp.isTokenGroupVisible(subGroup);
+          await tokensPage.tokensComp.isTokenGroupExpanded(subGroup);
         },
       );
 
       await mainTest.step(
-        `Verify token pill "big" is visible under "${subGroupData.name}" group`,
+        `Verify token pill "${renamedToken.name}" is visible under "${subGroup.name}" group`,
         async () => {
           await tokensPage.tokensComp.isTokenVisibleInGroup(
-            subGroupData,
-            renamedTokenName,
+            subGroup,
+            renamedTokenFullPath,
           );
           await tokensPage.tokensComp.isLastSegmentVisibleInGroup(
-            subGroupData,
-            'big',
+            subGroup,
+            renamedToken.name,
           );
         },
       );

--- a/tests/tokens/token-group.spec.ts
+++ b/tests/tokens/token-group.spec.ts
@@ -307,4 +307,87 @@ mainTest.describe(() => {
       );
     },
   );
+
+  mainTest(
+    qase(
+      [2736],
+      'Editing token path creates missing groups in UI and moves token accordingly',
+    ),
+    async () => {
+      const primaryBigToken: MainToken<TokenClass> = {
+        class: TokenClass.BorderRadius,
+        name: 'primary.big',
+        value: '16',
+        parent: { name: 'primary' },
+      };
+      const newGroupData = { name: 'newgroup' };
+      const subGroupData = { name: 'subgroup' };
+      const renamedTokenName = 'newgroup.subgroup.big';
+
+      await mainTest.step('Open Tokens panel', async () => {
+        await tokensPage.clickTokensTab();
+      });
+
+      await mainTest.step(
+        `Create a token named "${primaryBigToken.name}"`,
+        async () => {
+          await tokensPage.tokensComp.createTokenViaAddButtonAndEnter(
+            primaryBigToken,
+          );
+        },
+      );
+
+      await mainTest.step(
+        `Verify "${primaryBigToken.parent!.name}" group exists and contains "big" token pill`,
+        async () => {
+          await tokensPage.tokensComp.isTokenGroupVisible(primaryBigToken.parent!);
+          await tokensPage.tokensComp.isLastSegmentVisibleInGroup(
+            primaryBigToken.parent!,
+            'big',
+          );
+        },
+      );
+
+      await mainTest.step(
+        `Edit "${primaryBigToken.name}" and rename it to "${renamedTokenName}"`,
+        async () => {
+          await tokensPage.tokensComp.clickEditToken(primaryBigToken);
+          await tokensPage.tokensComp.tokenNameInput.fill(renamedTokenName);
+          await tokensPage.tokensComp.baseComp.modalSaveButton.click();
+          await mainPage.waitForChangeIsSaved();
+        },
+      );
+
+      await mainTest.step(
+        `Verify new groups "${newGroupData.name}" and "${subGroupData.name}" are created and automatically unfolded`,
+        async () => {
+          await tokensPage.tokensComp.isTokenGroupVisible(newGroupData);
+          await tokensPage.tokensComp.isTokenGroupExpanded(newGroupData);
+          await tokensPage.tokensComp.isTokenGroupVisible(subGroupData);
+          await tokensPage.tokensComp.isTokenGroupExpanded(subGroupData);
+        },
+      );
+
+      await mainTest.step(
+        `Verify token pill "big" is visible under "${subGroupData.name}" group`,
+        async () => {
+          await tokensPage.tokensComp.isTokenVisibleInGroup(
+            subGroupData,
+            renamedTokenName,
+          );
+          await tokensPage.tokensComp.isLastSegmentVisibleInGroup(
+            subGroupData,
+            'big',
+          );
+        },
+      );
+
+      await mainTest.step(
+        `Verify "${primaryBigToken.parent!.name}" group is removed from the DOM after moving its only token out`,
+        async () => {
+          await tokensPage.tokensComp.isTokenGroupCount(primaryBigToken.parent!, 0);
+        },
+      );
+    },
+  );
 });


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

_If relevant, include the Taiga URL_
[Taiga Ticket: 931](https://tree.taiga.io/project/kaleidos-qa/task/931)

## Description

This PR adds a new test to the token group spec: `Editing token path creates missing groups in UI and moves token accordingly (Qase: 2736)` 

## How to test

- [x] Check the code
- [x] Update the test case in Qase (Automation Status field or steps changed)
- [x] It complies with the test conventions
- [x] There are no missing snapshots for win32 (x3 browsers)
- [x] The tests run OK

## Screenshots 📸 (optional)
<img width="1677" height="654" alt="image" src="https://github.com/user-attachments/assets/9f93049a-9ae4-4ff3-a89d-f9120648c8b7" />

