### PR TITLE
fix(panels-features): fix stroke width locator

### DIFF
--- a/pages/workspace/design-panel-page.js
+++ b/pages/workspace/design-panel-page.js
@@ -275,6 +275,7 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
     });
 
     //Design panel - Stroke section
+    this.rightSidebar = this.page.getByTestId('right-sidebar');
     this.addStrokeButton = page.getByRole('button', { name: 'Add stroke color' });
     this.strokeSection = page.getByText('Stroke', { exact: true });
     this.strokeElement = page.locator('div[class*="stroke-color-actions"]').last();
@@ -287,7 +288,9 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
     this.strokeColorInput = this.strokeElement.locator(
       'input[class*="color-input"]',
     );
-    this.strokeWidthInput = page.locator('div[aria-label="Stroke width"] input');
+    this.strokeWidthInput = this.rightSidebar.getByRole('button', {
+      name: 'stroke-width',
+    });
     this.strokeOpacityInput = this.strokeElement.locator(
       'input[data-testid="opacity-input"]',
     );
@@ -1610,7 +1613,7 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
   }
 
   async checkStrokeWidth(value) {
-    await expect(this.strokeWidthInput).toHaveValue(value);
+    await expect(this.strokeWidthInput).toHaveText(value);
   }
 
   async checkRowGap(value) {


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/task/1205

## Description

Fix failing test Stroke width token copy button and tooltip with computed value (Qase ID: 2661) by refactoring stroke width locator that is currently using a CSS locator.

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Test Execution Results

<img width="1023" height="382" alt="image" src="https://github.com/user-attachments/assets/76fefade-76a5-4841-b370-0cee6e7a0e82" />

