### PR TITLE
fix(tests): fix import tokens test 2221

### DIFF
--- a/tests/tokens/import.spec.ts
+++ b/tests/tokens/import.spec.ts
@@ -42,6 +42,7 @@ mainTest(qase(2213, 'Import tokens'), async ({ page }) => {
 });
 
 mainTest(qase(2221, 'Import .penpot file with tokens'), async ({ page }) => {
+  const mainPage: MainPage = new MainPage(page);
   const dashboardPage: DashboardPage = new DashboardPage(page);
   const tokensPage: TokensPage = new TokensPage(page);
   await dashboardPage.openSidebarItem('Drafts');
@@ -50,6 +51,7 @@ mainTest(qase(2221, 'Import .penpot file with tokens'), async ({ page }) => {
   );
   await dashboardPage.isFilePresent('⚙️ Design Tokens Starter Set | Edited');
   await dashboardPage.openFileWithName('⚙️ Design Tokens Starter Set | Edited');
+  await mainPage.isMainPageLoaded();
   await tokensPage.clickTokensTab();
   await tokensPage.themesComp.checkSelectedTheme('2 active themes');
   await tokensPage.setsComp.isSetNameVisible('client_theme_template');


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/task/1046

## Description

Test Qase ID 2221 is failing in CI and seems related to the imported file not being properly loaded before clicking on TOKENS tab. 

This PR adds an assertion to validate that main page is properly loaded before clicking.

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Test Execution Results in CI

<img width="1004" height="689" alt="image" src="https://github.com/user-attachments/assets/e530a13e-1e55-4a5b-b339-b86639623bdf" />

