### PR TITLE
feat(board): add test for duplicate board PENPOT-253

### DIFF
--- a/pages/workspace/main-page.js
+++ b/pages/workspace/main-page.js
@@ -1075,6 +1075,14 @@ exports.MainPage = class MainPage extends BasePage {
     await this.duplicateOption.click();
   }
 
+  async duplicateLayerViaRightClickOnCanvas(name) {
+    const boardSel = this.page.locator(
+      `//*[@class='frame-title']//../*[text()='${name}']`,
+    );
+    await boardSel.click({ button: 'right', force: true });
+    await this.duplicateOption.click();
+  }
+
   async duplicateLayerViaLayersTab(name) {
     const layerSel = this.page.locator(
       `div[class*="element-list-body"] span[class*="element-name"]:text-is("${name}") >>nth=0`,

--- a/tests/composition/composition-board.spec.js
+++ b/tests/composition/composition-board.spec.js
@@ -820,6 +820,52 @@ mainTest.describe(() => {
       });
     },
   );
+
+  mainTest(
+    qase([253], 'Duplicate Board (From rightclick and Shortcut Ctrl+D)'),
+    async ({ browserName }) => {
+      await mainTest.step('Create the third board and rename it', async () => {
+        const board3 = 'Board #3';
+        await mainPage.clickCreateBoardButton();
+        await mainPage.clickViewportByCoordinates(350, 100);
+        await mainPage.waitForChangeIsSaved();
+        await mainPage.doubleClickBoardTitleOnCanvas('Board');
+        await mainPage.typeNameShapeLabelAndEnter(board3);
+        await mainPage.waitForChangeIsSaved();
+      });
+
+      await mainTest.step(
+        'Duplicate the first board via right click on layer in canvas',
+        async () => {
+          const board1 = 'Board #1';
+          await mainPage.duplicateLayerViaRightClickOnCanvas(board1);
+          await mainPage.waitForChangeIsSaved();
+          await expect(layersPanelPage.sidebarLayerItem).toHaveCount(4);
+        },
+      );
+
+      await mainTest.step(
+        'Duplicate the second board via right click on layer in layers tab',
+        async () => {
+          const board2 = 'Board #2';
+          await mainPage.duplicateLayerViaLayersTab(board2);
+          await mainPage.waitForChangeIsSaved();
+          await expect(layersPanelPage.sidebarLayerItem).toHaveCount(5);
+        },
+      );
+
+      await mainTest.step(
+        'Duplicate the third board via shortcut (Ctrl+D)',
+        async () => {
+          const board3 = 'Board #3';
+          await layersPanelPage.selectLayerByName(board3);
+          await mainPage.clickShortcutCtrlD(browserName);
+          await mainPage.waitForChangeIsSaved();
+          await expect(layersPanelPage.sidebarLayerItem).toHaveCount(6);
+        },
+      );
+    },
+  );
 });
 
 mainTest.describe(() => {


### PR DESCRIPTION
# Done Definition Checks

## Description

This PR add a test for duplicate board [PENPOT-253](https://app.qase.io/case/PENPOT-253).

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Screenshots 📸 (optional)

<img width="1006" height="1854" alt="board" src="https://github.com/user-attachments/assets/1b23382a-cbd9-49ab-8a0c-ba416b72f830" />
