### PR TITLE
fix(tests): update locators for token type tests stroke width and rotation

### DIFF
--- a/pages/workspace/design-panel-page.js
+++ b/pages/workspace/design-panel-page.js
@@ -1638,7 +1638,7 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
   }
 
   async checkStrokeWidth(value) {
-    await expect(this.strokeWidthInput).toHaveText(value);
+    await this.checkTokenField('Stroke width', value);
   }
 
   async checkRowGap(value) {

--- a/pages/workspace/design-panel-page.js
+++ b/pages/workspace/design-panel-page.js
@@ -1634,7 +1634,7 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
   }
 
   async checkRotationForLayer(value) {
-    await expect(this.layerRotationInput).toHaveValue(value);
+    await this.checkTokenField('Rotation', value);
   }
 
   async checkStrokeWidth(value) {

--- a/pages/workspace/design-panel-page.js
+++ b/pages/workspace/design-panel-page.js
@@ -1614,7 +1614,7 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
    * @param {string} value - Expected token name or numeric value.
    */
   async checkTokenField(ariaLabel, value) {
-    const tokenContainer = this.page.locator(`[aria-label="${ariaLabel}"]`);
+    const tokenContainer = this.page.getByLabel(ariaLabel, { exact: true });
     const tokenPill = tokenContainer
       .getByRole('button')
       .and(this.page.locator('[class*="token_field__pill"]'));


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/task/1236

## Description

Update locator for stroke width and rotation inputs.

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Test Execution Results (local)

<img width="605" height="96" alt="image" src="https://github.com/user-attachments/assets/fde7fdc1-938c-4540-907c-51e05a8d81d0" />

<img width="601" height="73" alt="image" src="https://github.com/user-attachments/assets/19794855-0947-4016-90a2-5373ceb49ad0" />

<img width="546" height="104" alt="image" src="https://github.com/user-attachments/assets/6d128249-4206-4166-9345-2dc936ebdae5" />

<img width="817" height="80" alt="image" src="https://github.com/user-attachments/assets/98a3a849-d7ee-4ad1-8d43-2c529489469a" />
