### PR TITLE
fix(test): fix dynamic guides issue in test 1297

### DIFF
--- a/tests/components/main-components/context-menu/context-menu-options.spec.ts
+++ b/tests/components/main-components/context-menu/context-menu-options.spec.ts
@@ -530,13 +530,11 @@ mainTest.describe(() => {
     await mainTest.step(
       'Detach copy instance from Design tab and resize',
       async () => {
-        await layersPanelPage.clickCopyComponentOnLayersTab();
         await designPanelPage.clickOnComponentMenuButton();
         await designPanelPage.clickOnDetachInstanceOption();
         await mainPage.waitForChangeIsSaved();
         await designPanelPage.changeHeightAndWidthForLayer('300', '300');
-        await designPanelPage.changeAxisXAndYForLayer('400', '300');
-        await mainPage.waitForChangeIsSaved();
+        await mainPage.waitForResizeHandlerVisible();
       },
     );
 


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

[Taiga Ticket: 1197](https://tree.taiga.io/project/kaleidos-qa/task/1197)

## Description

This PR resolves a problem with the dynamic guides interfering when the snapshot is taken, for test Detach instance from "Design" tab (Qase ID: 1297).
[Failed execution](https://kaleidos-qa-reports.s3.eu-west-1.amazonaws.com/run-26070862045/index.html#?q=s%3Afailed+1297&testId=fbb2d21f5712b03769a7-834caf39854fcbe68f2a)

<img width="946" height="393" alt="image" src="https://github.com/user-attachments/assets/20a0f0a8-2f4b-438c-a04a-7cbb1ea7c0b5" />


## Solution

- Wait until the resize handler becomes visible, as it ensures the dynamic guides are gone.
- Remove unrequired steps from the test

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Screenshots 📸 (optional)

<img width="923" height="170" alt="image" src="https://github.com/user-attachments/assets/de45ef7e-330a-47fd-8a42-35674c5f1de3" />

## Anything Else? (optional)

<img width="947" height="622" alt="image" src="https://github.com/user-attachments/assets/0da8505b-ee7b-4dd2-902b-84b1dca9f93a" />

Tests 1417 / 1416 should be fixed. One passes remotely (1417), the other one passes locally (1416).
In any case, it's a test problem to fix and not a real issue.
