### PR TITLE
fix(tests): fix the `layerRotationInput` locator

### DIFF
--- a/pages/workspace/design-panel-page.js
+++ b/pages/workspace/design-panel-page.js
@@ -14,7 +14,7 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
     this.canvasBackgroundColorIcon = page
       .locator('div[class*="page__element-set"] div[class*="color-bullet-wrapper"]')
       .first();
-    this.layerRotationInput = page.getByLabel('Rotation');
+    this.layerRotationInput = page.getByRole('textbox', { name: 'Rotation' });
     this.individualCornersRadiusButton = page.getByRole('button', {
       name: 'Show independent radius',
     });


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

_If relevant, include the Taiga URL_
[Taiga Ticket: 1219](https://tree.taiga.io/project/kaleidos-qa/task/1219)

## Description

This PR resolves errors in the following spec files due to the  `layerRotationInput` locator, which has become outdated with the 2.16 release changes: **1438**|**2263**|**1291**|**243**|**353**|**277**|**1270**|_380_|**512**|_2175_|**2247**

Bold QaseIDs have passed on a local run.
The two spec files in italic don't pass locally because of this [issue](https://tree.taiga.io/project/penpot/issue/14098). They should be fine one the isse is fixed.

## Solution

Fixing the locator by closing the elements returned, specifying their role (textbox).

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Screenshots 📸 (optional)

<img width="1404" height="1126" alt="image" src="https://github.com/user-attachments/assets/aea2973f-4bba-47e0-aa8c-eb2008ee9c7e" />
