### PR TITLE
fix(flex-layout): fix margin locators for flex layout

### DIFF
--- a/pages/workspace/design-panel-page.js
+++ b/pages/workspace/design-panel-page.js
@@ -127,12 +127,12 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
     this.flexElementAlignStartBtn = page.getByTestId('align-self-start');
     this.flexElementAlignCenterBtn = page.getByTestId('align-self-center');
     this.flexElementAlignEndBtn = page.getByTestId('align-self-end');
-    this.flexElementMarginVertInput = page.locator(
-      'div[aria-label="Vertical margin"] input',
-    );
-    this.flexElementMarginHorizontalInput = page.locator(
-      'div[aria-label="Horizontal margin"] input',
-    );
+    this.flexElementMarginVertInput = page.getByRole('textbox', {
+      name: 'Vertical margin',
+    });
+    this.flexElementMarginHorizontalInput = page.getByRole('textbox', {
+      name: 'Horizontal margin',
+    });
     this.flexElementPositionAbsolute = page.locator(
       'label[for=":absolute-position"] span',
     );


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/task/1234

## Description

Refactor margin locators for flex layout tests.

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Test Execution Results (local)

<img width="1003" height="141" alt="image" src="https://github.com/user-attachments/assets/9aa0eacb-c9e0-4be4-b3a6-5e69ee86670a" />
