### PR TITLE
feat(composition-board): add test to be automated: PENPOT-218 Create board without a default size preset (Shortcut B)

### DIFF
--- a/pages/workspace/design-panel-page.js
+++ b/pages/workspace/design-panel-page.js
@@ -1665,7 +1665,7 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
   }
 
   async checkSizePresetsDropdownVisible() {
-    await this.sizePresetsDropdown.waitFor({ state: 'visible' });
+    await expect(this.sizePresetsDropdown).toBeVisible();
   }
 
   async openSizePresetsDropdown() {

--- a/pages/workspace/design-panel-page.js
+++ b/pages/workspace/design-panel-page.js
@@ -1664,6 +1664,10 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
     }
   }
 
+  async checkSizePresetsDropdownVisible() {
+    await this.sizePresetsDropdown.waitFor({ state: 'visible' });
+  }
+
   async openSizePresetsDropdown() {
     await this.sizePresetsDropdown.click();
   }

--- a/pages/workspace/main-page.js
+++ b/pages/workspace/main-page.js
@@ -572,6 +572,10 @@ exports.MainPage = class MainPage extends BasePage {
     await this.page.keyboard.press('C');
   }
 
+  async pressBKeyboardShortcut() {
+    await this.page.keyboard.press('b');
+  }
+
   async clickMainMenuButton() {
     await this.mainMenuButton.click();
     await expect(this.mainMenuList).toBeVisible();

--- a/pages/workspace/main-page.js
+++ b/pages/workspace/main-page.js
@@ -573,7 +573,7 @@ exports.MainPage = class MainPage extends BasePage {
   }
 
   async pressBKeyboardShortcut() {
-    await this.page.keyboard.press('b');
+    await this.page.keyboard.press('B');
   }
 
   async clickMainMenuButton() {

--- a/tests/composition/composition-board.spec.js
+++ b/tests/composition/composition-board.spec.js
@@ -879,6 +879,30 @@ mainTest.describe(() => {
 });
 
 mainTest(
+  qase([218], 'Create a board without a default size preset (Shortcut B)'),
+  async () => {
+    await mainTest.step(
+      'Press B shortcut and verify Size presets dropdown appears',
+      async () => {
+        await mainPage.pressBKeyboardShortcut();
+        await designPanelPage.checkSizePresetsDropdownVisible();
+      },
+    );
+
+    await mainTest.step(
+      'Click on canvas and verify board with default size is created',
+      async () => {
+        await mainPage.clickViewportTwice();
+        await mainPage.waitForChangeIsSaved();
+        await mainPage.isCreatedLayerVisible();
+        await designPanelPage.checkSizeWidth('100');
+        await designPanelPage.checkSizeHeight('100');
+      },
+    );
+  },
+);
+
+mainTest(
   qase(
     [2390],
     'Create board with a default size preset allow to change frame orientation (Toolbar)',


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)
[Taiga Ticket: 1077](https://tree.taiga.io/project/kaleidos-qa/task/1077)

## Description

This PR adds a test marked to be automated: `PENPOT-218 Create board without a default size preset (Shortcut B)` 

## How to test

- [x] Check the code
- [x] Update the test case in Qase (Automation Status field or steps changed)
- [x] It complies with the test conventions
- [x] There are no missing snapshots for win32 (x3 browsers)
- [x] The tests run OK

## Screenshots 📸 (optional)
<img width="1669" height="1147" alt="image" src="https://github.com/user-attachments/assets/f187648b-d1aa-4c7a-87f1-5d15276a3c24" />

