### PR TITLE
feat(tests): add test for creating ellipse using shortcut E: PENPOT-328 

### DIFF
--- a/tests/composition/composition-ellipse.spec.js
+++ b/tests/composition/composition-ellipse.spec.js
@@ -36,6 +36,26 @@ mainTest.afterEach(async () => {
   await teamPage.deleteTeam(teamName);
 });
 
+mainTest(qase([328], 'Create Ellipse (Shortcut E)'), async () => {
+  await mainTest.step(
+    'Press E shortcut and verify ellipse tool is active',
+    async () => {
+      await mainPage.pressKeyboardShortcut('E');
+    },
+  );
+
+  await mainTest.step(
+    'Click on canvas and verify ellipse with default size is created',
+    async () => {
+      await mainPage.clickViewportTwice();
+      await mainPage.waitForChangeIsSaved();
+      await mainPage.isCreatedLayerVisible();
+      await designPanelPage.checkSizeWidth('100');
+      await designPanelPage.checkSizeHeight('100');
+    },
+  );
+});
+
 mainTest.describe(() => {
   mainTest.beforeEach(async () => {
     mainTest.slow();

--- a/tests/composition/composition-ellipse.spec.js
+++ b/tests/composition/composition-ellipse.spec.js
@@ -50,6 +50,7 @@ mainTest(qase([328], 'Create Ellipse (Shortcut E)'), async () => {
       await mainPage.clickViewportTwice();
       await mainPage.waitForChangeIsSaved();
       await mainPage.isCreatedLayerVisible();
+      await layersPanelPage.isLayerNameDisplayed('Ellipse');
       await designPanelPage.checkSizeWidth('100');
       await designPanelPage.checkSizeHeight('100');
     },


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)
[Taiga Ticket: 1081](https://tree.taiga.io/project/kaleidos-qa/task/1081)

## Description

This PR adds a new test, PENPOT-328, to create a new ellipse with a shortcut. 

## How to test

- [x] Check the code
- [x] Update the test case in Qase (Automation Status field or steps changed)
- [x] It complies with the test conventions
- [x] There are no missing snapshots for win32 (x3 browsers)
- [x] The tests run OK

## Screenshots 📸 (optional)

<img width="1704" height="1147" alt="image" src="https://github.com/user-attachments/assets/5683c70b-c77d-4522-87a4-0a9fe2ce1d9d" />

