### PR TITLE
fix(test): penpot-1943 pin autosaved version

### DIFF
--- a/tests/panels-features/panels-features-history-panel.spec.js
+++ b/tests/panels-features/panels-features-history-panel.spec.js
@@ -148,6 +148,7 @@ mainTest.describe(() => {
           await historyPage.clickOnAutosaveVersionsButton();
           await historyPage.selectSnapshotOption('Pin version');
           await historyPage.renameVersion(versionName);
+          await historyPage.clickHistoryPanelButton();
           await historyPage.checkLastVersionName(versionName);
           await historyPage.checkAutosaveVersionsCount('1');
         },


### PR DESCRIPTION
# Done Definition Checks

This PR fix a failure in PENPOT-1943 pin autosaved version

## How to test

- [ ] Check the code
- [ ] It complies with the test conventions
- [ ] The tests run OK

## Screenshots 📸 (optional)

<img width="1792" height="1814" alt="history-panel" src="https://github.com/user-attachments/assets/8dcd1f3d-b5ba-443d-8a4d-5d8ba9a4153a" />

