### PR TITLE
feat(assets): add test for PENPOT-2912 and PENPOT-2909

### DIFF
--- a/pages/workspace/assets-panel-page.js
+++ b/pages/workspace/assets-panel-page.js
@@ -38,6 +38,9 @@ exports.AssetsPanelPage = class AssetsPanelPage extends BasePage {
     this.deleteFileLibraryMenuItem = page
       .getByRole('menuitem')
       .filter({ hasText: 'Delete' });
+    this.duplicateFileLibraryMenuItem = page
+      .getByRole('menuitem')
+      .filter({ hasText: 'Duplicate' });
     this.editFileLibraryMenuItem = page
       .getByRole('menuitem')
       .filter({ hasText: 'Edit' });
@@ -61,6 +64,14 @@ exports.AssetsPanelPage = class AssetsPanelPage extends BasePage {
     this.renameGroupButton = page.getByRole('button', { name: 'Rename' });
     this.deleteGroupButton = page.getByRole('button', { name: 'Delete' });
     this.fileLibraryGroupTitle = page.locator('[class*="groups__path"]');
+    this.fileLibraryGroupTitleMenu = page.locator(
+      'div[class*="main_ui_workspace_sidebar_assets_groups__title-menu"]',
+    );
+    this.addTypographyToGroupButton = this.fileLibraryGroupTitleMenu.getByRole(
+      'button',
+      { name: 'Add typography' },
+    );
+    this.typographyItemInGroup = page.locator('div[class*="typography-item"]');
     this.fileLibraryListViewButton = page.getByTitle('List view', { exact: true });
     this.fileLibraryGridViewButton = page.getByTitle('Grid view', { exact: true });
     this.addFileLibraryColorButton = page.getByRole('button', { name: 'Add color' });
@@ -228,6 +239,19 @@ exports.AssetsPanelPage = class AssetsPanelPage extends BasePage {
     await this.ungroupFileLibraryMenuItem.click();
   }
 
+  async hoverOnGroupFileLibrary() {
+    await this.fileLibraryGroupTitle.hover();
+  }
+
+  async addTypographyToGroup() {
+    await expect(this.addTypographyToGroupButton).toBeVisible();
+    await this.addTypographyToGroupButton.click();
+  }
+
+  async checkTypographiesInGroupCount(count) {
+    await expect(this.typographyItemInGroup).toHaveCount(count);
+  }
+
   async deleteGroupFileLibrary() {
     await this.fileLibraryGroupTitle.click({ button: 'right' });
     await this.deleteGroupFileLibraryMenuItem.click();
@@ -273,6 +297,17 @@ exports.AssetsPanelPage = class AssetsPanelPage extends BasePage {
   async deleteFileLibraryColor() {
     await this.fileLibraryColorsColorBullet.click({ button: 'right' });
     await this.deleteFileLibraryMenuItem.click();
+  }
+
+  async duplicateFileLibraryColor() {
+    await this.fileLibraryColorsColorBullet.click({ button: 'right' });
+    await this.duplicateFileLibraryMenuItem.click();
+  }
+
+  async checkDuplicatedLibraryColor(colorName, count) {
+    await expect(
+      this.fileLibraryColorsColorTitle.filter({ hasText: colorName }),
+    ).toHaveCount(count);
   }
 
   async clickFileLibraryColorsColorBullet() {

--- a/pages/workspace/assets-panel-page.js
+++ b/pages/workspace/assets-panel-page.js
@@ -304,7 +304,7 @@ exports.AssetsPanelPage = class AssetsPanelPage extends BasePage {
     await this.duplicateFileLibraryMenuItem.click();
   }
 
-  async checkDuplicatedLibraryColor(colorName, count) {
+  async checkCountLibraryColorWithName(colorName, count) {
     await expect(
       this.fileLibraryColorsColorTitle.filter({ hasText: colorName }),
     ).toHaveCount(count);

--- a/tests/assets/assets-colors.spec.ts
+++ b/tests/assets/assets-colors.spec.ts
@@ -146,7 +146,7 @@ mainTest.describe(() => {
 
     await mainTest.step('Verify the color is duplicated', async () => {
       const count: number = 2;
-      await assetsPanelPage.checkDuplicatedLibraryColor(hexColor, count);
+      await assetsPanelPage.checkCountLibraryColorWithName(hexColor, count);
     });
   });
 

--- a/tests/assets/assets-colors.spec.ts
+++ b/tests/assets/assets-colors.spec.ts
@@ -10,6 +10,7 @@ import { qase } from 'playwright-qase-reporter/playwright';
 import { TeamPage } from '@pages/dashboard/team-page';
 
 const teamName = createTeamName();
+const hexColor: string = '#ffff00';
 
 let mainPage: MainPage;
 let dashboardPage: DashboardPage;
@@ -55,7 +56,7 @@ mainTest.describe(() => {
   mainTest.beforeEach(async () => {
     await assetsPanelPage.clickAssetsTab();
     await assetsPanelPage.clickAddFileLibraryColorButton();
-    await colorPalettePopUp.setHex('#ffff00');
+    await colorPalettePopUp.setHex(hexColor);
     await colorPalettePopUp.clickSaveColorStyleButton();
     await mainPage.clickViewportTwice();
     await mainPage.waitForChangeIsSaved();
@@ -63,7 +64,7 @@ mainTest.describe(() => {
 
   mainTest(qase([933], 'File library colors - add'), async () => {
     await mainTest.step('Verify color is added to file library', async () => {
-      await assetsPanelPage.isColorAddedToFileLibraryColors('#ffff00');
+      await assetsPanelPage.isColorAddedToFileLibraryColors(hexColor);
     });
   });
 
@@ -138,6 +139,17 @@ mainTest.describe(() => {
     );
   });
 
+  mainTest(qase([2909], 'File library colors - duplicate'), async () => {
+    await mainTest.step('Duplicate color', async () => {
+      await assetsPanelPage.duplicateFileLibraryColor();
+    });
+
+    await mainTest.step('Verify the color is duplicated', async () => {
+      const count: number = 2;
+      await assetsPanelPage.checkDuplicatedLibraryColor(hexColor, count);
+    });
+  });
+
   mainTest(qase([937], 'File library colors - create group'), async () => {
     await mainTest.step('Create group for color', async () => {
       await assetsPanelPage.createGroupFileLibraryAssets('Colors', 'Test Group');
@@ -182,7 +194,7 @@ mainTest.describe(() => {
       'Verify group is removed and color is restored',
       async () => {
         await assetsPanelPage.isFileLibraryGroupRemoved();
-        await assetsPanelPage.isColorAddedToFileLibraryColors('#ffff00');
+        await assetsPanelPage.isColorAddedToFileLibraryColors(hexColor);
       },
     );
   });

--- a/tests/assets/assets-typographies.spec.ts
+++ b/tests/assets/assets-typographies.spec.ts
@@ -174,7 +174,10 @@ mainTest.describe(() => {
   });
 
   mainTest(
-    qase([953, 2838], 'Typographic styles - create group and delete group'),
+    qase(
+      [953, 2912, 2838],
+      'Typographic styles - create group, add typography (+) and delete group',
+    ),
     async () => {
       await mainTest.step('(953) Typographic styles - create group', async () => {
         await mainTest.step('Create group for typography', async () => {
@@ -196,6 +199,28 @@ mainTest.describe(() => {
           },
         );
       });
+
+      await mainTest.step(
+        '(2912) Add typography in a group via quick-create (+)',
+        async () => {
+          await mainTest.step('Hover over the group name', async () => {
+            await assetsPanelPage.hoverOnGroupFileLibrary();
+          });
+
+          await mainTest.step('Add typography to the group', async () => {
+            await assetsPanelPage.addTypographyToGroup();
+            await assetsPanelPage.minimizeFileLibraryTypography();
+          });
+
+          await mainTest.step(
+            'Check the number of typographies in the group',
+            async () => {
+              const count: number = 2;
+              await assetsPanelPage.checkTypographiesInGroupCount(count);
+            },
+          );
+        },
+      );
 
       await mainTest.step('(2838) Typographic styles - delete group', async () => {
         await mainTest.step('Delete group', async () => {


### PR DESCRIPTION
# Done Definition Checks

## Description

This PR:
- add a test for [PENPOT-2912](https://app.qase.io/case/PENPOT-2912): Add typography in a group via quick-create (+)
- add a test for [PENPOT-2909](https://app.qase.io/case/PENPOT-2909): File library colors - duplicate
- refactorize a repeated hexadecimal color in a constant.

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Screenshots 📸 

<img width="680" height="1290" alt="assets" src="https://github.com/user-attachments/assets/7e76955d-2ce0-4bed-9947-554ed2c92a5f" />
