### PR TITLE
feat(new numeric input): add new test for PENPOT-2873

### DIFF
--- a/pages/workspace/design-panel-page.js
+++ b/pages/workspace/design-panel-page.js
@@ -1998,6 +1998,6 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
   }
 
   async clickOnDetachTokenButton() {
-    this.detachTokenButton.click();
+    await this.detachTokenButton.click();
   }
 };

--- a/pages/workspace/design-panel-page.js
+++ b/pages/workspace/design-panel-page.js
@@ -1996,4 +1996,8 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
   async isDetachTokenButtonVisible() {
     await expect(this.detachTokenButton).toBeVisible();
   }
+
+  async clickOnDetachTokenButton() {
+    this.detachTokenButton.click();
+  }
 };

--- a/tests/tokens/tokens-in-design-tab.spec.ts
+++ b/tests/tokens/tokens-in-design-tab.spec.ts
@@ -4,7 +4,6 @@ import { MainPage } from '@pages/workspace/main-page';
 import { TeamPage } from '@pages/dashboard/team-page';
 import { DashboardPage } from '@pages/dashboard/dashboard-page';
 import { TokensPage } from '@pages/workspace/tokens/tokens-base-page';
-import { LayersPanelPage } from '@pages/workspace/layers-panel-page';
 import { DesignPanelPage } from '@pages/workspace/design-panel-page';
 import { createTeamName } from 'helpers/teams/create-team-name';
 import { TokenClass } from '@pages/workspace/tokens/token-components/tokens-base-component';
@@ -15,7 +14,6 @@ let teamPage: TeamPage;
 let dashboardPage: DashboardPage;
 let mainPage: MainPage;
 let tokensPage: TokensPage;
