### PR TITLE
fix(tests): review [Non-regression and automated] PENPOT-2389

### DIFF
--- a/tests/composition/composition-board.spec.js
+++ b/tests/composition/composition-board.spec.js
@@ -904,7 +904,6 @@ mainTest(
 
     await mainTest.step('Change to custom dimensions after preset', async () => {
       await designPanelPage.changeHeightAndWidthForLayer('500', '750');
-      await mainPage.waitForChangeIsSaved();
       await designPanelPage.checkSizeWidth('750');
       await designPanelPage.checkSizeHeight('500');
     });

--- a/tests/composition/composition-board.spec.js
+++ b/tests/composition/composition-board.spec.js
@@ -863,46 +863,50 @@ mainTest.describe(() => {
       );
     },
   );
-
-  mainTest(
-    qase(
-      [2389],
-      'Create board with a default size preset (Toolbar) allows custom dimension after creation',
-    ),
-    async () => {
-      await mainPage.clickViewportOnce();
-      await mainPage.clickCreatedBoardTitleOnCanvas();
-      await designPanelPage.checkSizeWidth('600');
-      await designPanelPage.checkSizeHeight('600');
-    },
-  );
 });
 
 mainTest(
   qase(
-    [2390],
+    [2389, 2390],
     'Create board with a default size preset allow to change frame orientation (Toolbar)',
   ),
   async () => {
     await mainPage.clickCreateBoardButton();
 
-    await designPanelPage.selectSizePresetsOption('Expanded');
-    await designPanelPage.clickOnVerticalOrientationButton();
-    await mainPage.clickViewportByCoordinates(100, 150);
-    await mainPage.waitForChangeIsSaved();
-    await designPanelPage.isVerticalOrientationButtonChecked();
-    await designPanelPage.checkSizeWidth('800');
-    await designPanelPage.checkSizeHeight('1280');
+    await mainTest.step(
+      'Select Expanded preset and change to vertical orientation',
+      async () => {
+        await designPanelPage.selectSizePresetsOption('Expanded');
+        await designPanelPage.clickOnVerticalOrientationButton();
+        await mainPage.clickViewportByCoordinates(100, 150);
+        await mainPage.waitForChangeIsSaved();
+        await designPanelPage.isVerticalOrientationButtonChecked();
+        await designPanelPage.checkSizeWidth('800');
+        await designPanelPage.checkSizeHeight('1280');
+      },
+    );
 
-    await designPanelPage.selectSizePresetsOption('iPhone 16 ');
-    await mainPage.waitForChangeIsSaved();
-    await designPanelPage.isVerticalOrientationButtonChecked();
-    await designPanelPage.checkSizeWidth('393');
-    await designPanelPage.checkSizeHeight('852');
-    await designPanelPage.clickOnHorizontalOrientationButton();
-    await mainPage.waitForChangeIsSaved();
-    await designPanelPage.isHorizontalOrientationButtonChecked();
-    await designPanelPage.checkSizeWidth('852');
-    await designPanelPage.checkSizeHeight('393');
+    await mainTest.step(
+      'Select iPhone 16 preset and change to horizontal orientation',
+      async () => {
+        await designPanelPage.selectSizePresetsOption('iPhone 16 ');
+        await mainPage.waitForChangeIsSaved();
+        await designPanelPage.isVerticalOrientationButtonChecked();
+        await designPanelPage.checkSizeWidth('393');
+        await designPanelPage.checkSizeHeight('852');
+        await designPanelPage.clickOnHorizontalOrientationButton();
+        await mainPage.waitForChangeIsSaved();
+        await designPanelPage.isHorizontalOrientationButtonChecked();
+        await designPanelPage.checkSizeWidth('852');
+        await designPanelPage.checkSizeHeight('393');
+      },
+    );
+
+    await mainTest.step('Change to custom dimensions after preset', async () => {
+      await designPanelPage.changeHeightAndWidthForLayer('500', '750');
+      await mainPage.waitForChangeIsSaved();
+      await designPanelPage.checkSizeWidth('750');
+      await designPanelPage.checkSizeHeight('500');
+    });
   },
 );


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

_If relevant, include the Taiga URL_
[Taiga Ticket: 1076](https://tree.taiga.io/project/kaleidos-qa/task/1076)

## Description

This PR reviews the test PENPOT-2389, which is automated but is marked as not a regression. 

PENPOT-2389 was done incorrectly — it was added inside a describe block whose beforeEach created a board via coordinates (not via toolbar preset, as the Qase pre-conditions said), and the test itself only verified the 600×600 value that had already been set in beforeEach. It wasn't actually testing "custom dimension after creation" at all. PENPOT-2390 was more related to this scenario since it already covers the full toolbar preset workflow.

_Changes made:_

- Removed the PENPOT-2389 test from the resize-to-fit describe block, where it didn't belong.
- Updated test 2390 to include the ID 2389 in qase([2389, 2390], ...), as they are more similar and could be together.
- Added steps to test 2390 for clarity, including the new "Change to custom dimensions after preset" step that sets 750×500 dimensions after using the iPhone 16 preset and verifies the design panel reflects them correctly.

## How to test

- [x] Check the code
- [x] Update the test case in Qase (Automation Status field or steps changed)
- [x] It complies with the test conventions
- [x] There are no missing snapshots for win32 (x3 browsers)
- [x] The tests run OK

## Screenshots 📸 (optional)

<img width="1705" height="1028" alt="image" src="https://github.com/user-attachments/assets/4953ae4e-da33-4de1-8e40-bb02fe4947ae" />
