### PR TITLE
feat(mcp-workspace): add new tests accesing the MCP Server from the workspace

### DIFF
--- a/pages/profile-page.js
+++ b/pages/profile-page.js
@@ -469,6 +469,12 @@ exports.ProfilePage = class ProfilePage extends BasePage {
     await expect(this.integrationsHeader).toBeVisible();
   }
 
+  async openYourAccountIntegrationsPage() {
+    await this.openYourAccountPage();
+    await this.openIntegrationsPage();
+    await this.isHeaderDisplayed('Your account');
+  }
+
   // Integrations access token
 
   async createAccessToken(accessTokenName) {

--- a/pages/workspace/main-page.js
+++ b/pages/workspace/main-page.js
@@ -82,6 +82,10 @@ exports.MainPage = class MainPage extends BasePage {
     this.viewMainMenuItem = page.getByRole('menuitem').filter({ hasText: 'View' });
     this.fileMainMenuItem = page.getByRole('menuitem').filter({ hasText: 'File' });
     this.editMainMenuItem = page.getByRole('menuitem').filter({ hasText: 'Edit' });
+    this.mcpServerMainMenuItem = page.getByRole('menuitem', { name: 'MCP server' });
+    this.mcpServerMainMenuActiveStatus = page
+      .getByRole('menuitem')
+      .locator('.main_ui_workspace_main_menu__active');
     this.helpInfoMenuItem = page
       .getByRole('menuitem')
       .filter({ hasText: 'Help & info' });
@@ -144,6 +148,12 @@ exports.MainPage = class MainPage extends BasePage {
     this.shortcutsMenuSubItem = page
       .getByRole('menuitem')
       .filter({ hasText: 'Shortcuts' });
+    this.connectMCPServerMenuSubItem = page
+      .getByRole('menuitem')
+      .filter({ hasText: 'Connect' });
+    this.disconnectMCPServerMenuSubItem = page
+      .getByRole('menuitem')
+      .filter({ hasText: 'Disconnect' });
     this.downloadFileTickIcon = page.locator('svg[class="icon-tick"]');
     this.downloadFileCloseButton = page.locator('input[value="Close"]');
 
@@ -578,6 +588,10 @@ exports.MainPage = class MainPage extends BasePage {
     await this.editMainMenuItem.click();
   }
 
+  async hoverMCPServerMenuItem() {
+    await this.mcpServerMainMenuItem.hover();
+  }
+
   async clickHelpInfoMainMenuItem() {
     await this.helpInfoMenuItem.click();
   }
@@ -716,6 +730,38 @@ exports.MainPage = class MainPage extends BasePage {
 
   async clickShortcutsMainMenuSubItem() {
     await this.shortcutsMenuSubItem.click();
+  }
+
+  async isMCPServerStatusIndicatorActive(active = true, timeout = 10000) {
+    active
+      ? await this.mcpServerMainMenuActiveStatus.waitFor({
+          state: 'attached',
+          timeout: timeout,
+        })
+      : await this.mcpServerMainMenuActiveStatus.waitFor({
+          state: 'detached',
+          timeout: timeout,
+        });
+  }
+
+  async clickConnectMCPServerMenuSubItem() {
+    await this.connectMCPServerMenuSubItem.click();
+  }
+
+  async clickDisconnectMCPServerMenuSubItem() {
+    await this.disconnectMCPServerMenuSubItem.click();
+  }
+
+  getManageMCPServerStatusMenuSubItem(status) {
+    return this.page.getByRole('menuitem', { name: `Manage (Status: ${status})` });
+  }
+
+  async openManageMCPServerStatusPage(status) {
+    const manageMCPServerStatusSubItem =
+      this.getManageMCPServerStatusMenuSubItem(status);
+    const popupPromise = this.page.waitForEvent('popup');
+    await manageMCPServerStatusSubItem.click();
+    return popupPromise;
   }
 
   async clickZoomButton() {

--- a/tests/your-account/integrations/mcp-server.spec.ts
+++ b/tests/your-account/integrations/mcp-server.spec.ts
@@ -1,37 +1,145 @@
 import { ProfilePage } from '@pages/profile-page';
-import { integrationsTest } from '../your-account-fixture';
+import { mcpServerTest } from '../your-account-fixture';
 import { qase } from 'playwright-qase-reporter/playwright';
+import { DashboardPage } from '@pages/dashboard/dashboard-page';
+import { MainPage } from '@pages/workspace/main-page';
+import { expect } from '@playwright/test';
 
-integrationsTest(
+let mainPage: MainPage;
+let dashboardPage: DashboardPage;
+
+mcpServerTest.beforeEach(async ({ page }) => {
+  dashboardPage = new DashboardPage(page);
+  mainPage = new MainPage(page);
+});
+
+mcpServerTest(
   qase(
-    [2771, 2787, 2770, 2775],
+    [2771, 2770, 2775, 2783, 2785, 2787, 2791],
     'Enable MCP generating key, disable MCP, enable MCP with an existing key and delete key',
   ),
   async ({ profilePage }: { profilePage: ProfilePage }) => {
-    await integrationsTest.step('Enable MCP', async () => {
+    await mcpServerTest.step('2771 Enable MCP', async () => {
       await profilePage.enableMCPServerWithoutKey();
     });
-    await integrationsTest.step('Generate MCP key', async () => {
+    await mcpServerTest.step('2771 Generate MCP key', async () => {
       await profilePage.generateMCPKey();
     });
-    await integrationsTest.step('Disable MCP', async () => {
+
+    await mcpServerTest.step('2787 Disable MCP', async () => {
       await profilePage.disableMCPServer();
+      await profilePage.backToDashboardFromAccount();
     });
-    await integrationsTest.step(
-      'Enable MCP server with an existing MCP key',
+
+    await mcpServerTest.step(
+      '2785 Create a new file and open it in the workspace',
+      async () => {
+        await dashboardPage.createFileViaPlaceholder();
+        await mainPage.isMainPageLoaded();
+      },
+    );
+
+    await mcpServerTest.step(
+      '2785 Open the link to manage the MCP server status from the Workspace menu',
+      async () => {
+        await mainPage.clickMainMenuButton();
+        await mainPage.isMCPServerStatusIndicatorActive(false);
+        await mainPage.hoverMCPServerMenuItem();
+        const manageMCPServerPage =
+          await mainPage.openManageMCPServerStatusPage('disabled');
+        await expect(manageMCPServerPage).toHaveURL(/#\/settings\/integrations$/);
+      },
+    );
+
+    await mcpServerTest.step(
+      'Go back to the integrations page from file editor',
+      async () => {
+        await mainPage.backToDashboardFromFileEditor();
+        await profilePage.openYourAccountIntegrationsPage();
+      },
+    );
+
+    await mcpServerTest.step(
+      '2770 Enable MCP server with an existing MCP key',
       async () => {
         await profilePage.enableMCPServerWithKey();
       },
     );
-    await integrationsTest.step('Delete MCP key', async () => {
+
+    await mcpServerTest.step(
+      'Re-open the file from the Integrations page',
+      async () => {
+        await profilePage.backToDashboardFromAccount();
+        await dashboardPage.openFileWithName('New File 1');
+        await mainPage.isMainPageLoaded();
+      },
+    );
+
+    await mcpServerTest.step(
+      '2791 Disconnect with the MCP Server from the MCP Workspace menu',
+      async () => {
+        await mainPage.clickMainMenuButton();
+        await mainPage.hoverMCPServerMenuItem();
+        await mainPage.disconnectMCPServerMenuSubItem.waitFor();
+        await mainPage.isMCPServerStatusIndicatorActive(true);
+        await mainPage.clickDisconnectMCPServerMenuSubItem();
+
+        // The status indicator can take a while to be updated after disconnecting
+        await mainPage.refreshPage();
+        await mainPage.isMainPageLoaded();
+
+        await mainPage.clickMainMenuButton();
+        await mainPage.isMCPServerStatusIndicatorActive(false);
+        await mainPage.hoverMCPServerMenuItem();
+        await expect(mainPage.connectMCPServerMenuSubItem).toBeVisible();
+        await expect(
+          mainPage.getManageMCPServerStatusMenuSubItem('enabled'),
+        ).toBeVisible();
+        await mainPage.clickViewportByCoordinates(300, 300);
+      },
+    );
+
+    await mcpServerTest.step(
+      '2783 Connect with the MCP Server from the MCP Workspace menu',
+      async () => {
+        await mainPage.clickMainMenuButton();
+        await mainPage.hoverMCPServerMenuItem();
+        await mainPage.clickConnectMCPServerMenuSubItem();
+
+        // The status indicator can take a while to be updated after connecting
+        await mainPage.refreshPage();
+        await mainPage.isMainPageLoaded();
+
+        await mainPage.clickMainMenuButton();
+        await mainPage.hoverMCPServerMenuItem();
+        await mainPage.disconnectMCPServerMenuSubItem.waitFor();
+        await mainPage.isMCPServerStatusIndicatorActive(true);
+        await expect(
+          mainPage.getManageMCPServerStatusMenuSubItem('enabled'),
+        ).toBeVisible();
+      },
+    );
+
+    await mcpServerTest.step(
+      'Go back to the integrations page from file editor',
+      async () => {
+        await mainPage.backToDashboardFromFileEditor();
+        await profilePage.openYourAccountIntegrationsPage();
+      },
+    );
+
+    await mcpServerTest.step('2775 Delete MCP key', async () => {
       await profilePage.deleteMCPKey();
     });
-    await integrationsTest.step(
-      'Verify state persistence after reload',
+
+    await mcpServerTest.step(
+      '2775 Verify state persistence after reload',
       async () => {
         await profilePage.reloadPage();
         await profilePage.checkNoMCPKey();
       },
     );
+
+    await profilePage.backToDashboardFromAccount();
   },
 );

--- a/tests/your-account/your-account-fixture.ts
+++ b/tests/your-account/your-account-fixture.ts
@@ -1,4 +1,4 @@
-import { mainTest } from 'fixtures';
+import { mainTest, registerTest } from 'fixtures';
 import { ProfilePage } from '@pages/profile-page';
 
 type YourAccountFixtures = {
@@ -35,9 +35,19 @@ export const integrationsTest = mainTest.extend<YourAccountFixtures>({
   profilePage: async ({ page }, use) => {
     const profilePage = new ProfilePage(page);
 
-    await profilePage.openYourAccountPage();
-    await profilePage.openIntegrationsPage();
-    await profilePage.isHeaderDisplayed('Your account');
+    await profilePage.openYourAccountIntegrationsPage();
+
+    await use(profilePage);
+  },
+});
+
+// Open Your Account > Integrations section
+// NOTE: This fixture involves creating a new Penpot account
+export const mcpServerTest = registerTest.extend<YourAccountFixtures>({
+  profilePage: async ({ page }, use) => {
+    const profilePage = new ProfilePage(page);
+
+    await profilePage.openYourAccountIntegrationsPage();
 
     await use(profilePage);
   },


### PR DESCRIPTION
![gif](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExd200ZmxtcnE0NnJycmozMjkxdWdnems2Zng2YmcyYmszcTFpbmJodyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/QvGCMeHuP1vLYl2hLb/giphy.gif)

## Taiga URL (optional)

_If relevant, include the Taiga URL_
[Taiga Ticket: 1101](https://tree.taiga.io/project/kaleidos-qa/task/1101)

## Description

This PR adds three automated tests verifying the MCP functionality from the Workspace.

* [PENPOT-2785](https://app.qase.io/case/PENPOT-2785) Open the link to manage the MCP server status from the Workspace menu
* [PENPOT-2783](https://app.qase.io/case/PENPOT-2783)
Connect with the MCP Server from the MCP Workspace menu
* [PENPOT-2791](https://app.qase.io/case/PENPOT-2791)
Disconnect the MCP Server from the MCP Workspace menu

_What problem are you trying to solve?_

* The three tests require different MCP statuses to execute, as described in their preconditions, and they are accessed from Your account > Integrations (another page, not the Workspace).
* Solve the problem of cleaning the MCP status and key after running the tests
* Solve the problem of deleting the files
* The color bullet in the MCP workspace menu (reflecting the MCP status) sometimes doesn't get updated when the status changes (connected/disconnected), leading to some sort of flakiness.

## Solution

* Take advantage of the existing tests that change the MPC status and include the new tests between, reusing the generated context.
* Create a new `your-account-fixture.ts` which extends from registerTest, to use a new Penpot account to avoid the problem of cleaning the MCP status, key, and created files.
* Color bullet in the MCP Server menu:
  * Refresh the page to force the workspace to update menu.
  * Accept the flakiness, as it doesn't seem to be linked to any request (204 POS or WSS)

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Screenshots 📸 (optional)

<img width="771" height="141" alt="image" src="https://github.com/user-attachments/assets/37ae572b-e217-43b2-b3ce-7e32d99abd54" />
