### PR TITLE
feat(board): add new tests for rename and delete group PENPOT-266

### DIFF
--- a/pages/base-page.js
+++ b/pages/base-page.js
@@ -116,7 +116,7 @@ exports.BasePage = class BasePage {
       .filter({ hasText: 'Paste' })
       .first();
     this.cutOption = page.getByRole('listitem').filter({ hasText: 'Cut' });
-    this.groupOption = page.getByRole('listitem').filter({ hasText: 'Group' });
+    this.groupOption = page.getByRole('listitem').filter({ hasText: 'GroupCtrlG' });
     this.showMainComponentOption = page
       .getByRole('listitem')
       .filter({ hasText: 'Show main component' });

--- a/tests/composition/composition-board.spec.js
+++ b/tests/composition/composition-board.spec.js
@@ -866,6 +866,32 @@ mainTest.describe(() => {
       );
     },
   );
+
+  mainTest(qase([266], 'Rename and delete group'), async () => {
+    await mainTest.step('Select the two boards', async () => {
+      await mainPage.clickMainMenuButton();
+      await mainPage.clickEditMainMenuItem();
+      await mainPage.clickSelectAllMainMenuSubItem();
+    });
+
+    await mainTest.step('Create group', async () => {
+      await mainPage.groupLayerViaRightClick();
+      await mainPage.waitForChangeIsSaved();
+    });
+
+    await mainTest.step('Rename group', async () => {
+      const groupName = 'Group boards';
+      await layersPanelPage.renameSelectedLayerViaDoubleClick(groupName);
+      await mainPage.waitForChangeIsSaved();
+      await layersPanelPage.isLayerPresentOnLayersTab(groupName, true);
+    });
+
+    await mainTest.step('Delete group', async () => {
+      const groupName = 'Group boards';
+      await mainPage.deleteLayerViaRightClickByName(groupName);
+      await layersPanelPage.isLayerPresentOnLayersTab(groupName, false);
+    });
+  });
 });
 
 mainTest.describe(() => {

--- a/tests/composition/composition-board.spec.js
+++ b/tests/composition/composition-board.spec.js
@@ -877,6 +877,7 @@ mainTest.describe(() => {
     await mainTest.step('Create group', async () => {
       await mainPage.groupLayerViaRightClick();
       await mainPage.waitForChangeIsSaved();
+      await layersPanelPage.isLayerPresentOnLayersTab('Group', true);
     });
 
     await mainTest.step('Rename group', async () => {
@@ -889,6 +890,7 @@ mainTest.describe(() => {
     await mainTest.step('Delete group', async () => {
       const groupName = 'Group boards';
       await mainPage.deleteLayerViaRightClickByName(groupName);
+      await mainPage.waitForChangeIsSaved();
       await layersPanelPage.isLayerPresentOnLayersTab(groupName, false);
     });
   });


### PR DESCRIPTION
# Done Definition Checks

## Description

This PR add a new test for rename and delete group [PENPOT-266](https://app.qase.io/case/PENPOT-266)
Some failures related to the new feature "Switch new render" (deactivated by default). Not related to the new test.

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Screenshots 📸 (optional)

<img width="990" height="1896" alt="board" src="https://github.com/user-attachments/assets/252ad2b6-2fd3-4645-848b-56b9395ac55f" />

