### PR TITLE
fix(grid-layout): replace open grid editor from design tab instead of by double click on viewport

### DIFF
--- a/tests/composition/composition-grid-layout.spec.js
+++ b/tests/composition/composition-grid-layout.spec.js
@@ -505,7 +505,8 @@ mainTest.describe(() => {
     async () => {
       await designPanelPage.changeHeightAndWidthForLayer('600', '400');
       await mainPage.clickBoardOnCanvas();
-      await mainPage.doubleClickBoardOnCanvas();
+      await designPanelPage.expandGridLayoutMenu();
+      await designPanelPage.openGridEditModeFromDesignPanel();
       await mainPage.deleteGridRow();
       await mainPage.waitForChangeIsSaved();
       await expect(mainPage.viewport).toHaveScreenshot(
@@ -641,7 +642,8 @@ mainTest.describe(() => {
     async () => {
       await designPanelPage.changeHeightAndWidthForLayer('600', '400');
       await mainPage.clickBoardOnCanvas();
-      await mainPage.doubleClickBoardOnCanvas();
+      await designPanelPage.expandGridLayoutMenu();
+      await designPanelPage.openGridEditModeFromDesignPanel();
       await mainPage.duplicateGridRow();
       await mainPage.waitForChangeIsSaved();
       await expect(mainPage.viewport).toHaveScreenshot(


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/task/1175

## Description

Grid layout tests were previously opening the grid editor via double-clicking on the viewport, which led to inconsistent failures.

This PR refactors the tests to open the grid editor from the Design tab instead, providing a more stable and reliable interaction path.

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Test Execution Results in CI

<img width="1015" height="258" alt="image" src="https://github.com/user-attachments/assets/979aa001-7106-4a2e-9d6c-fa8bdce5d845" />
