### PR TITLE
fix(test): replace create component method to select specific layer

### DIFF
--- a/tests/components/main-components/update-main-components.spec.ts
+++ b/tests/components/main-components/update-main-components.spec.ts
@@ -105,7 +105,7 @@ mainTest.describe(() => {
   mainTest.beforeEach(async () => {
     await mainTest.slow();
     await mainPage.createDefaultRectangleByCoordinates(200, 300);
-    await mainPage.createComponentViaRightClick();
+    await mainPage.createComponentViaRightClickFromLayerByName('Rectangle');
     await mainPage.waitForChangeIsSaved();
     await designPanelPage.clickOnClipContentButton();
     await mainPage.waitForChangeIsSaved();


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/task/1237

## Description

Update method used in test to create a component.

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Test execution Results local

<img width="835" height="354" alt="image" src="https://github.com/user-attachments/assets/e830ece7-fba5-4aef-836b-f11dab026012" />
