### PR TITLE
feat(history): fix locator for history tests

### DIFF
--- a/pages/workspace/history-panel-page.js
+++ b/pages/workspace/history-panel-page.js
@@ -12,7 +12,9 @@ exports.HistoryPanelPage = class HistoryPanelPage extends MainPage {
     this.emptyVersionMessage = page.getByText('There are no versions yet');
     this.saveVersionButton = page.getByRole('button', { name: 'Save version' });
     this.versionNameInput = page.locator('input[class*="controls_utilities_input"]');
-    this.versionName = page.getByTestId('milestone');
+    this.versionName = page.locator(
+      '[class*="product_milestone__"][data-testid="milestone"] [class*="body-small-typography"]',
+    );
     this.optionsVersionButton = page.getByRole('button', {
       name: 'Open version menu',
     });

--- a/pages/workspace/history-panel-page.js
+++ b/pages/workspace/history-panel-page.js
@@ -11,11 +11,9 @@ exports.HistoryPanelPage = class HistoryPanelPage extends MainPage {
 
     this.emptyVersionMessage = page.getByText('There are no versions yet');
     this.saveVersionButton = page.getByRole('button', { name: 'Save version' });
+    this.versionEntry = page.getByTestId('milestone');
     this.versionNameInput = page.locator('input[class*="controls_utilities_input"]');
-    this.versionName = page.locator(
-      '[class*="product_milestone__"][data-testid="milestone"] [class*="body-small-typography"]',
-    );
-    this.optionsVersionButton = page.getByRole('button', {
+    this.optionsVersionButton = this.versionEntry.getByRole('button', {
       name: 'Open version menu',
     });
     this.renameVersionButton = page.getByRole('button', { name: 'Rename' });
@@ -58,6 +56,10 @@ exports.HistoryPanelPage = class HistoryPanelPage extends MainPage {
       .filter({ hasText: 'My versions' });
   }
 
+  getVersionEntryByName(name) {
+    return this.versionEntry.getByText(name, { exact: true });
+  }
+
   async isVersionListEmpty(empty = true) {
     empty
       ? await expect(this.emptyVersionMessage).toBeVisible()
@@ -80,62 +82,49 @@ exports.HistoryPanelPage = class HistoryPanelPage extends MainPage {
   }
 
   async checkVersionName(name) {
-    await expect(this.versionName).toHaveText(name);
+    await expect(
+      this.getVersionEntryByName(name),
+      `Version name is ${name}`,
+    ).toHaveText(name);
   }
 
   async checkFirstVersionName(name) {
-    await expect(this.versionName.last()).toHaveText(name);
+    await expect(
+      this.getVersionEntryByName(name).last(),
+      `First version name is ${name}`,
+    ).toHaveText(name);
   }
 
   async checkLastVersionName(name) {
-    await expect(this.versionName.first()).toHaveText(name);
+    await expect(
+      this.getVersionEntryByName(name).first(),
+      `Last version name is ${name}`,
+    ).toHaveText(name);
   }
 
   async openVersionOptionsMenu() {
     await this.optionsVersionButton.first().click();
   }
 
-  async selectVersionOption(option) {
-    await this.versionName.first().hover();
-    await this.openVersionOptionsMenu();
-    switch (option) {
-      case 'Rename':
-        await this.renameVersionButton.click();
-        break;
-      case 'Restore':
-        await this.restoreVersionButton.click();
-        break;
-      case 'Delete':
-        await this.deleteVersionButton.click();
-        break;
-      case 'Preview version':
-        await this.previewVersionButton.click();
-        break;
-    }
-  }
+  async selectVersionOption(option, versionName = '') {
+    const version = versionName
+      ? this.versionEntry.filter({ hasText: versionName })
+      : this.versionEntry.first();
 
-  async selectVersionOptionByVersion(versionName, option) {
-    const specificVersion = this.versionName.filter({ hasText: versionName });
-    const specificOptionsButton = specificVersion.getByRole('button', {
+    const menuButton = version.getByRole('button', {
       name: 'Open version menu',
     });
 
-    await specificVersion.hover();
-    await specificOptionsButton.click();
-    switch (option) {
-      case 'Rename':
-        await this.renameVersionButton.click();
-        break;
-      case 'Restore':
-        await this.restoreVersionButton.click();
-        break;
-      case 'Delete':
-        await this.deleteVersionButton.click();
-        break;
-      case 'Preview version':
-        await this.previewVersionButton.click();
-        break;
-    }
+    const optionMap = {
+      'Rename': this.renameVersionButton,
+      'Restore': this.restoreVersionButton,
+      'Delete': this.deleteVersionButton,
+      'Preview version': this.previewVersionButton,
+    };
+
+    await version.hover();
+    await menuButton.click();
+    await optionMap[option].click();
   }
 
   async clickRestoreVersionButton() {

--- a/tests/panels-features/history/panels-features-history-panel.spec.ts
+++ b/tests/panels-features/history/panels-features-history-panel.spec.ts
@@ -1,14 +1,14 @@
-import { mainTest } from '../../../fixtures';
-import { MainPage } from '../../../pages/workspace/main-page';
-import { TeamPage } from '../../../pages/dashboard/team-page';
-import { DashboardPage } from '../../../pages/dashboard/dashboard-page';
+import { mainTest } from 'fixtures';
+import { MainPage } from '@pages/workspace/main-page';
+import { HistoryPanelPage } from '@pages/workspace/history-panel-page';
+import { LayersPanelPage } from '@pages/workspace/layers-panel-page';
+import { TeamPage } from '@pages/dashboard/team-page';
+import { DashboardPage } from '@pages/dashboard/dashboard-page';
 import { qase } from 'playwright-qase-reporter/playwright';
-import { HistoryPanelPage } from '../../../pages/workspace/history-panel-page';
-import { LayersPanelPage } from '../../../pages/workspace/layers-panel-page';
-import { ProfilePage } from '../../../pages/profile-page';
-import { LoginPage } from '../../../pages/login-page';
 import { setupAdminRoleUser } from '../../../helpers/user-flows';
 import { createTeamName } from 'helpers/teams/create-team-name';
+import { ProfilePage } from '@pages/profile-page';
+import { LoginPage } from '@pages/login-page';
 
 const teamName = createTeamName();
 

--- a/tests/panels-features/history/panels-features-history-preview-version.spec.ts
+++ b/tests/panels-features/history/panels-features-history-preview-version.spec.ts
@@ -1,11 +1,11 @@
-import { mainTest } from '../../../fixtures';
-import { MainPage } from '../../../pages/workspace/main-page';
-import { TeamPage } from '../../../pages/dashboard/team-page';
-import { DashboardPage } from '../../../pages/dashboard/dashboard-page';
-import { qase } from 'playwright-qase-reporter/playwright';
-import { HistoryPanelPage } from '../../../pages/workspace/history-panel-page';
-import { LayersPanelPage } from '../../../pages/workspace/layers-panel-page';
+import { mainTest } from 'fixtures';
+import { MainPage } from '@pages/workspace/main-page';
+import { HistoryPanelPage } from '@pages/workspace/history-panel-page';
+import { LayersPanelPage } from '@pages/workspace/layers-panel-page';
+import { TeamPage } from '@pages/dashboard/team-page';
+import { DashboardPage } from '@pages/dashboard/dashboard-page';
 import { createTeamName } from 'helpers/teams/create-team-name';
+import { qase } from 'playwright-qase-reporter/playwright';
 import { expect, test } from 'playwright/test';
 
 const teamName = createTeamName();
@@ -90,6 +90,7 @@ mainTest(
 
     await test.step(`Restore Version ${versionName[0]} and validate snapshot`, async () => {
       await historyPage.clickRestoreVersionButton();
+      await mainPage.waitForChangeIsSaved();
       // TO DO - Add confirmation modal when implemented
       await expect(mainPage.viewport).toHaveScreenshot('restored-version-a.png', {
         mask: mainPage.maskViewport(),

--- a/tests/panels-features/history/panels-features-history-preview-version.spec.ts
+++ b/tests/panels-features/history/panels-features-history-preview-version.spec.ts
@@ -5,8 +5,6 @@ import { DashboardPage } from '../../../pages/dashboard/dashboard-page';
 import { qase } from 'playwright-qase-reporter/playwright';
 import { HistoryPanelPage } from '../../../pages/workspace/history-panel-page';
 import { LayersPanelPage } from '../../../pages/workspace/layers-panel-page';
-import { ProfilePage } from '../../../pages/profile-page';
-import { LoginPage } from '../../../pages/login-page';
 import { createTeamName } from 'helpers/teams/create-team-name';
 import { expect, test } from 'playwright/test';
 
@@ -17,8 +15,6 @@ let dashboardPage: DashboardPage;
 let mainPage: MainPage;
 let historyPage: HistoryPanelPage;
 let layersPanelPage: LayersPanelPage;
-let profilePage: ProfilePage;
-let loginPage: LoginPage;
 
 mainTest.beforeEach(async ({ page }) => {
   teamPage = new TeamPage(page);
@@ -60,10 +56,7 @@ mainTest(
     });
 
     await test.step(`Open Preview version ${versionName[0]} and validate notification`, async () => {
-      await historyPage.selectVersionOptionByVersion(
-        versionName[0],
-        'Preview version',
-      );
+      await historyPage.selectVersionOption('Preview version', versionName[0]);
       await historyPage.isPreviewVersionNotificationVisible(versionName[0]);
       await expect(mainPage.viewport).toHaveScreenshot(
         'preview-version-snapshot-a.png',
@@ -74,10 +67,7 @@ mainTest(
     });
 
     await test.step(`Open Preview version ${versionName[1]} and validate notification`, async () => {
-      await historyPage.selectVersionOptionByVersion(
-        versionName[1],
-        'Preview version',
-      );
+      await historyPage.selectVersionOption('Preview version', versionName[1]);
       await historyPage.isPreviewVersionNotificationVisible(versionName[1]);
       await expect(mainPage.viewport).toHaveScreenshot(
         'preview-version-snapshot-b.png',
@@ -88,10 +78,7 @@ mainTest(
     });
 
     await test.step(`Open Preview version ${versionName[0]} and validate notification`, async () => {
-      await historyPage.selectVersionOptionByVersion(
-        versionName[0],
-        'Preview version',
-      );
+      await historyPage.selectVersionOption('Preview version', versionName[0]);
       await historyPage.isPreviewVersionNotificationVisible(versionName[0]);
       await expect(mainPage.viewport).toHaveScreenshot(
         'preview-version-snapshot-a.png',


### PR DESCRIPTION
# Done Definition Checks

## Description

Fix for locator pushed by mistake into main https://github.com/penpot/penpotqa/commit/f6eb5337f8222c45c3d445768085b64578401a90.

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Test Execution Results CI

Note: error non related to tests, it is happening on the after hooks when deleting the team.

<img width="1019" height="267" alt="image" src="https://github.com/user-attachments/assets/5c58e95b-4c3e-4762-8ad0-256dd2e63f2f" />

<img width="1024" height="993" alt="image" src="https://github.com/user-attachments/assets/07e6d058-4b0d-4374-87a3-dbf59e4ca5af" />
