### PR TITLE
feat(history): add confirmation modal to restore from preview history

### DIFF
--- a/pages/workspace/history-panel-page.js
+++ b/pages/workspace/history-panel-page.js
@@ -208,6 +208,16 @@ exports.HistoryPanelPage = class HistoryPanelPage extends MainPage {
     ).toBeVisible();
   }
 
+  async isRestoreConfirmationModalVisible() {
+    const previewVersionMessage = this.previewVersionNotification.getByText(
+      'Do you want to restore this version?',
+    );
+    expect(
+      previewVersionMessage,
+      `Restore confirmation modal is visible`,
+    ).toBeVisible();
+  }
+
   async clickRestoreVersionButton() {
     await this.restoreButton.click();
   }

--- a/tests/panels-features/history/panels-features-history-preview-version.spec.ts
+++ b/tests/panels-features/history/panels-features-history-preview-version.spec.ts
@@ -88,10 +88,10 @@ mainTest(
       );
     });
 
-    await test.step(`Restore Version ${versionName[0]} and validate snapshot`, async () => {
+    await test.step(`Click on RESTORE ${versionName[0]}, assert confirmation modal, click to confirm and validate snapshot`, async () => {
       await historyPage.clickRestoreVersionButton();
-      await mainPage.waitForChangeIsSaved();
-      // TO DO - Add confirmation modal when implemented
+      await historyPage.isRestoreConfirmationModalVisible();
+      await historyPage.clickRestoreVersionButton();
       await expect(mainPage.viewport).toHaveScreenshot('restored-version-a.png', {
         mask: mainPage.maskViewport(),
       });


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/task/1312

## Description

Implements a step to click on RESTORE from confirmation modal for restoring a history version (https://app.qase.io/case/PENPOT-2903). This  was not implemented yet.

## Solution

Adding a new assertion to validate confirmation before restoring a version.

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Test Execution Results (local)

<img width="1909" height="851" alt="image" src="https://github.com/user-attachments/assets/7e451fc9-6f50-4994-96ce-ed6b25eb14c1" />
