### PR TITLE
feat(access-token): add new test for delete access token

### DIFF
--- a/pages/profile-page.js
+++ b/pages/profile-page.js
@@ -131,6 +131,33 @@ exports.ProfilePage = class ProfilePage extends BasePage {
     this.skipPaymentsDetailsButton = page.locator(
       'input[value="Skip for now and start trial"]',
     );
+
+    // Integrations
+    this.integrationsSidebarOption = page
+      .getByRole('listitem')
+      .filter({ hasText: 'Integrations' });
+    this.integrationsHeader = page.getByRole('heading', { name: 'Integrations' });
+    this.createNewAccessTokenButton = page.getByRole('button', {
+      name: 'Create new access token',
+    });
+    this.createAccessTokenHeaderModalForm = page.getByRole('heading', {
+      name: 'Create access token',
+    });
+    this.accessTokenInputName = page.getByRole('textbox', { name: 'Name' });
+    this.createAccessTokenButtonSubmit = page.getByRole('button', {
+      name: 'Create access token',
+    });
+    this.accessTokenCreatedHeaderModal = page.getByRole('heading', {
+      name: 'Access token created',
+    });
+    this.closeModalButton = page.getByRole('button').filter({ hasText: 'Close' });
+    this.optionItem = page.getByRole('button', { name: 'Options' });
+    this.deleteOption = page.getByTestId('token-delete');
+    this.deleteTokenHeaderModal = page.getByRole('heading', {
+      name: 'Delete token',
+    });
+    this.deleteTokenButton = page.getByRole('button', { name: 'Delete token' });
+    this.noAccessTokensText = page.getByText('You have no tokens so far.');
   }
 
   async openYourAccountPage() {
@@ -409,5 +436,34 @@ exports.ProfilePage = class ProfilePage extends BasePage {
     const popupPromise = this.page.waitForEvent('popup');
     await this.termsOfServiceMenuItem.click();
     return popupPromise;
+  }
+
+  async openIntegrationsPage() {
+    await this.integrationsSidebarOption.click();
+    await expect(this.integrationsHeader).toBeVisible();
+  }
+
+  async createAccessToken(accessTokenName) {
+    await this.createNewAccessTokenButton.click();
+    await expect(this.createAccessTokenHeaderModalForm).toBeVisible();
+    await this.accessTokenInputName.fill(accessTokenName);
+    await this.createAccessTokenButtonSubmit.click();
+    await expect(this.accessTokenCreatedHeaderModal).toBeVisible();
+    await this.closeModalButton.click();
+    const createdAccessToken = this.page.getByText(accessTokenName);
+    await expect(createdAccessToken).toBeVisible();
+  }
+
+  async deleteAccessToken() {
+    await this.optionItem.click();
+    await expect(this.deleteOption).toBeVisible();
+    await this.deleteOption.click();
+    await expect(this.deleteTokenHeaderModal).toBeVisible();
+    await this.deleteTokenButton.click();
+    await this.checkNoAccessTokens();
+  }
+
+  async checkNoAccessTokens() {
+    await expect(this.noAccessTokensText).toBeVisible();
   }
 };

--- a/tests/your-account/integrations.spec.js
+++ b/tests/your-account/integrations.spec.js
@@ -1,0 +1,26 @@
+const { ProfilePage } = require('@pages/profile-page');
+const { integrationsTest } = require('./your-account-fixture');
+const { qase } = require('playwright-qase-reporter/playwright');
+
+integrationsTest(
+  qase(
+    2749,
+    'Delete an existing access token and verify it is removed from the list',
+  ),
+  async ({ profilePage }) => {
+    await integrationsTest.step('Create an access token', async () => {
+      const accessTokenName = 'Access token test';
+      await profilePage.createAccessToken(accessTokenName);
+    });
+    await integrationsTest.step('Delete the created access token', async () => {
+      await profilePage.deleteAccessToken();
+    });
+    await integrationsTest.step(
+      'Reload page and check that the created access token is deleted',
+      async () => {
+        await profilePage.reloadPage();
+        await profilePage.checkNoAccessTokens();
+      },
+    );
+  },
+);

--- a/tests/your-account/your-account-fixture.js
+++ b/tests/your-account/your-account-fixture.js
@@ -26,6 +26,19 @@ const passwordTest = mainTest.extend({
   },
 });
 
+// Open Your Account > Integrations section
+const integrationsTest = mainTest.extend({
+  profilePage: async ({ page }, use) => {
+    const profilePage = new ProfilePage(page);
+
+    await profilePage.openYourAccountPage();
+    await profilePage.openIntegrationsPage();
+    await profilePage.isHeaderDisplayed('Your account');
+
+    await use(profilePage);
+  },
+});
+
 // Open Your Account > Give Feedback section
 const giveFeedbackTest = mainTest.extend({
   profilePage: async ({ page }, use) => {
@@ -38,4 +51,4 @@ const giveFeedbackTest = mainTest.extend({
   },
 });
 
-module.exports = { profileTest, passwordTest, giveFeedbackTest };
+module.exports = { profileTest, passwordTest, giveFeedbackTest, integrationsTest };


### PR DESCRIPTION
# Done Definition Checks

## Description

This PR add a new test about delete access token [PENPOT-2749](https://app.qase.io/case/PENPOT-2749)

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Screenshots 📸 (optional)

<img width="1990" height="434" alt="delete-access-token" src="https://github.com/user-attachments/assets/affe9e66-1c42-4276-8f4c-4faa541292c1" />
