### PR TITLE
refactor(text): refactor create text methods to reduce flakiness

### DIFF
--- a/pages/workspace/main-page.js
+++ b/pages/workspace/main-page.js
@@ -1038,8 +1038,8 @@ exports.MainPage = class MainPage extends BasePage {
   async createDefaultTextLayer() {
     await this.clickCreateTextButton();
     await this.clickViewportByCoordinates(200, 300);
-    await expect(this.textbox).toBeFocused();
     await expect(this.textbox).toBeVisible();
+    await expect(this.textbox).toBeFocused();
     await this.typeTextFromKeyboard();
     await this.clickMoveButton();
     await this.waitForChangeIsSaved();

--- a/pages/workspace/main-page.js
+++ b/pages/workspace/main-page.js
@@ -290,7 +290,8 @@ exports.MainPage = class MainPage extends BasePage {
   }
 
   async typeTextFromKeyboard() {
-    await this.page.keyboard.type('Hello world!');
+    await this.page.keyboard.type('Hello world!', { delay: 50 });
+    await expect(this.textbox).toHaveText('Hello world!');
   }
 
   async uploadImage(filePath) {
@@ -1037,6 +1038,7 @@ exports.MainPage = class MainPage extends BasePage {
   async createDefaultTextLayer() {
     await this.clickCreateTextButton();
     await this.clickViewportByCoordinates(200, 300);
+    await expect(this.textbox).toBeFocused();
     await expect(this.textbox).toBeVisible();
     await this.typeTextFromKeyboard();
     await this.clickMoveButton();
@@ -1047,6 +1049,7 @@ exports.MainPage = class MainPage extends BasePage {
     await this.clickCreateTextButton();
     await this.clickViewportByCoordinates(x, y);
     await expect(this.textbox).toBeVisible();
+    await expect(this.textbox).toBeFocused();
     await this.typeTextFromKeyboard();
     await this.clickMoveButton();
     await this.waitForChangeIsSaved();
@@ -1056,8 +1059,20 @@ exports.MainPage = class MainPage extends BasePage {
     await this.page.keyboard.press('T');
     await this.clickViewportByCoordinates(200, 300);
     await expect(this.textbox).toBeVisible();
+    await expect(this.textbox).toBeFocused();
     await this.typeTextFromKeyboard();
     await this.clickMoveButton();
+  }
+
+  async createTextLayerByCoordinates(x, y, text) {
+    await this.clickCreateTextButton();
+    await this.clickViewportByCoordinates(x, y);
+    await expect(this.textbox).toBeVisible();
+    await expect(this.textbox).toBeFocused();
+    await this.page.keyboard.type(text, { delay: 50 });
+    await expect(this.textbox).toHaveText(text);
+    await this.clickMoveButton();
+    await this.waitForChangeIsSaved();
   }
 
   async clickOnMainToolBar() {
@@ -1414,17 +1429,6 @@ exports.MainPage = class MainPage extends BasePage {
     await this.page.mouse.up();
 
     await this.page.keyboard.up('Alt');
-  }
-
-  async createTextLayerByCoordinates(x, y, text) {
-    await this.clickCreateTextButton();
-    await this.clickViewportByCoordinates(x, y);
-    await expect(this.textbox).toBeVisible();
-    await expect(this.textbox).toBeFocused();
-    await this.page.keyboard.type(text, { delay: 50 });
-    await expect(this.textbox).toHaveText(text);
-    await this.clickMoveButton();
-    await this.waitForChangeIsSaved();
   }
 
   async isCornerHandleVisible(visible = true) {

--- a/tests/composition/composition-grid-layout.spec.js
+++ b/tests/composition/composition-grid-layout.spec.js
@@ -623,7 +623,6 @@ mainTest.describe(() => {
     ),
     async () => {
       await mainPage.createDefaultTextLayerByCoordinates(500, 500);
-      await mainPage.waitForChangeIsSaved();
       await layersPanelPage.dragAndDropComponentToBoard('Hello world!');
       await mainPage.waitForChangeIsUnsaved();
       await mainPage.waitForChangeIsSaved();

--- a/tests/composition/text/text-search.spec.ts
+++ b/tests/composition/text/text-search.spec.ts
@@ -48,9 +48,7 @@ mainTest.describe(() => {
 
     await mainTest.step('Create text layers', async () => {
       await mainPage.createTextLayerByCoordinates(100, 200, secondText);
-      await mainPage.waitForChangeIsSaved();
       await mainPage.createTextLayerByCoordinates(100, 300, thirdText);
-      await mainPage.waitForChangeIsSaved();
     });
 
     await mainTest.step(

--- a/tests/tokens/rename-and-remap.spec.ts
+++ b/tests/tokens/rename-and-remap.spec.ts
@@ -75,7 +75,6 @@ mainTest.describe(() => {
           await mainPage.createDefaultBoardByCoordinates(320, 210);
           await mainPage.doubleClickCreatedBoardTitleOnCanvas();
           await mainPage.createDefaultTextLayerByCoordinates(350, 250);
-          await mainPage.waitForChangeIsSaved();
           await tokensPage.tokensComp.createTokenViaAddButtonAndEnter(
             borderRadiusToken,
           );

--- a/tests/tokens/token-types/font-size-token.spec.ts
+++ b/tests/tokens/token-types/font-size-token.spec.ts
@@ -109,7 +109,6 @@ mainTest.describe(() => {
         await mainPage.waitForChangeIsSaved();
         await tokensPage.tokensComp.isTokenAppliedWithName(fontSizeToken.name);
         await mainPage.createDefaultTextLayerByCoordinates(100, 600);
-        await mainPage.waitForChangeIsSaved();
         await tokensPage.tokensComp.clickOnTokenWithName(fontSizeToken.name);
         await mainPage.waitForChangeIsSaved();
         await tokensPage.tokensComp.isTokenAppliedWithName(fontSizeToken.name);
@@ -173,7 +172,6 @@ mainTest(
         await tokensPage.tokensComp.createTokenViaAddButtonAndEnter(colorToken2);
         await tokensPage.tokensComp.isTokenVisibleWithName(colorToken2.name);
         await mainPage.createDefaultTextLayerByCoordinates(100, 200);
-        await mainPage.waitForChangeIsSaved();
         await mainPage.waitForResizeHandlerVisible();
         await tokensPage.tokensComp.clickOnTokenWithName(colorToken1.name);
         await tokensPage.tokensComp.isTokenAppliedWithName(colorToken1.name);

--- a/tests/view-mode/view-mode.spec.js
+++ b/tests/view-mode/view-mode.spec.js
@@ -582,7 +582,6 @@ mainTest.describe(() => {
     await mainPage.waitForChangeIsUnsaved();
     await mainPage.waitForChangeIsSaved();
     await mainPage.createDefaultTextLayerByCoordinates(220, 330);
-    await mainPage.waitForChangeIsSaved();
     await layersPanelPage.dragAndDropComponentToBoard('Hello world!');
     await mainPage.waitForChangeIsUnsaved();
     await mainPage.waitForChangeIsSaved();


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/us/1318

## Description

Some tests were flaky because snapshot assertions could run before text input had finished. This PR refactors the affected methods to wait until the textbox is focused, the text has been fully entered, and the expected text is visible before proceeding with assertions.

It also removes redundant waits from tests where the underlying methods already handle the necessary synchronization.

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Test Execution Results in CI

_Note: flakiness due to errors on afterHooks not on tests_

<img width="1003" height="689" alt="image" src="https://github.com/user-attachments/assets/3122aad7-7080-47ad-ab69-2611f8a69dfb" />

<img width="1026" height="332" alt="image" src="https://github.com/user-attachments/assets/1e6a0bfd-eae4-4397-850a-347d873486b2" />

