### PR TITLE
fix(tests): fix Qase ID 1519

### DIFF
--- a/pages/workspace/main-page.js
+++ b/pages/workspace/main-page.js
@@ -170,7 +170,7 @@ exports.MainPage = class MainPage extends BasePage {
       .filter({ hasText: 'Zoom to selected' });
 
     //Pages
-    this.addPageButton = page.locator('button[class*="add-page"]');
+    this.addPageButton = page.getByRole('button', { name: 'Add page' });
     this.pagesBlock = page.locator('div.main_ui_workspace_sidebar_sitemap__sitemap');
     this.firstPageListItem = page
       .getByTestId('page-name')

--- a/tests/panels-features/panels-features-pages.spec.js
+++ b/tests/panels-features/panels-features-pages.spec.js
@@ -142,7 +142,7 @@ mainTest(
     1519,
     'Copy and paste components from Page 1 to Page 2, on Page 2 right-click component and select "Show main component"',
   ),
-  async ({ browserName }) => {
+  async () => {
     await mainPage.createDefaultRectangleByCoordinates(300, 300);
     await mainPage.createComponentViaRightClick();
     await mainPage.waitForChangeIsSaved();

--- a/tests/panels-features/panels-features-pages.spec.js
+++ b/tests/panels-features/panels-features-pages.spec.js
@@ -150,7 +150,9 @@ mainTest(
     await mainPage.clickAddPageButton();
     await mainPage.waitForChangeIsSaved();
     await mainPage.clickOnPageOnLayersPanel(2);
+    await mainPage.isSecondPageNameDisplayed('Page 2');
     await mainPage.pressPasteShortcut(browserName);
+    await mainPage.waitForChangeIsSaved();
     await layersPanelPage.clickCopyComponentOnLayersTab();
     await basePage.showMainComponentViaRightClick();
     await mainPage.waitForChangeIsSaved();

--- a/tests/panels-features/panels-features-pages.spec.js
+++ b/tests/panels-features/panels-features-pages.spec.js
@@ -146,12 +146,12 @@ mainTest(
     await mainPage.createDefaultRectangleByCoordinates(300, 300);
     await mainPage.createComponentViaRightClick();
     await mainPage.waitForChangeIsSaved();
-    await mainPage.pressCopyShortcut(browserName);
+    await mainPage.copyLayerViaRightClick();
     await mainPage.clickAddPageButton();
     await mainPage.waitForChangeIsSaved();
     await mainPage.clickOnPageOnLayersPanel(2);
     await mainPage.isSecondPageNameDisplayed('Page 2');
-    await mainPage.pressPasteShortcut(browserName);
+    await mainPage.pasteLayerViaRightClick();
     await mainPage.waitForChangeIsSaved();
     await layersPanelPage.clickCopyComponentOnLayersTab();
     await basePage.showMainComponentViaRightClick();


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/task/1070

## Description

Fix for Qase ID 1519 by replacing shortcut methdos with UI ones.

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Test Execution Results in CI

<img width="1009" height="856" alt="image" src="https://github.com/user-attachments/assets/256869d7-8814-46f3-8dab-c80fb5a6822e" />
