### PR TITLE
feat(tokens-group): add new test 2835 for duplicating tokens group

### DIFF
--- a/documents/tokens/duplicating_token_groups.json
+++ b/documents/tokens/duplicating_token_groups.json
@@ -1,0 +1,28 @@
+{
+  "set": {
+    "button": {
+      "primary": {
+        "background-color": {
+          "$value": "#f00",
+          "$type": "color",
+          "$description": ""
+        }
+      }
+    },
+    "button-copy": {
+      "primary": {
+        "token": {
+          "$value": "rgb(179, 255, 142)",
+          "$type": "color",
+          "$description": ""
+        }
+      }
+    }
+  },
+  "$themes": [],
+  "$metadata": {
+    "tokenSetOrder": ["set"],
+    "activeThemes": [],
+    "activeSets": []
+  }
+}

--- a/pages/workspace/tokens/token-components/tokens-base-component.ts
+++ b/pages/workspace/tokens/token-components/tokens-base-component.ts
@@ -278,39 +278,27 @@ export class TokensComponent {
       .click({ button: 'right' });
   }
 
-  async deleteTokenGroup(
+  async selectTokenGroupContextMenuItem(
     group: TokenGroupData,
-    option: TokensGroupContextMenuItem = 'Delete',
+    option: TokensGroupContextMenuItem,
   ) {
     await this.rightClickOnTokenGroup(group);
     await this.getTokensGroupContextMenuOptions(option).click();
   }
 
-  async selectRenameTokenGroupOption(
-    group: TokenGroupData,
-    option: TokensGroupContextMenuItem = 'Rename',
-  ) {
-    await this.rightClickOnTokenGroup(group);
-    await this.getTokensGroupContextMenuOptions(option).click();
+  async deleteTokenGroup(group: TokenGroupData) {
+    await this.selectTokenGroupContextMenuItem(group, 'Delete');
   }
 
-  async selectDuplicateTokenGroupOption(
-    group: TokenGroupData,
-    option: TokensGroupContextMenuItem = 'Duplicate',
-  ) {
-    await this.rightClickOnTokenGroup(group);
-    await this.getTokensGroupContextMenuOptions(option).click();
-  }
-
-  async renameTokenGroup(oldGroup: TokenGroupData, newGroupName: string) {
-    await this.selectRenameTokenGroupOption(oldGroup);
-    await this.renameInput.fill(newGroupName);
+  async renameTokenGroup(group: TokenGroupData, newName: string) {
+    await this.selectTokenGroupContextMenuItem(group, 'Rename');
+    await this.renameInput.fill(newName);
     await this.renameButton.click();
   }
 
-  async duplicateTokenGroup(oldGroup: TokenGroupData, newGroupName: string) {
-    await this.selectDuplicateTokenGroupOption(oldGroup);
-    await this.duplicateInput.fill(newGroupName);
+  async duplicateTokenGroup(group: TokenGroupData, newName: string) {
+    await this.selectTokenGroupContextMenuItem(group, 'Duplicate');
+    await this.duplicateInput.fill(newName);
     await this.duplicateButton.click();
   }
 

--- a/pages/workspace/tokens/token-components/tokens-base-component.ts
+++ b/pages/workspace/tokens/token-components/tokens-base-component.ts
@@ -85,6 +85,9 @@ export class TokensComponent {
   readonly renameModal: Locator;
   readonly renameButton: Locator;
   readonly renameInput: Locator;
+  readonly duplicateModal: Locator;
+  readonly duplicateButton: Locator;
+  readonly duplicateInput: Locator;
 
   constructor(page: Page, tokensPage: TokensPage) {
     this.page = page;
@@ -137,6 +140,15 @@ export class TokensComponent {
       .filter({ hasText: 'Rename tokens group' });
     this.renameButton = this.renameModal.getByRole('button', { name: 'Rename' });
     this.renameInput = this.renameModal.getByRole('textbox');
+
+    // Duplicate Modal Locators
+    this.duplicateModal = page
+      .getByTestId('token-rename-node-modal')
+      .filter({ hasText: 'Duplicate tokens group' });
+    this.duplicateButton = this.duplicateModal.getByRole('button', {
+      name: 'Duplicate',
+    });
+    this.duplicateInput = this.duplicateModal.getByRole('textbox');
   }
 
   private getTokensGroupContextMenuOptions(
@@ -282,10 +294,24 @@ export class TokensComponent {
     await this.getTokensGroupContextMenuOptions(option).click();
   }
 
+  async selectDuplicateTokenGroupOption(
+    group: TokenGroupData,
+    option: TokensGroupContextMenuItem = 'Duplicate',
+  ) {
+    await this.rightClickOnTokenGroup(group);
+    await this.getTokensGroupContextMenuOptions(option).click();
+  }
+
   async renameTokenGroup(oldGroup: TokenGroupData, newGroupName: string) {
     await this.selectRenameTokenGroupOption(oldGroup);
     await this.renameInput.fill(newGroupName);
     await this.renameButton.click();
+  }
+
+  async duplicateTokenGroup(oldGroup: TokenGroupData, newGroupName: string) {
+    await this.selectDuplicateTokenGroupOption(oldGroup);
+    await this.duplicateInput.fill(newGroupName);
+    await this.duplicateButton.click();
   }
 
   async clickEditToken(
@@ -323,8 +349,8 @@ export class TokensComponent {
       .getByRole('button')
       .locator(`span[aria-label="${name}"]`);
     visible
-      ? await expect(token).toBeVisible()
-      : await expect(token).not.toBeVisible();
+      ? await expect(token, `Token "${name}" is visible`).toBeVisible()
+      : await expect(token, `Token "${name}" is not visible`).not.toBeVisible();
   }
 
   async clickOnTokenWithName(name: string) {
@@ -491,8 +517,14 @@ export class TokensComponent {
       hasText: new RegExp(`^${group.name}$`),
     });
     visible
-      ? await expect(groupLocator).toBeVisible()
-      : await expect(groupLocator).not.toBeVisible();
+      ? await expect(
+          groupLocator,
+          `Token group "${group.name}" is visible`,
+        ).toBeVisible()
+      : await expect(
+          groupLocator,
+          `Token group "${group.name}" is not visible`,
+        ).not.toBeVisible();
   }
 
   async isTokenVisibleInGroup(
@@ -537,6 +569,7 @@ export class TokensComponent {
   async isTokenGroupCount(group: TokenGroupData, count: number) {
     await expect(
       this.tokenGroupName.filter({ hasText: new RegExp(`^${group.name}$`) }),
+      `Token group "${group.name}" has ${count}`,
     ).toHaveCount(count);
   }
 

--- a/tests/tokens/token-group/token-group-options.spec.ts
+++ b/tests/tokens/token-group/token-group-options.spec.ts
@@ -298,3 +298,84 @@ mainTest.describe('Context menu > Rename', () => {
     },
   );
 });
+
+mainTest.describe('Context menu > Duplicate', () => {
+  const tokenValue = '#ff0000';
+
+  // Token nested in the 'button' group
+  const buttonGroup = { name: 'button' };
+  const primaryButtonGroupGroup = { name: 'primary', parent: buttonGroup };
+  const backgroundColorButtonGroupToken: MainToken<TokenClass> = {
+    class: TokenClass.Color,
+    name: buildTokenPath('background-color', primaryButtonGroupGroup),
+    value: tokenValue,
+  };
+
+  // Token nested in the 'button-copy' group
+  const buttonGroupCopy = { name: 'button-copy' };
+  const primaryButtonGroupCopyGroup = { name: 'primary', parent: buttonGroupCopy };
+  const backgroundColorButtonGroupCopyToken: MainToken<TokenClass> = {
+    class: TokenClass.Color,
+    name: buildTokenPath('background-color', primaryButtonGroupCopyGroup),
+    value: tokenValue,
+  };
+
+  mainTest(
+    qase(
+      [2835],
+      'Duplicate 2nd-level token group supports merging new content into an existing token group',
+    ),
+    async () => {
+      await mainTest.step(
+        'Import tokens file with 2nd level token groups',
+        async () => {
+          await tokensPage.toolsComp.clickOnTokenToolsButton();
+          await tokensPage.toolsComp.importTokens(
+            'documents/tokens/duplicating_token_groups.json',
+          );
+        },
+      );
+
+      await mainTest.step(
+        `Expand token group ${TokenClass.Color} and verify groups "${buttonGroup.name}" and "${buttonGroupCopy.name}" are visible with expected tokens`,
+        async () => {
+          await tokensPage.tokensComp.expandTokenByName(TokenClass.Color);
+          await tokensPage.tokensComp.isTokenGroupVisible(buttonGroup);
+          await tokensPage.tokensComp.isTokenGroupCount(buttonGroup, 1);
+          await tokensPage.tokensComp.isTokenGroupVisible(buttonGroupCopy);
+          await tokensPage.tokensComp.isTokenGroupCount(buttonGroupCopy, 1);
+          await tokensPage.tokensComp.isTokenVisibleWithName(
+            backgroundColorButtonGroupToken.name,
+          );
+        },
+      );
+
+      await mainTest.step(
+        `Duplicate "${buttonGroup.name}" token group and merge into "${buttonGroupCopy.name}" token group`,
+        async () => {
+          await tokensPage.tokensComp.duplicateTokenGroup(
+            buttonGroup,
+            buttonGroupCopy.name,
+          );
+        },
+      );
+
+      await mainTest.step(
+        `Verify the groups are merged with both of them containing the expected token "${backgroundColorButtonGroupToken.name}" and "${backgroundColorButtonGroupCopyToken.name}" respectively`,
+        async () => {
+          await tokensPage.tokensComp.isTokenGroupVisible(buttonGroup);
+          await tokensPage.tokensComp.isTokenGroupCount(buttonGroup, 1);
+          await tokensPage.tokensComp.isTokenVisibleWithName(
+            backgroundColorButtonGroupToken.name,
+          );
+
+          await tokensPage.tokensComp.isTokenGroupVisible(buttonGroupCopy);
+          await tokensPage.tokensComp.isTokenGroupCount(buttonGroupCopy, 1);
+          await tokensPage.tokensComp.isTokenVisibleWithName(
+            backgroundColorButtonGroupCopyToken.name,
+          );
+        },
+      );
+    },
+  );
+});


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/task/1295

## Description

Implements a new test for https://app.qase.io/case/PENPOT-2835 covering token group duplication behavior.

## Solution

- Adds a new test for duplicating token groups.
- Adds a new JSON fixture file used for token import during the test.
- Adds new locators and helper methods required by the test.
- Adds descriptive assertion comments to improve debugging and test readability.

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] The tests run OK

## Test Execution Results in CI

<img width="997" height="897" alt="image" src="https://github.com/user-attachments/assets/1d52b2ae-671d-447d-bc92-ceb7104c27f0" />