-let layersPanelPage: LayersPanelPage;
 let designPanelPage: DesignPanelPage;
 
 mainTest.beforeEach(async ({ page }) => {
@@ -23,7 +21,6 @@ mainTest.beforeEach(async ({ page }) => {
   dashboardPage = new DashboardPage(page);
   mainPage = new MainPage(page);
   tokensPage = new TokensPage(page);
-  layersPanelPage = new LayersPanelPage(page);
   designPanelPage = new DesignPanelPage(page);
   await teamPage.createTeam(teamName);
   await teamPage.isTeamSelected(teamName);
@@ -50,42 +47,63 @@ mainTest.describe(() => {
 
   mainTest(
     qase(
-      2905,
-      'Selecting a token via the Token Icon updates the input value applied to a shape',
+      [2905, 2873],
+      'Selecting a token via the Token Icon and detaching via detach button ',
     ),
     async () => {
       const tokenName: string = 'SIZING-2';
 
-      await mainTest.step('Create rectangle', async () => {
-        await tokensPage.createDefaultRectangleByCoordinates(100, 200);
-      });
-      await mainTest.step('Hover on Width field in Design tab', async () => {
-        await designPanelPage.hoverOnWidthForLayer();
-      });
-      await mainTest.step('Open token list in Width field', async () => {
-        const widthFieldIndex = 1;
-        await designPanelPage.openTokenListByIndex(widthFieldIndex);
-      });
-      await mainTest.step('Select token in token list by name', async () => {
-        await designPanelPage.selectTokenInTokenListByName(tokenName);
-      });
-      await mainTest.step('Check applied token', async () => {
-        const tokenValue: string = '2';
-        await designPanelPage.checkSizeWidth(tokenValue);
-      });
       await mainTest.step(
-        'Hover in token value, check tooltip and detach token button',
+        '(2905) Selecting a token via the Token Icon updates the input value applied to a shape',
         async () => {
-          const ariaLabel: string = 'Width';
-          await designPanelPage.hoverOnTokenPill(ariaLabel);
-          await designPanelPage.isTokenPillTooltipVisible(tokenName);
-          await designPanelPage.isDetachTokenButtonVisible();
+          await mainTest.step('Create rectangle', async () => {
+            await tokensPage.createDefaultRectangleByCoordinates(100, 200);
+          });
+          await mainTest.step('Hover on Width field in Design tab', async () => {
+            await designPanelPage.hoverOnWidthForLayer();
+          });
+          await mainTest.step('Open token list in Width field', async () => {
+            const widthFieldIndex = 1;
+            await designPanelPage.openTokenListByIndex(widthFieldIndex);
+          });
+          await mainTest.step('Select token in token list by name', async () => {
+            await designPanelPage.selectTokenInTokenListByName(tokenName);
+          });
+          await mainTest.step('Check applied token', async () => {
+            const tokenValue: string = '2';
+            await designPanelPage.checkSizeWidth(tokenValue);
+          });
+          await mainTest.step(
+            'Hover in token value, check tooltip and detach token button',
+            async () => {
+              const ariaLabel: string = 'Width';
+              await designPanelPage.hoverOnTokenPill(ariaLabel);
+              await designPanelPage.isTokenPillTooltipVisible(tokenName);
+              await designPanelPage.isDetachTokenButtonVisible();
+            },
+          );
+          await mainTest.step('Check applied token in Token tab', async () => {
+            await tokensPage.tokensComp.expandTokenByName(TokenClass.Sizing);
+            await tokensPage.tokensComp.isTokenAppliedWithName(tokenName);
+          });
         },
       );
-      await mainTest.step('Check applied token in Token tab', async () => {
-        await tokensPage.tokensComp.expandTokenByName(TokenClass.Sizing);
-        await tokensPage.tokensComp.isTokenAppliedWithName(tokenName);
-      });
+      await mainTest.step(
+        '(2873) Detaching via detach button removes token and displays raw value in the numeric input',
+        async () => {
+          await mainTest.step('Detach token', async () => {
+            await designPanelPage.clickOnDetachTokenButton();
+          });
+          await mainTest.step('Check unapplied token in Token tab', async () => {
+            await tokensPage.tokensComp.isTokenAppliedWithName(tokenName, false);
+          });
+          await mainTest.step('Edit width', async () => {
+            const newWidthValue: string = '10';
+            await designPanelPage.changeWidthForLayer(newWidthValue);
+            await designPanelPage.checkSizeWidth(newWidthValue);
+          });
+        },
+      );
     },
   );
 });

--- a/tests/tokens/tokens-in-design-tab.spec.ts
+++ b/tests/tokens/tokens-in-design-tab.spec.ts
@@ -48,10 +48,11 @@ mainTest.describe(() => {
   mainTest(
     qase(
       [2905, 2873],
-      'Selecting a token via the Token Icon and detaching via detach button ',
+      'Selecting a token via the Token Icon and detaching via the detach button ',
     ),
     async () => {
       const tokenName: string = 'SIZING-2';
+      const tokenValue: string = '2';
 
       await mainTest.step(
         '(2905) Selecting a token via the Token Icon updates the input value applied to a shape',
@@ -70,7 +71,6 @@ mainTest.describe(() => {
             await designPanelPage.selectTokenInTokenListByName(tokenName);
           });
           await mainTest.step('Check applied token', async () => {
-            const tokenValue: string = '2';
             await designPanelPage.checkSizeWidth(tokenValue);
           });
           await mainTest.step(
@@ -93,6 +93,7 @@ mainTest.describe(() => {
         async () => {
           await mainTest.step('Detach token', async () => {
             await designPanelPage.clickOnDetachTokenButton();
+            await designPanelPage.checkSizeWidth(tokenValue);
           });
           await mainTest.step('Check unapplied token in Token tab', async () => {
             await tokensPage.tokensComp.isTokenAppliedWithName(tokenName, false);


### PR DESCRIPTION
# Done Definition Checks

## Description

This PR add new test for [PENPOT-2873](https://app.qase.io/case/PENPOT-2873): Detaching via detach button removes token and displays raw value in the numeric input

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Screenshots 📸 

<img width="2048" height="470" alt="detach-token" src="https://github.com/user-attachments/assets/708a16c6-b122-490c-9250-b92f14fab4cd" />
