### PR TITLE
feat(new numeric input): add new test for PENPOT-2905

### DIFF
--- a/pages/workspace/design-panel-page.js
+++ b/pages/workspace/design-panel-page.js
@@ -1,8 +1,6 @@
 const { expect } = require('@playwright/test');
 const { BasePage } = require('../base-page');
 const { mainTest } = require('../../fixtures');
-const { assert } = require('console');
-const exp = require('constants');
 
 exports.DesignPanelPage = class DesignPanelPage extends BasePage {
   /**

--- a/pages/workspace/design-panel-page.js
+++ b/pages/workspace/design-panel-page.js
@@ -1,6 +1,8 @@
 const { expect } = require('@playwright/test');
 const { BasePage } = require('../base-page');
 const { mainTest } = require('../../fixtures');
+const { assert } = require('console');
+const exp = require('constants');
 
 exports.DesignPanelPage = class DesignPanelPage extends BasePage {
   /**
@@ -36,6 +38,7 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
     this.openTokenListButton = page.locator(
       'div[aria-label="Open token list"] button',
     );
+    this.detachTokenButton = page.getByRole('button', { name: 'Detach token' });
     this.resizeBoardToFitButton = page.getByRole('button', {
       name: 'Resize board to fit content',
     });
@@ -1961,5 +1964,38 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
   async openTokenListByIndex(index) {
     await expect(this.getOpenTokenListButtonByIndex(index)).toBeVisible();
     await this.getOpenTokenListButtonByIndex(index).click();
+  }
+
+  async selectTokenInTokenListByName(name) {
+    const tokenOption = this.page.getByRole('option', { name: name });
+    await expect(tokenOption).toBeVisible();
+    await tokenOption.click();
+  }
+
+  /**
+   * @param {string} ariaLabel - Accessible label of the field container (e.g. 'Width').
+   */
+  async hoverOnTokenPill(ariaLabel) {
+    const tokenContainer = this.page.getByLabel(ariaLabel, { exact: true });
+    const tokenPill = tokenContainer
+      .getByRole('button')
+      .and(this.page.locator('[class*="token_field__pill"]'));
+
+    await expect(tokenPill.first()).toBeVisible();
+    await tokenPill.first().hover();
+  }
+
+  /**
+   * @param {string} value - Token name.
+   */
+  async isTokenPillTooltipVisible(value) {
+    const tokenTooltipValue = this.page.getByText(value, {
+      exact: true,
+    });
+    await expect(tokenTooltipValue).toBeVisible();
+  }
+
+  async isDetachTokenButtonVisible() {
+    await expect(this.detachTokenButton).toBeVisible();
   }
 };

--- a/pages/workspace/design-panel-page.js
+++ b/pages/workspace/design-panel-page.js
@@ -33,6 +33,9 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
     this.sizeHeightInput = page.locator('div[aria-label="Height"] input');
     this.xAxisInput = page.locator('div[aria-label="X axis"] input');
     this.yAxisInput = page.locator('div[aria-label="Y axis"] input');
+    this.openTokenListButton = page.locator(
+      'div[aria-label="Open token list"] button',
+    );
     this.resizeBoardToFitButton = page.getByRole('button', {
       name: 'Resize board to fit content',
     });
@@ -1945,5 +1948,18 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
       await shadowColorButton,
       `Shadow Color Button has expected value: "${color}"`,
     ).toBeVisible();
+  }
+
+  async hoverOnWidthForLayer() {
+    await this.sizeWidthInput.hover();
+  }
+
+  getOpenTokenListButtonByIndex(index) {
+    return this.openTokenListButton.nth(index);
+  }
+
+  async openTokenListByIndex(index) {
+    await expect(this.getOpenTokenListButtonByIndex(index)).toBeVisible();
+    await this.getOpenTokenListButtonByIndex(index).click();
   }
 };

