### PR TITLE
fix(tests): remove accept invitation after onboarding modal

### DIFF
--- a/helpers/user-flows.js
+++ b/helpers/user-flows.js
@@ -84,7 +84,6 @@ async function setupUserWithRole(
   const verificationMessage = await getVerificationMessage(userEmail);
   await page.goto(verificationMessage.inviteUrl);
   await dashboardPage.fillOnboardingQuestions();
-  await page.goto(invite.inviteUrl);
   await teamPage.isTeamSelected(teamName);
 
   return {

--- a/tests/action-menu/copy-link.spec.ts
+++ b/tests/action-menu/copy-link.spec.ts
@@ -102,7 +102,6 @@ mainTest.describe(() => {
           const verificationMessage = await getVerificationMessage(firstEmail);
           await page.goto(verificationMessage.inviteUrl);
           await dashboardPage.fillOnboardingQuestions();
-          await page.goto(firstInvite.inviteUrl);
           await teamPage.isTeamSelected(teamName);
           await page.goto(link);
           await mainPage.isMainPageLoaded();

--- a/tests/composition/composition-comments.spec.js
+++ b/tests/composition/composition-comments.spec.js
@@ -246,7 +246,6 @@ mainTest.describe(() => {
       const verificationMessage = await getVerificationMessage(firstEmail);
       await page.goto(verificationMessage.inviteUrl);
       await dashboardPage.fillOnboardingQuestions();
-      await page.goto(firstInvite.inviteUrl);
       await teamPage.isTeamSelected(teamName);
 
       await profilePage.logout();
@@ -321,7 +320,6 @@ mainTest.describe(() => {
     const verificationMessage = await getVerificationMessage(firstEmail);
     await page.goto(verificationMessage.inviteUrl);
     await dashboardPage.fillOnboardingQuestions();
-    await page.goto(firstInvite.inviteUrl);
     await teamPage.isTeamSelected(teamName);
 
     await dashboardPage.openFile();
@@ -384,7 +382,6 @@ mainTest.describe(() => {
     const verificationMessage = await getVerificationMessage(firstEmail);
     await page.goto(verificationMessage.inviteUrl);
     await dashboardPage.fillOnboardingQuestions();
-    await page.goto(firstInvite.inviteUrl);
     await teamPage.isTeamSelected(teamName);
 
     await profilePage.logout();
@@ -474,7 +471,6 @@ mainTest.describe(() => {
       const verificationMessage = await getVerificationMessage(firstEmail);
       await page.goto(verificationMessage.inviteUrl);
       await dashboardPage.fillOnboardingQuestions();
-      await page.goto(firstInvite.inviteUrl);
       await teamPage.isTeamSelected(teamName);
 
       await profilePage.logout();

--- a/tests/dashboard/teams/teams-invitations.spec.ts
+++ b/tests/dashboard/teams/teams-invitations.spec.ts
@@ -227,7 +227,6 @@ mainTest.describe(
         const firstVerificationMessage = await getVerificationMessage(firstEmail);
         await page.goto(firstVerificationMessage!.inviteUrl);
         await dashboardPage.fillOnboardingQuestions();
-        await page.goto(firstInvite!.inviteUrl);
         await teamPage.isTeamSelected(team);
         await profilePage.logout();
         await loginPage.isLoginPageOpened();
@@ -241,7 +240,6 @@ mainTest.describe(
         const secondVerificationMessage = await getVerificationMessage(secondEmail);
         await page.goto(secondVerificationMessage!.inviteUrl);
         await dashboardPage.fillOnboardingQuestions();
-        await page.goto(secondInvite!.inviteUrl);
         await teamPage.isTeamSelected(team);
 
         await teamPage.openMembersPageViaOptionsMenu();

--- a/tests/dashboard/teams/teams-leave-team.spec.js
+++ b/tests/dashboard/teams/teams-leave-team.spec.js
@@ -58,7 +58,6 @@ async function setupInvitedUser(page, role = 'Editor') {
   const verificationMessage = await getVerificationMessage(userEmail);
   await page.goto(verificationMessage.inviteUrl);
   await dashboardPage.fillOnboardingQuestions();
-  await page.goto(invite.inviteUrl);
   await teamPage.isTeamSelected(teamName);
 
   return {

--- a/tests/dashboard/teams/teams-members.spec.js
+++ b/tests/dashboard/teams/teams-members.spec.js
@@ -177,7 +177,6 @@ mainTest(qase(1196, 'Team. Members - leave team (as owner)'), async ({ page }) =
   const verificationMessage = await getVerificationMessage(firstEmail);
   await page.goto(verificationMessage.inviteUrl);
   await dashboardPage.fillOnboardingQuestions();
-  await page.goto(firstInvite.inviteUrl);
   await teamPage.isTeamSelected(team);
 
   await profilePage.logout();

--- a/tests/dashboard/teams/teams-permissions.spec.js
+++ b/tests/dashboard/teams/teams-permissions.spec.js
@@ -72,7 +72,6 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       const mainVerificationMessage = await getVerificationMessage(mainEmail);
       await page.goto(mainVerificationMessage.inviteUrl);
       await dashboardPage.fillOnboardingQuestions();
-      await page.goto(mainInvite.inviteUrl);
       await teamPage.isTeamSelected(team);
 
       await teamPage.openInvitationsPageViaOptionsMenu();
@@ -111,7 +110,6 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       const firstVerificationMessage = await getVerificationMessage(firstEmail);
       await page.goto(firstVerificationMessage.inviteUrl);
       await dashboardPage.fillOnboardingQuestions();
-      await page.goto(firstInvite.inviteUrl);
       await teamPage.isTeamSelected(team);
       await profilePage.logout();
       await loginPage.isLoginPageOpened();
@@ -125,7 +123,6 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       const secondVerificationMessage = await getVerificationMessage(secondEmail);
       await page.goto(secondVerificationMessage.inviteUrl);
       await dashboardPage.fillOnboardingQuestions();
-      await page.goto(secondInvite.inviteUrl);
       await teamPage.isTeamSelected(team);
 
       await teamPage.openMembersPageViaOptionsMenu();
@@ -172,7 +169,6 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       const mainVerificationMessage = await getVerificationMessage(mainEmail);
       await page.goto(mainVerificationMessage.inviteUrl);
       await dashboardPage.fillOnboardingQuestions();
-      await page.goto(mainInvite.inviteUrl);
       await teamPage.isTeamSelected(team);
 
       await teamPage.openInvitationsPageViaOptionsMenu();
@@ -229,7 +225,6 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       const verificationMessage = await getVerificationMessage(secondEmail);
       await page.goto(verificationMessage.inviteUrl);
       await dashboardPage.fillOnboardingQuestions();
-      await page.goto(secondInvite.inviteUrl);
       await teamPage.isTeamSelected(team);
 
       await profilePage.logout();
@@ -300,7 +295,6 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       const firstVerificationMessage = await getVerificationMessage(firstEmail);
       await page.goto(firstVerificationMessage.inviteUrl);
       await dashboardPage.fillOnboardingQuestions();
-      await page.goto(firstInvite.inviteUrl);
       await teamPage.isTeamSelected(team);
       await profilePage.logout();
       await loginPage.isLoginPageOpened();
@@ -314,7 +308,6 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       const secondVerificationMessage = await getVerificationMessage(secondEmail);
       await page.goto(secondVerificationMessage.inviteUrl);
       await dashboardPage.fillOnboardingQuestions();
-      await page.goto(secondInvite.inviteUrl);
       await teamPage.isTeamSelected(team);
 
       await teamPage.openMembersPageViaOptionsMenu();
@@ -396,7 +389,6 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       const firstVerificationMessage = await getVerificationMessage(firstEmail);
       await page.goto(firstVerificationMessage.inviteUrl);
       await dashboardPage.fillOnboardingQuestions();
-      await page.goto(firstInvite.inviteUrl);
       await teamPage.isTeamSelected(team);
       await profilePage.logout();
       await loginPage.isLoginPageOpened();
@@ -410,7 +402,6 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       const secondVerificationMessage = await getVerificationMessage(secondEmail);
       await page.goto(secondVerificationMessage.inviteUrl);
       await dashboardPage.fillOnboardingQuestions();
-      await page.goto(secondInvite.inviteUrl);
       await teamPage.isTeamSelected(team);
 
       await teamPage.openMembersPageViaOptionsMenu();
@@ -461,7 +452,6 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       const firstVerificationMessage = await getVerificationMessage(firstEmail);
       await page.goto(firstVerificationMessage.inviteUrl);
       await dashboardPage.fillOnboardingQuestions();
-      await page.goto(firstInvite.inviteUrl);
       await teamPage.isTeamSelected(team);
 
       await teamPage.openMembersPageViaOptionsMenu();
@@ -513,7 +503,6 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       const secondVerificationMessage = await getVerificationMessage(secondEmail);
       await page.goto(secondVerificationMessage.inviteUrl);
       await dashboardPage.fillOnboardingQuestions();
-      await page.goto(secondInvite.inviteUrl);
       await teamPage.isTeamSelected(team);
 
       await teamPage.openInvitationsPageViaOptionsMenu();
@@ -556,7 +545,6 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       const firstVerificationMessage = await getVerificationMessage(firstEmail);
       await page.goto(firstVerificationMessage.inviteUrl);
       await dashboardPage.fillOnboardingQuestions();
-      await page.goto(firstInvite.inviteUrl);
       await teamPage.isTeamSelected(team);
 
       await profilePage.logout();
@@ -612,7 +600,6 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       const firstVerificationMessage = await getVerificationMessage(firstEmail);
       await page.goto(firstVerificationMessage.inviteUrl);
       await dashboardPage.fillOnboardingQuestions();
-      await page.goto(firstInvite.inviteUrl);
       await teamPage.isTeamSelected(team);
       await profilePage.logout();
       await loginPage.isLoginPageOpened();
@@ -626,7 +613,6 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       const secondVerificationMessage = await getVerificationMessage(secondEmail);
       await page.goto(secondVerificationMessage.inviteUrl);
       await dashboardPage.fillOnboardingQuestions();
-      await page.goto(secondInvite.inviteUrl);
       await teamPage.isTeamSelected(team);
 
       await teamPage.openMembersPageViaOptionsMenu();
@@ -687,7 +673,6 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       const firstVerificationMessage = await getVerificationMessage(firstEmail);
       await page.goto(firstVerificationMessage.inviteUrl);
       await dashboardPage.fillOnboardingQuestions();
-      await page.goto(firstInvite.inviteUrl);
       await teamPage.isTeamSelected(team);
       await profilePage.logout();
       await loginPage.isLoginPageOpened();
@@ -701,7 +686,6 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       const secondVerificationMessage = await getVerificationMessage(secondEmail);
       await page.goto(secondVerificationMessage.inviteUrl);
       await dashboardPage.fillOnboardingQuestions();
-      await page.goto(secondInvite.inviteUrl);
       await teamPage.isTeamSelected(team);
 
       await teamPage.openMembersPageViaOptionsMenu();
@@ -761,7 +745,6 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       const firstVerificationMessage = await getVerificationMessage(firstEmail);
       await page.goto(firstVerificationMessage.inviteUrl);
       await dashboardPage.fillOnboardingQuestions();
-      await page.goto(firstInvite.inviteUrl);
       await teamPage.isTeamSelected(team);
       await teamPage.openInvitationsPageViaOptionsMenu();
       await teamPage.isMultipleInvitationRecordDisplayed(

--- a/tests/dashboard/teams/teams-rename.spec.js
+++ b/tests/dashboard/teams/teams-rename.spec.js
@@ -66,7 +66,6 @@ mainTest.describe('Rename a team', () => {
       const verificationMessage = await getVerificationMessage(firstEmail);
       await page.goto(verificationMessage.inviteUrl);
       await dashboardPage.fillOnboardingQuestions();
-      await page.goto(firstInvite.inviteUrl);
       await teamPage.isTeamSelected(team);
       await teamPage.openTeamOptionsMenu();
       await teamPage.assertRenameItemNotVisible();

--- a/tests/dashboard/teams/teams-viewer-role.spec.js
+++ b/tests/dashboard/teams/teams-viewer-role.spec.js
@@ -57,7 +57,6 @@ async function setupViewerUser(page, role = 'Viewer') {
   const verificationMessage = await getVerificationMessage(userEmail);
   await page.goto(verificationMessage.inviteUrl);
   await dashboardPage.fillOnboardingQuestions();
-  await page.goto(invite.inviteUrl);
   await teamPage.isTeamSelected(teamName);
 
   return {
@@ -251,7 +250,6 @@ mainTest.describe('Viewer Role - Role Changes', () => {
       const verificationMessage = await getVerificationMessage(adminEmail);
       await page.goto(verificationMessage.inviteUrl);
       await dashboardPage.fillOnboardingQuestions();
-      await page.goto(invite.inviteUrl);
       await teamPage.isTeamSelected(teamName);
 
       // Change Admin → Viewer

--- a/tests/panels-features/panels-features-history-panel.spec.js
+++ b/tests/panels-features/panels-features-history-panel.spec.js
@@ -257,7 +257,6 @@ mainTest.describe(() => {
       const verificationMessage = await getVerificationMessage(firstEmail);
       await page.goto(verificationMessage.inviteUrl);
       await dashboardPage.fillOnboardingQuestions();
-      await page.goto(firstInvite.inviteUrl);
       await teamPage.isTeamSelected(teamName);
 
       await dashboardPage.openFile();

--- a/tests/view-mode/view-mode.spec.js
+++ b/tests/view-mode/view-mode.spec.js
@@ -870,7 +870,6 @@ mainTest.describe(() => {
       const verificationMessage = await getVerificationMessage(firstEmail);
       await page.goto(verificationMessage.inviteUrl);
       await dashboardPage.fillOnboardingQuestions();
-      await page.goto(firstInvite.inviteUrl);
       await teamPage.isTeamSelected(teamName);
 
       await dashboardPage.openFile();


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/task/1283

## Description

Remove navigation to /verify-token after filling out onboarding modal as the invite has already been accepted when joined the team.

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Test Execution Results in CI

<img width="1016" height="635" alt="image" src="https://github.com/user-attachments/assets/74b3f203-6543-4148-b576-15cd3b808b32" />



