### PR TITLE
fix(page-objects): update input selectors to use getByRole instead of CSS

### DIFF
--- a/pages/workspace/assets-panel-page.js
+++ b/pages/workspace/assets-panel-page.js
@@ -70,9 +70,9 @@ exports.AssetsPanelPage = class AssetsPanelPage extends BasePage {
     this.addFileLibraryTypographyButton = page.getByRole('button', {
       name: 'Add typography',
     });
-    this.minimizeFileLibraryTypographyButton = page.locator(
-      '[class*="typography__action-btns"] [aria-label="Close"] button',
-    );
+    this.minimizeFileLibraryTypographyButton = page.getByRole('button', {
+      name: 'Close',
+    });
     this.expandFileLibraryTypographyButton = page.locator(
       'div[class*="typography__element-set-actions"] button',
     );

--- a/pages/workspace/design-panel-page.js
+++ b/pages/workspace/design-panel-page.js
@@ -29,10 +29,10 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
     this.bottomRightCornerRadiusInput = page.getByRole('textbox', {
       name: 'Bottom right',
     });
-    this.sizeWidthInput = page.locator('div[aria-label="Width"] input');
-    this.sizeHeightInput = page.locator('div[aria-label="Height"] input');
-    this.xAxisInput = page.locator('div[aria-label="X axis"] input');
-    this.yAxisInput = page.locator('div[aria-label="Y axis"] input');
+    this.sizeWidthInput = page.getByRole('textbox', { name: 'Width' });
+    this.sizeHeightInput = page.getByRole('textbox', { name: 'Height' });
+    this.xAxisInput = page.getByRole('textbox', { name: 'X axis' });
+    this.yAxisInput = page.getByRole('textbox', { name: 'Y axis' });
     this.resizeBoardToFitButton = page.getByRole('button', {
       name: 'Resize board to fit content',
     });

--- a/pages/workspace/design-panel-page.js
+++ b/pages/workspace/design-panel-page.js
@@ -14,11 +14,11 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
     this.canvasBackgroundColorIcon = page
       .locator('div[class*="page__element-set"] div[class*="color-bullet-wrapper"]')
       .first();
-    this.layerRotationInput = page.locator('div[aria-label="Rotation"] input');
+    this.layerRotationInput = page.getByRole('textbox', { name: 'Rotation' });
     this.individualCornersRadiusButton = page.getByRole('button', {
       name: 'Show independent radius',
     });
-    this.generalCornerRadiusInput = page.locator('div[aria-label="Radius"] input');
+    this.generalCornerRadiusInput = page.getByRole('textbox', { name: 'Radius' });
     this.topLeftCornerRadiusInput = page.getByRole('textbox', { name: 'Top left' });
     this.topRightCornerRadiusInput = page.getByRole('textbox', {
       name: 'Top right',
@@ -127,12 +127,12 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
     this.flexElementAlignStartBtn = page.getByTestId('align-self-start');
     this.flexElementAlignCenterBtn = page.getByTestId('align-self-center');
     this.flexElementAlignEndBtn = page.getByTestId('align-self-end');
-    this.flexElementMarginVertInput = page.locator(
-      'div[aria-label="Vertical margin"] input',
-    );
-    this.flexElementMarginHorizontalInput = page.locator(
-      'div[aria-label="Horizontal margin"] input',
-    );
+    this.flexElementMarginVertInput = page.getByRole('textbox', {
+      name: 'Vertical margin',
+    });
+    this.flexElementMarginHorizontalInput = page.getByRole('textbox', {
+      name: 'Horizontal margin',
+    });
     this.flexElementPositionAbsolute = page.locator(
       'label[for=":absolute-position"] span',
     );
@@ -214,25 +214,25 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
       'Justify content space-evenly',
       { exact: true },
     );
-    this.layoutColumnGapInput = page.locator('div[aria-label="Column gap"] input');
-    this.layoutRowGapInput = page.locator('div[aria-label="Row gap"] input');
-    this.layoutVerticalPaddingInput = page.locator(
-      'div[aria-label="Vertical padding"] input',
-    );
-    this.layoutHorizontalPaddingInput = page.locator(
-      'div[aria-label="Horizontal padding"] input',
-    );
+    this.layoutColumnGapInput = page.getByRole('textbox', { name: 'Column gap' });
+    this.layoutRowGapInput = page.getByRole('textbox', { name: 'Row gap' });
+    this.layoutVerticalPaddingInput = page.getByRole('textbox', {
+      name: 'Vertical padding',
+    });
+    this.layoutHorizontalPaddingInput = page.getByRole('textbox', {
+      name: 'Horizontal padding',
+    });
     this.layoutIndepPaddingsIcon = page.locator('button[class*="padding-toggle"]');
-    this.layoutPaddingTopInput = page.locator('div[aria-label="Top padding"] input');
-    this.layoutPaddingRightInput = page.locator(
-      'div[aria-label="Right padding"] input',
-    );
-    this.layoutPaddingBottomInput = page.locator(
-      'div[aria-label="Bottom padding"] input',
-    );
-    this.layoutPaddingLeftInput = page.locator(
-      'div[aria-label="Left padding"] input',
-    );
+    this.layoutPaddingTopInput = page.getByRole('textbox', { name: 'Top padding' });
+    this.layoutPaddingRightInput = page.getByRole('textbox', {
+      name: 'Right padding',
+    });
+    this.layoutPaddingBottomInput = page.getByRole('textbox', {
+      name: 'Bottom padding',
+    });
+    this.layoutPaddingLeftInput = page.getByRole('textbox', {
+      name: 'Left padding',
+    });
     this.layoutGridJustifyStartBtn = page.getByTitle('Justify items start', {
       exact: true,
     });
@@ -287,7 +287,7 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
     this.strokeColorInput = this.strokeElement.locator(
       'input[class*="color-input"]',
     );
-    this.strokeWidthInput = page.locator('div[aria-label="Stroke width"] input');
+    this.strokeWidthInput = page.getByRole('textbox', { name: 'Stroke width' });
     this.strokeOpacityInput = this.strokeElement.locator(
       'input[data-testid="opacity-input"]',
     );

--- a/pages/workspace/inspect-panel-page.js
+++ b/pages/workspace/inspect-panel-page.js
@@ -19,9 +19,7 @@ exports.InspectPanelPage = class InspectPanelPage extends BasePage {
       'div[class*="layout-row"] div[title="Row gap"]',
     );
     this.codeTabButton = page.getByRole('tab', { name: 'code' });
-    this.inspectTabSelector = page.locator(
-      'button[aria-label="inspect.tabs-switcher-label"]',
-    );
+    this.inspectTabSelector = page.getByRole('tab', { name: 'Inspect' });
     this.codeOption = page.getByRole('option', { name: 'Code' });
     this.computedOption = page.getByRole('option', { name: 'Computed' });
     this.copyCssCodeButton = page.locator('button[class*="css-copy-btn"]');


### PR DESCRIPTION
# Done Definition Checks

## Description

This PR changes the selectors from CSS to getByRole. 

## How to test

- [x] Check the code
- [x] Update the test case in Qase (Automation Status field or steps changed)
- [x] It complies with the test conventions
- [x] There are no missing snapshots for win32 (x3 browsers)
- [x] The tests run OK

## Screenshots 📸 (optional)
<img width="1711" height="1165" alt="image" src="https://github.com/user-attachments/assets/49c8013c-aa55-41de-b3f8-7c71c0af9043" />

