### PR TITLE
feat(composition-rectangle): add test PENPOT-275 Create rectangle (Shortcut R)

### DIFF
--- a/pages/workspace/main-page.js
+++ b/pages/workspace/main-page.js
@@ -576,6 +576,10 @@ exports.MainPage = class MainPage extends BasePage {
     await this.page.keyboard.press('B');
   }
 
+  async pressRKeyboardShortcut() {
+    await this.page.keyboard.press('R');
+  }
+
   async clickMainMenuButton() {
     await this.mainMenuButton.click();
     await expect(this.mainMenuList).toBeVisible();

--- a/pages/workspace/main-page.js
+++ b/pages/workspace/main-page.js
@@ -544,40 +544,20 @@ exports.MainPage = class MainPage extends BasePage {
     await this.nodePanelJoinNodesButton.click();
   }
 
-  async pressJKeyboardShortcut() {
-    await this.page.keyboard.press('J');
+  async pressKeyboardShortcut(key) {
+    await this.page.keyboard.press(key);
   }
 
   async clickSeparateNodesButtonOnNodePanel() {
     await this.nodePanelSeparateNodesButton.click();
   }
 
-  async pressKKeyboardShortcut() {
-    await this.page.keyboard.press('K');
-  }
-
   async clickToCornerButtonOnNodePanel() {
     await this.nodePanelToCornerButton.click();
   }
 
-  async pressXKeyboardShortcut() {
-    await this.page.keyboard.press('X');
-  }
-
   async clickToCurveButtonOnNodePanel() {
     await this.nodePanelToCurveButton.click();
-  }
-
-  async pressCKeyboardShortcut() {
-    await this.page.keyboard.press('C');
-  }
-
-  async pressBKeyboardShortcut() {
-    await this.page.keyboard.press('B');
-  }
-
-  async pressRKeyboardShortcut() {
-    await this.page.keyboard.press('R');
   }
 
   async clickMainMenuButton() {

--- a/pages/workspace/main-page.js
+++ b/pages/workspace/main-page.js
@@ -545,7 +545,8 @@ exports.MainPage = class MainPage extends BasePage {
   }
 
   async pressKeyboardShortcut(key) {
-    await this.page.keyboard.press(key);
+    const normalizedKey = key.length === 1 ? key.toUpperCase() : key;
+    await this.page.keyboard.press(normalizedKey);
   }
 
   async clickSeparateNodesButtonOnNodePanel() {

--- a/tests/composition/composition-board.spec.js
+++ b/tests/composition/composition-board.spec.js
@@ -871,7 +871,7 @@ mainTest(
     await mainTest.step(
       'Press B shortcut and verify Size presets dropdown appears',
       async () => {
-        await mainPage.pressBKeyboardShortcut();
+        await mainPage.pressKeyboardShortcut('B');
         await designPanelPage.checkSizePresetsDropdownVisible();
       },
     );

--- a/tests/composition/composition-comments.spec.js
+++ b/tests/composition/composition-comments.spec.js
@@ -187,7 +187,7 @@ mainTest(qase([2148], 'Zoom out and check comment bubbles'), async () => {
   const xAxisCommentsCoordinates = [100, 50, 700];
   const yAxisCommentsCoordinates = [150, 50, 700];
 
-  await mainPage.pressCKeyboardShortcut();
+  await mainPage.pressKeyboardShortcut('C');
   for (let i = 0; i < xAxisCommentsCoordinates.length; i++) {
     await mainPage.clickViewportByCoordinates(
       xAxisCommentsCoordinates[i],

--- a/tests/composition/composition-path-node-panel.spec.js
+++ b/tests/composition/composition-path-node-panel.spec.js
@@ -130,7 +130,7 @@ mainTest.describe(() => {
     await mainPage.clickFifthNode();
     await mainPage.clickSecondNode();
     await mainPage.releaseShiftKeyboardButton();
-    await mainPage.pressJKeyboardShortcut();
+    await mainPage.pressKeyboardShortcut('J');
     await mainPage.waitForChangeIsSaved();
     await expect(mainPage.viewport).toHaveScreenshot('path-joined-nodes-twice.png', {
       mask: mainPage.maskViewport(),
@@ -156,7 +156,7 @@ mainTest.describe(() => {
       await mainPage.holdShiftKeyboardButton();
       await mainPage.clickThirdNode();
       await mainPage.releaseShiftKeyboardButton();
-      await mainPage.pressKKeyboardShortcut();
+      await mainPage.pressKeyboardShortcut('K');
       await mainPage.waitForChangeIsSaved();
       await expect(mainPage.viewport).toHaveScreenshot(
         'path-separated-nodes-twice.png',
@@ -180,7 +180,7 @@ mainTest.describe(() => {
         },
       );
       await mainPage.clickSecondNode();
-      await mainPage.pressXKeyboardShortcut();
+      await mainPage.pressKeyboardShortcut('X');
       await mainPage.waitForChangeIsSaved();
       await expect(mainPage.viewport).toHaveScreenshot(
         'path-to-corner-two-nodes.png',
@@ -208,7 +208,7 @@ mainTest(
       mask: mainPage.maskViewport(),
     });
     await mainPage.clickSecondNode();
-    await mainPage.pressCKeyboardShortcut();
+    await mainPage.pressKeyboardShortcut('C');
     await mainPage.waitForChangeIsSaved();
     await expect(mainPage.viewport).toHaveScreenshot('path-to-curve-two-nodes.png', {
       mask: mainPage.maskViewport(),

--- a/tests/composition/composition-rectangle.spec.js
+++ b/tests/composition/composition-rectangle.spec.js
@@ -36,6 +36,26 @@ mainTest.afterEach(async () => {
   await teamPage.deleteTeam(teamName);
 });
 
+mainTest(qase([275], 'Create Rectangle (Shortcut R)'), async () => {
+  await mainTest.step(
+    'Press R shortcut and verify rectangle tool is active',
+    async () => {
+      await mainPage.pressKeyboardShortcut('R');
+    },
+  );
+
+  await mainTest.step(
+    'Click on canvas and verify rectangle with default size is created',
+    async () => {
+      await mainPage.clickViewportTwice();
+      await mainPage.waitForChangeIsSaved();
+      await mainPage.isCreatedLayerVisible();
+      await designPanelPage.checkSizeWidth('100');
+      await designPanelPage.checkSizeHeight('100');
+    },
+  );
+});
+
 mainTest.describe(() => {
   mainTest.beforeEach(async () => {
     await mainTest.slow();
@@ -366,26 +386,6 @@ mainTest.describe(() => {
       mask: mainPage.maskViewport(),
     });
   });
-});
-
-mainTest(qase([275], 'Create Rectangle (Shortcut R)'), async () => {
-  await mainTest.step(
-    'Press R shortcut and verify rectangle tool is active',
-    async () => {
-      await mainPage.pressKeyboardShortcut('R');
-    },
-  );
-
-  await mainTest.step(
-    'Click on canvas and verify rectangle with default size is created',
-    async () => {
-      await mainPage.clickViewportTwice();
-      await mainPage.waitForChangeIsSaved();
-      await mainPage.isCreatedLayerVisible();
-      await designPanelPage.checkSizeWidth('100');
-      await designPanelPage.checkSizeHeight('100');
-    },
-  );
 });
 
 mainTest(qase([2255], 'Select and deselect rectangles'), async ({ browserName }) => {

--- a/tests/composition/composition-rectangle.spec.js
+++ b/tests/composition/composition-rectangle.spec.js
@@ -368,6 +368,26 @@ mainTest.describe(() => {
   });
 });
 
+mainTest(qase([275], 'Create Rectangle (Shortcut R)'), async () => {
+  await mainTest.step(
+    'Press R shortcut and verify rectangle tool is active',
+    async () => {
+      await mainPage.pressRKeyboardShortcut();
+    },
+  );
+
+  await mainTest.step(
+    'Click on canvas and verify rectangle with default size is created',
+    async () => {
+      await mainPage.clickViewportTwice();
+      await mainPage.waitForChangeIsSaved();
+      await mainPage.isCreatedLayerVisible();
+      await designPanelPage.checkSizeWidth('100');
+      await designPanelPage.checkSizeHeight('100');
+    },
+  );
+});
+
 mainTest(qase([2255], 'Select and deselect rectangles'), async ({ browserName }) => {
   await mainPage.createDefaultRectangleByCoordinates(400, 800);
   await mainPage.createDefaultRectangleByCoordinates(400, 200, true);

--- a/tests/composition/composition-rectangle.spec.js
+++ b/tests/composition/composition-rectangle.spec.js
@@ -372,7 +372,7 @@ mainTest(qase([275], 'Create Rectangle (Shortcut R)'), async () => {
   await mainTest.step(
     'Press R shortcut and verify rectangle tool is active',
     async () => {
-      await mainPage.pressRKeyboardShortcut();
+      await mainPage.pressKeyboardShortcut('R');
     },
   );
 


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

_If relevant, include the Taiga URL_
[Taiga Ticket: 1080](https://tree.taiga.io/project/kaleidos-qa/task/1080)

## Description

This PR adds a test: PENPOT-275 Create rectangle (Shortcut R), also creates a generic method to press a keyboard shortcut (`pressKeyboardShortcut`), and updates the tests accordingly. 

## How to test

- [x] Check the code
- [x] Update the test case in Qase (Automation Status field or steps changed)
- [x] It complies with the test conventions
- [x] There are no missing snapshots for win32 (x3 browsers)
- [x] The tests run OK

## Screenshots 📸 (optional)
<img width="1651" height="1154" alt="image" src="https://github.com/user-attachments/assets/979c8d97-430c-4d17-a2a6-8fc197bd0c79" />
