### PR TITLE
fix(teams): replace "" in checkInviteText gmail method

### DIFF
--- a/helpers/gmail.js
+++ b/helpers/gmail.js
@@ -142,7 +142,7 @@ async function checkInviteText(text, team, user = 'k8q6byz') {
   const messageText =
     'Hello!\r\n' +
     '\r\n' +
-    `${user} has invited you to join the team “${team}”.\r\n` +
+    `${user} has invited you to join the team "${team}".\r\n` +
     '\r\n' +
     'Accept invitation using this link:\r\n' +
     '\r\n' +


### PR DESCRIPTION
# Done Definition Checks

## Description

Fix team permissions tests failing due to "" in gmail method.

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Test Execution Results in CI

Error non-related.

<img width="1038" height="265" alt="image" src="https://github.com/user-attachments/assets/a4c85b0c-0e59-4155-b2da-1a7f70f71162" />

