### PR TITLE
feat(assets): add new test for PENPOT-2838

### DIFF
--- a/pages/workspace/assets-panel-page.js
+++ b/pages/workspace/assets-panel-page.js
@@ -47,6 +47,9 @@ exports.AssetsPanelPage = class AssetsPanelPage extends BasePage {
     this.ungroupFileLibraryMenuItem = page
       .getByRole('menuitem')
       .filter({ hasText: 'Ungroup' });
+    this.deleteGroupFileLibraryMenuItem = page
+      .getByRole('menuitem')
+      .filter({ hasText: 'Delete group' });
     this.combineAsVariantsFileLibraryMenuItem = page
       .getByRole('menuitem')
       .filter({ hasText: 'Combine as variants' });
@@ -56,6 +59,7 @@ exports.AssetsPanelPage = class AssetsPanelPage extends BasePage {
       exact: true,
     });
     this.renameGroupButton = page.getByRole('button', { name: 'Rename' });
+    this.deleteGroupButton = page.getByRole('button', { name: 'Delete' });
     this.fileLibraryGroupTitle = page.locator('[class*="groups__path"]');
     this.fileLibraryListViewButton = page.getByTitle('List view', { exact: true });
     this.fileLibraryGridViewButton = page.getByTitle('Grid view', { exact: true });
@@ -222,6 +226,12 @@ exports.AssetsPanelPage = class AssetsPanelPage extends BasePage {
   async ungroupFileLibrary() {
     await this.fileLibraryGroupTitle.click({ button: 'right' });
     await this.ungroupFileLibraryMenuItem.click();
+  }
+
+  async deleteGroupFileLibrary() {
+    await this.fileLibraryGroupTitle.click({ button: 'right' });
+    await this.deleteGroupFileLibraryMenuItem.click();
+    await this.deleteGroupButton.click();
   }
 
   async clickFileLibraryListViewButton() {

--- a/tests/assets/assets-typographies.spec.ts
+++ b/tests/assets/assets-typographies.spec.ts
@@ -173,26 +173,41 @@ mainTest.describe(() => {
     });
   });
 
-  mainTest(qase([953], 'Typographic styles - create group'), async () => {
-    await mainTest.step('Create group for typography', async () => {
-      await assetsPanelPage.createGroupFileLibraryAssets(
-        'Typographies',
-        'Test Group',
-      );
-      await mainPage.waitForChangeIsSaved();
-    });
+  mainTest(
+    qase([953, 2838], 'Typographic styles - create group and delete group'),
+    async () => {
+      await mainTest.step('(953) Typographic styles - create group', async () => {
+        await mainTest.step('Create group for typography', async () => {
+          await assetsPanelPage.createGroupFileLibraryAssets(
+            'Typographies',
+            'Test Group',
+          );
+          await mainPage.waitForChangeIsSaved();
+        });
 
-    await mainTest.step(
-      'Verify group is created and screenshot matches',
-      async () => {
-        await assetsPanelPage.isFileLibraryGroupCreated('Test Group');
-        await expect(
-          assetsPanelPage.assetsPanel,
-          'Grouped typography should match screenshot',
-        ).toHaveScreenshot('group-typographies.png');
-      },
-    );
-  });
+        await mainTest.step(
+          'Verify group is created and screenshot matches',
+          async () => {
+            await assetsPanelPage.isFileLibraryGroupCreated('Test Group');
+            await expect(
+              assetsPanelPage.assetsPanel,
+              'Grouped typography should match screenshot',
+            ).toHaveScreenshot('group-typographies.png');
+          },
+        );
+      });
+
+      await mainTest.step('(2838) Typographic styles - delete group', async () => {
+        await mainTest.step('Delete group', async () => {
+          await assetsPanelPage.deleteGroupFileLibrary();
+        });
+
+        await mainTest.step('Verify group is removed', async () => {
+          await assetsPanelPage.isFileLibraryGroupRemoved();
+        });
+      });
+    },
+  );
 
   mainTest(qase([955], 'Typographic styles - rename group'), async () => {
     await mainTest.step('Create and rename group', async () => {


### PR DESCRIPTION
# Done Definition Checks

## Description

This PR add a new test for [PENPOT-2838](https://app.qase.io/case/PENPOT-2838): Typographic styles - delete group

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Screenshots 📸 

<img width="1990" height="1402" alt="assets" src="https://github.com/user-attachments/assets/95745ab4-5cd7-4a92-b182-bdc365900cf1" />
