### PR TITLE
fix(tests): fix the `generalCornerRadiusInput` locator

### DIFF
--- a/pages/workspace/design-panel-page.js
+++ b/pages/workspace/design-panel-page.js
@@ -18,7 +18,7 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
     this.individualCornersRadiusButton = page.getByRole('button', {
       name: 'Show independent radius',
     });
-    this.generalCornerRadiusInput = page.getByLabel('Radius');
+    this.generalCornerRadiusInput = page.getByRole('textbox', { name: 'Radius' });
     this.topLeftCornerRadiusInput = page.getByRole('textbox', { name: 'Top left' });
     this.topRightCornerRadiusInput = page.getByRole('textbox', {
       name: 'Top right',


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

_If relevant, include the Taiga URL_
[Taiga Ticket: 1243](https://tree.taiga.io/project/kaleidos-qa/task/1243)

## Description

This PR resolves errors in the spec file [Change border radius one value (Design page in the right) (Qase ID: 460)](https://kaleidos-qa-reports.s3.eu-west-1.amazonaws.com/run-25895432945/index.html#?testId=73bb2c13de90480896c1-361fd4ff07efc3b009b6)

## Solution

Fixing the locator by closing the elements returned, specifying their role (textbox).

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Screenshots 📸 (optional)

<img width="847" height="148" alt="image" src="https://github.com/user-attachments/assets/7e69c588-4a26-49cc-bfea-61c5fff72f1d" />
