### PR TITLE
feat(mcp-workspace): add test accesing the MCP Server from the worksp…

### DIFF
--- a/pages/workspace/main-page.js
+++ b/pages/workspace/main-page.js
@@ -759,8 +759,9 @@ exports.MainPage = class MainPage extends BasePage {
   async openManageMCPServerStatusPage(status) {
     const manageMCPServerStatusSubItem =
       this.getManageMCPServerStatusMenuSubItem(status);
-    const popupPromise = this.page.waitForEvent('popup');
-    await manageMCPServerStatusSubItem.click();
+    await manageMCPServerStatusSubItem.waitFor({ timeout: 15000 });
+    const popupPromise = this.page.waitForEvent('popup', { timeout: 40000 });
+    await manageMCPServerStatusSubItem.click({ timeout: 40000 });
     return popupPromise;
   }
 

--- a/tests/your-account/integrations/mcp-server.spec.ts
+++ b/tests/your-account/integrations/mcp-server.spec.ts
@@ -15,7 +15,7 @@ integrationsTest.beforeEach(async ({ page }) => {
 
 integrationsTest(
   qase(
-    [2771, 2770, 2775, 2783, 2785, 2787, 2791],
+    [2771, 2770, 2775, 2782, 2783, 2784, 2785, 2787, 2791],
     'Enable MCP generating key, disable MCP, enable MCP with an existing key and delete key',
   ),
   async ({ profilePage }: { profilePage: ProfilePage }) => {
@@ -40,10 +40,16 @@ integrationsTest(
     );
 
     await integrationsTest.step(
-      '2785 Open the link to manage the MCP server status from the Workspace menu',
+      '2782 MCP Workspace menu displays the "Disabled" status when the MCP server is not enabled',
       async () => {
         await mainPage.clickMainMenuButton();
         await mainPage.isMCPServerStatusIndicatorActive(false);
+      },
+    );
+
+    await integrationsTest.step(
+      '2785 Open the link to manage the MCP server status from the Workspace menu',
+      async () => {
         await mainPage.hoverMCPServerMenuItem();
         const manageMCPServerPage =
           await mainPage.openManageMCPServerStatusPage('disabled');
@@ -83,13 +89,17 @@ integrationsTest(
         await mainPage.disconnectMCPServerMenuSubItem.waitFor();
         await mainPage.isMCPServerStatusIndicatorActive(true);
         await mainPage.clickDisconnectMCPServerMenuSubItem();
+      },
+    );
 
+    await integrationsTest.step(
+      '2784 MCP Workspace menu displays the "Enabled" status when the MCP server is enabled (with no active connection)',
+      async () => {
         // The status indicator can take a while to be updated after disconnecting
         await mainPage.refreshPage();
         await mainPage.isMainPageLoaded();
 
         await mainPage.clickMainMenuButton();
-        await mainPage.isMCPServerStatusIndicatorActive(false);
         await mainPage.hoverMCPServerMenuItem();
         await expect(mainPage.connectMCPServerMenuSubItem).toBeVisible();
         await expect(
@@ -113,7 +123,6 @@ integrationsTest(
         await mainPage.clickMainMenuButton();
         await mainPage.hoverMCPServerMenuItem();
         await mainPage.disconnectMCPServerMenuSubItem.waitFor();
-        await mainPage.isMCPServerStatusIndicatorActive(true);
         await expect(
           mainPage.getManageMCPServerStatusMenuSubItem('enabled'),
         ).toBeVisible();


### PR DESCRIPTION
![gif](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExbWg4MWc5Y3BpemN4dnkxcXY5Mm8yMHFjcWN5NmUxZDV1cmp0MjVjdSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/13CoXDiaCcCoyk/giphy.gif)

# Done Definition Checks

## Taiga URL (optional)

_If relevant, include the Taiga URL_
[Taiga Ticket: 1101](https://tree.taiga.io/project/kaleidos-qa/task/1101)

## Description

* This PR adds the IDs of x2 tests that were already being covered in the existing code, splitting their responsibility as new steps. 
These two tests are non-real-time versions of the test [PENPOT-2788](https://app.qase.io/case/PENPOT-2788), which has been removed from automation due to its complexity and potential flakiness. 
* This PR fixes the flakiness we have in the MCP Server tests due to:
  * color bullet indicating the MCP status is not being refreshed correctly
  * a timeout when opening the Manage MCP server from the menu

<img width="887" height="612" alt="image" src="https://github.com/user-attachments/assets/028e98fb-995c-4c04-8277-c5b3a58c5b2f" />

## Solution

* Introduce in the main test description, and as new steps, the Qase Ids and titles.
* Removing the color bullet assertions in the two conflicting places (connecting and disconnecting from the MCP)
* Leave the two other color bullet assertions that are safe
* Introduce an explicit waitFor and timeouts before clicking the link to manage the MCP server

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Screenshots 📸 (optional)

<img width="889" height="184" alt="image" src="https://github.com/user-attachments/assets/1f651289-f018-4a06-88c2-15f563a596c9" />

<img width="890" height="189" alt="image" src="https://github.com/user-attachments/assets/eecaa18a-4a50-43fa-8bf1-db4f3bfcbec7" />

<img width="888" height="196" alt="image" src="https://github.com/user-attachments/assets/3123b54b-4110-4299-82e7-7f3a2b18f197" />



## Anything Else? (optional)

It's been stable (green) in the last four remote executions run. 9 tests in one! :crossed_fingers: 
