### PR TITLE
fix(view-mode): add a step to close cookies modal before logging out

### DIFF
--- a/tests/view-mode/view-mode.spec.js
+++ b/tests/view-mode/view-mode.spec.js
@@ -816,6 +816,7 @@ mainTest.describe(() => {
       );
       await viewModePage.gotoLink(process.env.BASE_URL);
       await mainPage.isHeaderDisplayed('Projects');
+      await loginPage.acceptCookie();
       await profilePage.logout();
     },
   );


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/task/1132

## Description

The cookies modal was displayed on the Dashboard page after clearing cookies and logging in with a second account. This modal overlapped with and interfered with the Logout button.

This PR adds a step to close the cookies modal before attempting to log out, ensuring the Logout action works as expected.

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Test Execution Results in CI

<img width="1034" height="183" alt="image" src="https://github.com/user-attachments/assets/25b86f99-085d-46ad-96ed-10266cbad775" />

