### PR TITLE
addtests): add test for Error handling: Prevent creating token with empty name or invalid path format (Qase: 2741)

### DIFF
--- a/pages/workspace/tokens/token-components/tokens-base-component.ts
+++ b/pages/workspace/tokens/token-components/tokens-base-component.ts
@@ -406,7 +406,7 @@ export class TokensComponent {
     });
     const childrenContainerId = await groupButton.getAttribute('aria-controls');
     const token = this.page
-      .locator(`#${childrenContainerId}`)
+      .locator(`[id="${childrenContainerId}"]`)
       .getByRole('button', { name: tokenName });
     visible
       ? await expect(token).toBeVisible()
@@ -418,8 +418,13 @@ export class TokensComponent {
     segment: string,
     visible = true,
   ) {
+    const groupButton = this.page.getByRole('button', {
+      name: group.name,
+      exact: true,
+    });
+    const childrenContainerId = await groupButton.getAttribute('aria-controls');
     const lastSegment = this.page
-      .locator(`#folder-children-${group.name}`)
+      .locator(`[id="${childrenContainerId}"]`)
       .locator('span[class*="last-name-wrapper"]')
       .filter({ hasText: segment });
     visible

--- a/pages/workspace/tokens/token-components/tokens-base-component.ts
+++ b/pages/workspace/tokens/token-components/tokens-base-component.ts
@@ -188,6 +188,10 @@ export class TokensComponent {
     await this.baseComp.clickOnEnter();
   }
 
+  async isSaveButtonDisabled() {
+    await expect(this.baseComp.modalSaveButton).toBeDisabled();
+  }
+
   async clickEditToken(
     updatedToken:
       | TypographyToken<TokenClass>

--- a/tests/tokens/token-group.spec.ts
+++ b/tests/tokens/token-group.spec.ts
@@ -438,9 +438,7 @@ mainTest.describe(() => {
         `Attempt to create a token with an empty name "${emptyNameToken.name}" and verify Save button is disabled`,
         async () => {
           await tokensPage.tokensComp.clickOnAddTokenAndFillData(emptyNameToken);
-          await expect(
-            tokensPage.tokensComp.baseComp.modalSaveButton,
-          ).toBeDisabled();
+          await tokensPage.tokensComp.isSaveButtonDisabled();
           await tokensPage.tokensComp.baseComp.clickOnCancelButton();
         },
       );
@@ -449,9 +447,7 @@ mainTest.describe(() => {
         `Attempt to create a token with a malformed path "${doubleDotToken.name}" and verify Save button is disabled`,
         async () => {
           await tokensPage.tokensComp.clickOnAddTokenAndFillData(doubleDotToken);
-          await expect(
-            tokensPage.tokensComp.baseComp.modalSaveButton,
-          ).toBeDisabled();
+          await tokensPage.tokensComp.isSaveButtonDisabled();
           await tokensPage.tokensComp.baseComp.clickOnCancelButton();
         },
       );
@@ -469,9 +465,7 @@ mainTest.describe(() => {
           await tokensPage.tokensComp.clickOnAddTokenAndFillData(
             leadingTrailingDotToken,
           );
-          await expect(
-            tokensPage.tokensComp.baseComp.modalSaveButton,
-          ).toBeDisabled();
+          await tokensPage.tokensComp.isSaveButtonDisabled();
           await tokensPage.tokensComp.baseComp.clickOnCancelButton();
         },
       );

--- a/tests/tokens/token-group.spec.ts
+++ b/tests/tokens/token-group.spec.ts
@@ -414,19 +414,30 @@ mainTest.describe(() => {
     async () => {
       const tokenValue = '8';
       const primaryGroup = { name: 'primary' };
+      const emptyNameToken: MainToken<TokenClass> = {
+        class: TokenClass.BorderRadius,
+        name: '',
+        value: tokenValue,
+      };
+      const doubleDotToken: MainToken<TokenClass> = {
+        class: TokenClass.BorderRadius,
+        name: 'primary..big',
+        value: tokenValue,
+      };
+      const leadingTrailingDotToken: MainToken<TokenClass> = {
+        class: TokenClass.BorderRadius,
+        name: '.primary.big.',
+        value: tokenValue,
+      };
 
       await mainTest.step('Open Tokens panel', async () => {
         await tokensPage.clickTokensTab();
       });
 
       await mainTest.step(
-        'Attempt to create a token with an empty name and verify Save button is disabled',
+        `Attempt to create a token with an empty name "${emptyNameToken.name}" and verify Save button is disabled`,
         async () => {
-          await tokensPage.tokensComp.clickOnAddTokenAndFillData({
-            class: TokenClass.BorderRadius,
-            name: '',
-            value: tokenValue,
-          });
+          await tokensPage.tokensComp.clickOnAddTokenAndFillData(emptyNameToken);
           await expect(
             tokensPage.tokensComp.baseComp.modalSaveButton,
           ).toBeDisabled();
@@ -435,20 +446,29 @@ mainTest.describe(() => {
       );
 
       await mainTest.step(
-        'Verify no groups or token pills were created after the empty name attempt',
+        `Attempt to create a token with a malformed path "${doubleDotToken.name}" and verify Save button is disabled`,
+        async () => {
+          await tokensPage.tokensComp.clickOnAddTokenAndFillData(doubleDotToken);
+          await expect(
+            tokensPage.tokensComp.baseComp.modalSaveButton,
+          ).toBeDisabled();
+          await tokensPage.tokensComp.baseComp.clickOnCancelButton();
+        },
+      );
+
+      await mainTest.step(
+        `Verify no "${primaryGroup.name}" group is created after the double-dot path attempt`,
         async () => {
           await tokensPage.tokensComp.isTokenGroupCount(primaryGroup, 0);
         },
       );
 
       await mainTest.step(
-        'Attempt to create a token with a malformed path "primary..big" and verify Save button is disabled',
+        `Attempt to create a token with leading/trailing separators "${leadingTrailingDotToken.name}" and verify Save button is disabled`,
         async () => {
-          await tokensPage.tokensComp.clickOnAddTokenAndFillData({
-            class: TokenClass.BorderRadius,
-            name: 'primary..big',
-            value: tokenValue,
-          });
+          await tokensPage.tokensComp.clickOnAddTokenAndFillData(
+            leadingTrailingDotToken,
+          );
           await expect(
             tokensPage.tokensComp.baseComp.modalSaveButton,
           ).toBeDisabled();
@@ -457,29 +477,7 @@ mainTest.describe(() => {
       );
 
       await mainTest.step(
-        'Verify no group with an empty name segment is created after the double-dot path attempt',
-        async () => {
-          await tokensPage.tokensComp.isTokenGroupCount(primaryGroup, 0);
-        },
-      );
-
-      await mainTest.step(
-        'Attempt to create a token with leading/trailing separators ".primary.big." and verify Save button is disabled',
-        async () => {
-          await tokensPage.tokensComp.clickOnAddTokenAndFillData({
-            class: TokenClass.BorderRadius,
-            name: '.primary.big.',
-            value: tokenValue,
-          });
-          await expect(
-            tokensPage.tokensComp.baseComp.modalSaveButton,
-          ).toBeDisabled();
-          await tokensPage.tokensComp.baseComp.clickOnCancelButton();
-        },
-      );
-
-      await mainTest.step(
-        'Verify no incorrect groups are created after the leading/trailing separator attempt',
+        `Verify no "${primaryGroup.name}" group is created after the leading/trailing separator attempt`,
         async () => {
           await tokensPage.tokensComp.isTokenGroupCount(primaryGroup, 0);
         },

--- a/tests/tokens/token-group.spec.ts
+++ b/tests/tokens/token-group.spec.ts
@@ -405,4 +405,85 @@ mainTest.describe(() => {
       );
     },
   );
+
+  mainTest(
+    qase(
+      [2741],
+      'Error handling: Prevent creating token with empty name or invalid path format',
+    ),
+    async () => {
+      const tokenValue = '8';
+      const primaryGroup = { name: 'primary' };
+
+      await mainTest.step('Open Tokens panel', async () => {
+        await tokensPage.clickTokensTab();
+      });
+
+      await mainTest.step(
+        'Attempt to create a token with an empty name and verify Save button is disabled',
+        async () => {
+          await tokensPage.tokensComp.clickOnAddTokenAndFillData({
+            class: TokenClass.BorderRadius,
+            name: '',
+            value: tokenValue,
+          });
+          await expect(
+            tokensPage.tokensComp.baseComp.modalSaveButton,
+          ).toBeDisabled();
+          await tokensPage.tokensComp.baseComp.clickOnCancelButton();
+        },
+      );
+
+      await mainTest.step(
+        'Verify no groups or token pills were created after the empty name attempt',
+        async () => {
+          await tokensPage.tokensComp.isTokenGroupCount(primaryGroup, 0);
+        },
+      );
+
+      await mainTest.step(
+        'Attempt to create a token with a malformed path "primary..big" and verify Save button is disabled',
+        async () => {
+          await tokensPage.tokensComp.clickOnAddTokenAndFillData({
+            class: TokenClass.BorderRadius,
+            name: 'primary..big',
+            value: tokenValue,
+          });
+          await expect(
+            tokensPage.tokensComp.baseComp.modalSaveButton,
+          ).toBeDisabled();
+          await tokensPage.tokensComp.baseComp.clickOnCancelButton();
+        },
+      );
+
+      await mainTest.step(
+        'Verify no group with an empty name segment is created after the double-dot path attempt',
+        async () => {
+          await tokensPage.tokensComp.isTokenGroupCount(primaryGroup, 0);
+        },
+      );
+
+      await mainTest.step(
+        'Attempt to create a token with leading/trailing separators ".primary.big." and verify Save button is disabled',
+        async () => {
+          await tokensPage.tokensComp.clickOnAddTokenAndFillData({
+            class: TokenClass.BorderRadius,
+            name: '.primary.big.',
+            value: tokenValue,
+          });
+          await expect(
+            tokensPage.tokensComp.baseComp.modalSaveButton,
+          ).toBeDisabled();
+          await tokensPage.tokensComp.baseComp.clickOnCancelButton();
+        },
+      );
+
+      await mainTest.step(
+        'Verify no incorrect groups are created after the leading/trailing separator attempt',
+        async () => {
+          await tokensPage.tokensComp.isTokenGroupCount(primaryGroup, 0);
+        },
+      );
+    },
+  );
 });

--- a/tests/tokens/token-group.spec.ts
+++ b/tests/tokens/token-group.spec.ts
@@ -307,4 +307,87 @@ mainTest.describe(() => {
       );
     },
   );
+
+  mainTest(
+    qase(
+      [2736],
+      'Editing token path creates missing groups in UI and moves token accordingly',
+    ),
+    async () => {
+      const primaryBigToken: MainToken<TokenClass> = {
+        class: TokenClass.BorderRadius,
+        name: 'primary.big',
+        value: '16',
+        parent: { name: 'primary' },
+      };
+      const newGroupData = { name: 'newgroup' };
+      const subGroupData = { name: 'subgroup' };
+      const renamedTokenName = 'newgroup.subgroup.big';
+
+      await mainTest.step('Open Tokens panel', async () => {
+        await tokensPage.clickTokensTab();
+      });
+
+      await mainTest.step(
+        `Create a token named "${primaryBigToken.name}"`,
+        async () => {
+          await tokensPage.tokensComp.createTokenViaAddButtonAndEnter(
+            primaryBigToken,
+          );
+        },
+      );
+
+      await mainTest.step(
+        `Verify "${primaryBigToken.parent!.name}" group exists and contains "big" token pill`,
+        async () => {
+          await tokensPage.tokensComp.isTokenGroupVisible(primaryBigToken.parent!);
+          await tokensPage.tokensComp.isLastSegmentVisibleInGroup(
+            primaryBigToken.parent!,
+            'big',
+          );
+        },
+      );
+
+      await mainTest.step(
+        `Edit "${primaryBigToken.name}" and rename it to "${renamedTokenName}"`,
+        async () => {
+          await tokensPage.tokensComp.clickEditToken(primaryBigToken);
+          await tokensPage.tokensComp.tokenNameInput.fill(renamedTokenName);
+          await tokensPage.tokensComp.baseComp.modalSaveButton.click();
+          await mainPage.waitForChangeIsSaved();
+        },
+      );
+
+      await mainTest.step(
+        `Verify new groups "${newGroupData.name}" and "${subGroupData.name}" are created and automatically unfolded`,
+        async () => {
+          await tokensPage.tokensComp.isTokenGroupVisible(newGroupData);
+          await tokensPage.tokensComp.isTokenGroupExpanded(newGroupData);
+          await tokensPage.tokensComp.isTokenGroupVisible(subGroupData);
+          await tokensPage.tokensComp.isTokenGroupExpanded(subGroupData);
+        },
+      );
+
+      await mainTest.step(
+        `Verify token pill "big" is visible under "${subGroupData.name}" group`,
+        async () => {
+          await tokensPage.tokensComp.isTokenVisibleInGroup(
+            subGroupData,
+            renamedTokenName,
+          );
+          await tokensPage.tokensComp.isLastSegmentVisibleInGroup(
+            subGroupData,
+            'big',
+          );
+        },
+      );
+
+      await mainTest.step(
+        `Verify "${primaryBigToken.parent!.name}" group is removed from the DOM after moving its only token out`,
+        async () => {
+          await tokensPage.tokensComp.isTokenGroupCount(primaryBigToken.parent!, 0);
+        },
+      );
+    },
+  );
 });

--- a/tests/tokens/token-group.spec.ts
+++ b/tests/tokens/token-group.spec.ts
@@ -390,4 +390,85 @@ mainTest.describe(() => {
       );
     },
   );
+
+  mainTest(
+    qase(
+      [2741],
+      'Error handling: Prevent creating token with empty name or invalid path format',
+    ),
+    async () => {
+      const tokenValue = '8';
+      const primaryGroup = { name: 'primary' };
+
+      await mainTest.step('Open Tokens panel', async () => {
+        await tokensPage.clickTokensTab();
+      });
+
+      await mainTest.step(
+        'Attempt to create a token with an empty name and verify Save button is disabled',
+        async () => {
+          await tokensPage.tokensComp.clickOnAddTokenAndFillData({
+            class: TokenClass.BorderRadius,
+            name: '',
+            value: tokenValue,
+          });
+          await expect(
+            tokensPage.tokensComp.baseComp.modalSaveButton,
+          ).toBeDisabled();
+          await tokensPage.tokensComp.baseComp.clickOnCancelButton();
+        },
+      );
+
+      await mainTest.step(
+        'Verify no groups or token pills were created after the empty name attempt',
+        async () => {
+          await tokensPage.tokensComp.isTokenGroupCount(primaryGroup, 0);
+        },
+      );
+
+      await mainTest.step(
+        'Attempt to create a token with a malformed path "primary..big" and verify Save button is disabled',
+        async () => {
+          await tokensPage.tokensComp.clickOnAddTokenAndFillData({
+            class: TokenClass.BorderRadius,
+            name: 'primary..big',
+            value: tokenValue,
+          });
+          await expect(
+            tokensPage.tokensComp.baseComp.modalSaveButton,
+          ).toBeDisabled();
+          await tokensPage.tokensComp.baseComp.clickOnCancelButton();
+        },
+      );
+
+      await mainTest.step(
+        'Verify no group with an empty name segment is created after the double-dot path attempt',
+        async () => {
+          await tokensPage.tokensComp.isTokenGroupCount(primaryGroup, 0);
+        },
+      );
+
+      await mainTest.step(
+        'Attempt to create a token with leading/trailing separators ".primary.big." and verify Save button is disabled',
+        async () => {
+          await tokensPage.tokensComp.clickOnAddTokenAndFillData({
+            class: TokenClass.BorderRadius,
+            name: '.primary.big.',
+            value: tokenValue,
+          });
+          await expect(
+            tokensPage.tokensComp.baseComp.modalSaveButton,
+          ).toBeDisabled();
+          await tokensPage.tokensComp.baseComp.clickOnCancelButton();
+        },
+      );
+
+      await mainTest.step(
+        'Verify no incorrect groups are created after the leading/trailing separator attempt',
+        async () => {
+          await tokensPage.tokensComp.isTokenGroupCount(primaryGroup, 0);
+        },
+      );
+    },
+  );
 });


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

_If relevant, include the Taiga URL_
[Taiga Ticket: 931](https://tree.taiga.io/project/kaleidos-qa/task/931)

## Description

This PR adds a test for Error handling: Prevent creating a token with an empty name or an invalid path format (Qase: 2741)

## How to test

- [x] Check the code
- [x] Update the test case in Qase (Automation Status field or steps changed)
- [x] It complies with the test conventions
- [x] There are no missing snapshots for win32 (x3 browsers)
- [x] The tests run OK

## Screenshots 📸 (optional)

<img width="1742" height="800" alt="image" src="https://github.com/user-attachments/assets/d5946289-c868-4ad4-bd63-e8ed582ea501" />