--- a/tests/tokens/tokens-in-design-tab.spec.ts
+++ b/tests/tokens/tokens-in-design-tab.spec.ts
@@ -1,0 +1,71 @@
+import { mainTest } from 'fixtures';
+import { qase } from 'playwright-qase-reporter/playwright';
+import { MainPage } from '@pages/workspace/main-page';
+import { TeamPage } from '@pages/dashboard/team-page';
+import { DashboardPage } from '@pages/dashboard/dashboard-page';
+import { TokensPage } from '@pages/workspace/tokens/tokens-base-page';
+import { LayersPanelPage } from '@pages/workspace/layers-panel-page';
+import { DesignPanelPage } from '@pages/workspace/design-panel-page';
+import { createTeamName } from 'helpers/teams/create-team-name';
+
+const teamName = createTeamName();
+
+let teamPage: TeamPage;
+let dashboardPage: DashboardPage;
+let mainPage: MainPage;
+let tokensPage: TokensPage;
+let layersPanelPage: LayersPanelPage;
+let designPanelPage: DesignPanelPage;
+
+mainTest.beforeEach(async ({ page }) => {
+  teamPage = new TeamPage(page);
+  dashboardPage = new DashboardPage(page);
+  mainPage = new MainPage(page);
+  tokensPage = new TokensPage(page);
+  layersPanelPage = new LayersPanelPage(page);
+  designPanelPage = new DesignPanelPage(page);
+  await teamPage.createTeam(teamName);
+  await teamPage.isTeamSelected(teamName);
+  await dashboardPage.isHeaderDisplayed('Projects');
+});
+
+mainTest.afterEach(async () => {
+  await mainPage.backToDashboardFromFileEditor();
+  await teamPage.deleteTeam(teamName);
+});
+
+mainTest.describe(() => {
+  mainTest.beforeEach(async () => {
+    await dashboardPage.createFileViaPlaceholder();
+    await mainPage.isMainPageLoaded();
+    await mainPage.clickMoveButton();
+    await tokensPage.clickTokensTab();
+    await tokensPage.toolsComp.clickOnTokenToolsButton();
+    await tokensPage.toolsComp.importTokens(
+      'documents/tokens-for-each-category.json',
+    );
+    await tokensPage.setsComp.isSetNameVisible('Global');
+  });
+
+  mainTest(
+    qase(
+      2905,
+      'Selecting a token via the Token Icon updates the input value applied to a shape',
+    ),
+    async () => {
+      await mainTest.step('Create rectangle', async () => {
+        await tokensPage.createDefaultRectangleByCoordinates(100, 200);
+      });
+      await mainTest.step('Open Layers tab', async () => {
+        await layersPanelPage.openLayersTab();
+      });
+      await mainTest.step('Hover on Width field in Design tab', async () => {
+        await designPanelPage.hoverOnWidthForLayer();
+      });
+      await mainTest.step('Open token list in Width field', async () => {
+        const widthFieldIndex = 1;
+        await designPanelPage.openTokenListByIndex(widthFieldIndex);
+      });
+    },
+  );
+});

--- a/tests/tokens/tokens-in-design-tab.spec.ts
+++ b/tests/tokens/tokens-in-design-tab.spec.ts
@@ -7,6 +7,7 @@ import { TokensPage } from '@pages/workspace/tokens/tokens-base-page';
 import { LayersPanelPage } from '@pages/workspace/layers-panel-page';
 import { DesignPanelPage } from '@pages/workspace/design-panel-page';
 import { createTeamName } from 'helpers/teams/create-team-name';
+import { TokenClass } from '@pages/workspace/tokens/token-components/tokens-base-component';
 
 const teamName = createTeamName();
 
@@ -53,11 +54,10 @@ mainTest.describe(() => {
       'Selecting a token via the Token Icon updates the input value applied to a shape',
     ),
     async () => {
+      const tokenName: string = 'SIZING-2';
+
       await mainTest.step('Create rectangle', async () => {
         await tokensPage.createDefaultRectangleByCoordinates(100, 200);
-      });
-      await mainTest.step('Open Layers tab', async () => {
-        await layersPanelPage.openLayersTab();
       });
       await mainTest.step('Hover on Width field in Design tab', async () => {
         await designPanelPage.hoverOnWidthForLayer();
@@ -65,6 +65,26 @@ mainTest.describe(() => {
       await mainTest.step('Open token list in Width field', async () => {
         const widthFieldIndex = 1;
         await designPanelPage.openTokenListByIndex(widthFieldIndex);
+      });
+      await mainTest.step('Select token in token list by name', async () => {
+        await designPanelPage.selectTokenInTokenListByName(tokenName);
+      });
+      await mainTest.step('Check applied token', async () => {
+        const tokenValue: string = '2';
+        await designPanelPage.checkSizeWidth(tokenValue);
+      });
+      await mainTest.step(
+        'Hover in token value, check tooltip and detach token button',
+        async () => {
+          const ariaLabel: string = 'Width';
+          await designPanelPage.hoverOnTokenPill(ariaLabel);
+          await designPanelPage.isTokenPillTooltipVisible(tokenName);
+          await designPanelPage.isDetachTokenButtonVisible();
+        },
+      );
+      await mainTest.step('Check applied token in Token tab', async () => {
+        await tokensPage.tokensComp.expandTokenByName(TokenClass.Sizing);
+        await tokensPage.tokensComp.isTokenAppliedWithName(tokenName);
       });
     },
   );


### PR DESCRIPTION
# Done Definition Checks

## Description

This PR add a new test for [PENPOT-2905](https://app.qase.io/case/PENPOT-2905): Selecting a token via the Token Icon updates the input value applied to a shape

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Screenshots 📸 

<img width="2064" height="460" alt="tokens-in-design-tab" src="https://github.com/user-attachments/assets/5ed9a376-7647-48f3-9fe0-d577645c80a6" />
