### PR TITLE
fix(grid-layout): fix grid layout advanced options locators

### DIFF
--- a/pages/workspace/design-panel-page.js
+++ b/pages/workspace/design-panel-page.js
@@ -369,12 +369,17 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
     this.useDefaultGridButton = page
       .getByRole('button')
       .filter({ hasText: 'Use default' });
-    this.gridWidthInput = page.locator(
-      'div[aria-label="Width"] input[class*="grid__numeric-input"]',
+
+    // Design panel - Grid Layout section - Advanced Options
+    this.gridAdvancedOptionsSection = page.locator(
+      '.main_ui_workspace_sidebar_options_common__advanced-options-wrapper',
     );
-    this.gridHeightInput = page.locator(
-      'div[aria-label="Height"] input[class*="grid__numeric-input"]',
-    );
+    this.gridWidthInput = this.gridAdvancedOptionsSection
+      .getByTitle('Width')
+      .getByPlaceholder('Auto');
+    this.gridHeightInput = this.gridAdvancedOptionsSection
+      .getByTitle('Height')
+      .getByPlaceholder('Auto');
 
     //Design panel - Component section
     this.componentContent = page.locator('div[class*="component-content"]');


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/task/1222
https://tree.taiga.io/project/kaleidos-qa/task/1223

## Description

Fix locator that is failing due to not being found. Created a new parent locator to chain both Width and Height.

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Test Execution Results local

<img width="586" height="643" alt="image" src="https://github.com/user-attachments/assets/3cb9a2dc-f243-48cb-a9f9-d2a539076395" />