### PR TITLE
fix(basePage): add layer item locator and refactor method

### DIFF
--- a/pages/base-page.js
+++ b/pages/base-page.js
@@ -27,6 +27,7 @@ exports.BasePage = class BasePage {
 
     //Layer right-click menu items
     this.createdLayer = page.getByTestId('layer-row').first();
+    this.layerItem = page.getByTestId('layer-item').first();
     this.copyLayer = page
       .locator('div[class*="viewport"] [class*="viewport-selrect"]')
       .last();
@@ -405,7 +406,7 @@ exports.BasePage = class BasePage {
   }
 
   async createComponentViaRightClickFromLayerByName(name) {
-    const layerSel = this.createdLayer.getByText(name, { exact: true });
+    const layerSel = this.layerItem.getByText(name, { exact: true });
     await layerSel.last().click({ button: 'right' });
     await this.createComponentMenuItem.waitFor({ state: 'visible' });
     await this.createComponentMenuItem.click();


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/task/1235

## Description

Adds a new locator for layer-item and modify method that was failing when using it. 

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Test Execution Results (local)

<img width="460" height="277" alt="image" src="https://github.com/user-attachments/assets/fe286ede-5b27-481c-9f2d-06a8b8b4e85f" />

