### PR TITLE
remove(tests): remove qase id 1295

### DIFF
--- a/pages/workspace/main-page.js
+++ b/pages/workspace/main-page.js
@@ -355,10 +355,10 @@ exports.MainPage = class MainPage extends BasePage {
     await expect(this.unSavedChangesIcon).toBeVisible();
   }
 
-  async isCreatedLayerVisible(visible = true, timeout) {
+  async isCreatedLayerVisible(visible = true) {
     visible
-      ? await expect(this.createdLayer).toBeVisible({ timeout })
-      : await expect(this.createdLayer).not.toBeVisible({ timeout });
+      ? await expect(this.createdLayer).toBeVisible()
+      : await expect(this.createdLayer).not.toBeVisible();
   }
 
   async isCopyLayerVisible() {

--- a/pages/workspace/main-page.js
+++ b/pages/workspace/main-page.js
@@ -355,10 +355,10 @@ exports.MainPage = class MainPage extends BasePage {
     await expect(this.unSavedChangesIcon).toBeVisible();
   }
 
-  async isCreatedLayerVisible(visible = true) {
+  async isCreatedLayerVisible(visible = true, timeout) {
     visible
-      ? await expect(this.createdLayer).toBeVisible()
-      : await expect(this.createdLayer).not.toBeVisible();
+      ? await expect(this.createdLayer).toBeVisible({ timeout })
+      : await expect(this.createdLayer).not.toBeVisible({ timeout });
   }
 
   async isCopyLayerVisible() {

--- a/tests/components/main-components/delete-main-components.spec.js
+++ b/tests/components/main-components/delete-main-components.spec.js
@@ -28,18 +28,6 @@ mainTest.afterEach(async () => {
   await teamPage.deleteTeam(teamName);
 });
 
-mainTest(qase([1295], 'Undo deleted component'), async ({ browserName }) => {
-  await mainPage.createDefaultRectangleByCoordinates(200, 300);
-  await mainPage.createComponentViaRightClickFromLayerByName('Rectangle');
-  await mainPage.waitForChangeIsSaved();
-  await mainPage.deleteLayerViaRightClick();
-  await mainPage.waitForChangeIsSaved();
-  await mainPage.isCreatedLayerVisible(false, 10000);
-  await mainPage.clickShortcutCtrlZ(browserName);
-  await mainPage.waitForChangeIsSaved();
-  await mainPage.isCreatedLayerVisible(true, 10000);
-});
-
 mainTest(qase([1456], 'Delete component Assets tab'), async () => {
   await mainPage.createDefaultRectangleByCoordinates(200, 300);
   await mainPage.createComponentViaRightClick();

--- a/tests/components/main-components/delete-main-components.spec.js
+++ b/tests/components/main-components/delete-main-components.spec.js
@@ -33,9 +33,11 @@ mainTest(qase([1295], 'Undo deleted component'), async ({ browserName }) => {
   await mainPage.createComponentViaRightClickFromLayerByName('Rectangle');
   await mainPage.waitForChangeIsSaved();
   await mainPage.deleteLayerViaRightClick();
-  await mainPage.isCreatedLayerVisible(false);
+  await mainPage.waitForChangeIsSaved();
+  await mainPage.isCreatedLayerVisible(false, 10000);
   await mainPage.clickShortcutCtrlZ(browserName);
-  await mainPage.isCreatedLayerVisible(true);
+  await mainPage.waitForChangeIsSaved();
+  await mainPage.isCreatedLayerVisible(true, 10000);
 });
 
 mainTest(qase([1456], 'Delete component Assets tab'), async () => {


### PR DESCRIPTION
# Done Definition Checks

## Description

Remove Qase ID 1295 due to its flakiness and as delete main component is already covered in another test.

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK