### PR TITLE
feat(new numeric input): add new test for PENPOT-2893

### DIFF
--- a/pages/workspace/design-panel-page.js
+++ b/pages/workspace/design-panel-page.js
@@ -40,6 +40,9 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
     this.notValidReferencedButton = page.getByRole('button', {
       name: 'Reference is not valid or is not in any active set',
     });
+    this.notInAnyActiveSetButton = page.getByRole('button', {
+      name: 'This token is not in any active set or has an invalid value',
+    });
     this.resizeBoardToFitButton = page.getByRole('button', {
       name: 'Resize board to fit content',
     });
@@ -2009,11 +2012,14 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
     await expect(this.notValidReferencedButton).toBeVisible();
   }
 
+  async isNotInAnyActiveSetButtonVisible() {
+    await expect(this.notInAnyActiveSetButton).toBeVisible();
+  }
+
   /**
-   * @param {string} hexColor - hexadecimal color
+   * @param {string} messageText - Message text
    */
-  async checkTooltipInFillColorInput(hexColor) {
-    const messageText = `Resolved value: ${hexColor}`;
+  async checkTooltipInFillColorInput(messageText) {
     await this.fillSection.getByRole('button', { name: messageText }).hover();
     await this.isTokenPillTooltipVisible(messageText);
   }

--- a/tests/tokens/tokens-in-design-tab.spec.ts
+++ b/tests/tokens/tokens-in-design-tab.spec.ts
@@ -203,6 +203,9 @@ mainTest.describe(() => {
 });
 
 mainTest.describe(() => {
+  const hexColor: string = '#ec9090';
+  const setName: string = 'Light';
+
   mainTest.beforeEach(async () => {
     await dashboardPage.openSidebarItem('Drafts');
     await dashboardPage.importFileFromProjectPage(
@@ -221,18 +224,17 @@ mainTest.describe(() => {
       'Token pill updates displayed value after token value change in active token set',
     ),
     async () => {
-      const hexColor: string = '#ec9090';
       const newHexColor: string = '#f1d0d0';
 
       await mainTest.step(
         'Hover on fill color input and check token value in tootltip message',
         async () => {
-          await designPanelPage.checkTooltipInFillColorInput(hexColor);
+          const messageText = `Resolved value: ${hexColor}`;
+          await designPanelPage.checkTooltipInFillColorInput(messageText);
         },
       );
 
       await mainTest.step('Click on the Mode/Light token set', async () => {
-        const setName: string = 'Light';
         await tokensPage.setsComp.isSetNameVisible(setName);
         await tokensPage.setsComp.clickSetItemButton(setName);
       });
@@ -251,7 +253,42 @@ mainTest.describe(() => {
       await mainTest.step(
         'Hover on fill color input and check token value in tootltip message',
         async () => {
-          await designPanelPage.checkTooltipInFillColorInput(newHexColor);
+          const messageText = `Resolved value: ${newHexColor}`;
+          await designPanelPage.checkTooltipInFillColorInput(messageText);
+        },
+      );
+    },
+  );
+
+  mainTest(
+    qase(2893, 'Token pill shows unresolved state when token set becomes inactive'),
+    async () => {
+      await mainTest.step(
+        'Hover on fill color input and check token value in tootltip message',
+        async () => {
+          const messageText = `Resolved value: ${hexColor}`;
+          await designPanelPage.checkTooltipInFillColorInput(messageText);
+        },
+      );
+
+      await mainTest.step('Deactivate the Mode/Light set', async () => {
+        await tokensPage.setsComp.isSetNameVisible(setName);
+        await tokensPage.setsComp.clickOnSetCheckboxByName(setName);
+      });
+
+      await mainTest.step(
+        'Check not in any active set red dot in input',
+        async () => {
+          await designPanelPage.isNotInAnyActiveSetButtonVisible();
+        },
+      );
+
+      await mainTest.step(
+        'Hover on fill color input and check error in tootltip message',
+        async () => {
+          const messageText: string =
+            'This token is not in any active set or has an invalid value.';
+          await designPanelPage.checkTooltipInFillColorInput(messageText);
         },
       );
     },


### PR DESCRIPTION
# Done Definition Checks

## Description

This PR :
- Add a new test for [PENPOT-2893](https://app.qase.io/case/PENPOT-2893): Token pill shows unresolved state when token set becomes inactive
- Refactor a method to make it more generic

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Screenshots 📸 

<img width="1980" height="808" alt="tokens-in-design-tab" src="https://github.com/user-attachments/assets/97f8e985-b14a-4785-863e-db7e417988a1" />
