### PR TITLE
refactor(teardown): implement API teardown

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,9 @@ LOGIN_EMAIL="" # Your email from your Penpot account
 SECOND_EMAIL="" # A secondary email for tests that require it, needs same password than LOGIN_EMAIL
 LOGIN_PWD="" # Your password from your Penpot account
 BASE_URL="" # Penpot url - e.g. http://localhost:9001/ if deployed locally
-TEST_RUN_ID=local   # CI should override this with a unique value per run e.g. github run id
+
+# TEST_RUN_ID should be injected by CI (e.g. GitHub run id). If not set, globalSetup will generate one.
+# TEST_RUN_ID=
 
 # — Optional: set to true to delete all teams created in bulk (default is run-scoped) —
 # FULL_CLEANUP=false

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@ LOGIN_EMAIL="" # Your email from your Penpot account
 SECOND_EMAIL="" # A secondary email for tests that require it, needs same password than LOGIN_EMAIL
 LOGIN_PWD="" # Your password from your Penpot account
 BASE_URL="" # Penpot url - e.g. http://localhost:9001/ if deployed locally
+TEST_RUN_ID=local   # CI should override this with a unique value per run e.g. github run id
+
+# — Optional: set to true to delete all teams created in bulk (default is run-scoped) —
+# FULL_CLEANUP=false
 
 ######################
 ## Integrations     ##

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,9 @@ npm-debug.log*
 /playwright/.cache/
 .playwright-cli/
 
+# Playwright test run state
+.test-run-id
+
 # Test results
 /test-results/
 testResults.json

--- a/tests/global.setup.ts
+++ b/tests/global.setup.ts
@@ -1,9 +1,13 @@
 import { randomUUID } from 'crypto';
+import { writeFileSync } from 'fs';
+
+const RUN_ID_FILE = '.test-run-id';
 
 export default async function globalSetup(): Promise<void> {
-  const runId = randomUUID().slice(0, 8);
+  const runId = process.env.TEST_RUN_ID ?? randomUUID().slice(0, 8);
 
   process.env.TEST_RUN_ID = runId;
+  writeFileSync(RUN_ID_FILE, runId, 'utf-8');
 
   console.log(`🧪 Test Run ID: ${runId}`);
 }

--- a/tests/global.teardown.ts
+++ b/tests/global.teardown.ts
@@ -1,65 +1,87 @@
-import { chromium } from 'playwright';
-import { LoginPage } from '@pages/login-page';
-import { DashboardPage } from '@pages/dashboard/dashboard-page';
-import { TeamPage } from '@pages/dashboard/team-page';
+import { request } from '@playwright/test';
+
+const AUTOTEST_REGEX = /autotest/i;
+const CONCURRENCY = 15;
 
 export default async function globalTeardown() {
-  console.log('🌍 Cleaning up autotest teams...');
+  console.log('🌍 Cleaning autotest teams via API...');
 
-  const browser = await chromium.launch({
-    headless: true,
-    args: ['--no-sandbox'],
+  const api = await request.newContext({
+    baseURL: process.env.BASE_URL?.replace(/\/$/, ''),
+    extraHTTPHeaders: {
+      'Content-Type': 'application/json',
+    },
   });
-  const context = await browser.newContext();
-  const page = await context.newPage();
 
   try {
-    await context.tracing.start({ screenshots: false, snapshots: true });
+    // Login
+    const loginResponse = await api.post(
+      '/api/rpc/command/login-with-password?_fmt=json',
+      {
+        data: {
+          email: process.env.LOGIN_EMAIL,
+          password: process.env.LOGIN_PWD,
+        },
+      },
+    );
 
-    const loginPage = new LoginPage(page);
-    const dashboardPage = new DashboardPage(page);
-    const teamPage = new TeamPage(page);
-
-    await page.goto(`${process.env.BASE_URL}#/auth/login`);
-    await loginPage.acceptCookie();
-    await loginPage.enterEmailAndClickOnContinue(process.env.LOGIN_EMAIL);
-    await loginPage.enterPwd(process.env.LOGIN_PWD);
-    await loginPage.clickLoginButton();
-    await dashboardPage.isDashboardOpenedAfterLogin();
-
-    const autotestRegex = /autotest/i;
-
-    for (let attempt = 0; attempt < 20; attempt++) {
-      await teamPage.openTeamsListIfClosed();
-
-      const teamMenuItems = page.getByRole('menuitem');
-      const teamCount = await teamMenuItems.count();
-      let deletedOne = false;
-
-      for (let i = 0; i < teamCount; i++) {
-        const teamItem = teamMenuItems.nth(i);
-        if (!(await teamItem.isVisible())) continue;
-
-        const teamText = (await teamItem.textContent())?.trim();
-        if (!teamText || teamText === 'Your Penpot') continue;
-        if (!autotestRegex.test(teamText)) continue;
-
-        console.log(`🧹 Deleting team: ${teamText}`);
-        await teamPage.deleteTeam(teamText);
-        deletedOne = true;
-        break;
-      }
-
-      if (!deletedOne) break;
+    if (!loginResponse.ok()) {
+      throw new Error(`Login failed: ${loginResponse.status()}`);
     }
 
-    console.log('✅ Global teardown complete.');
-  } catch (err) {
-    console.error('❌ Global teardown failed:', err);
-    await context.tracing.stop({
-      path: 'playwright-report/trace/global-teardown-failure.zip',
+    console.log('✅ Logged in via API');
+
+    // Fetch teams (GET request)
+    const teamsResponse = await api.get('/api/rpc/command/get-teams?_fmt=json');
+
+    if (!teamsResponse.ok()) {
+      throw new Error(`Failed fetching teams: ${teamsResponse.status()}`);
+    }
+
+    const teams = await teamsResponse.json();
+
+    const autotestTeams = teams.filter(
+      (team: any) => !team.isDefault && AUTOTEST_REGEX.test(team.name),
+    );
+
+    console.log(`🧹 Found ${autotestTeams.length} autotest teams`);
+
+    if (!autotestTeams.length) {
+      console.log('✅ Nothing to clean');
+      return;
+    }
+
+    // Delete with concurrency
+    const queue = [...autotestTeams];
+
+    const workers = Array.from({ length: CONCURRENCY }).map(async () => {
+      while (queue.length) {
+        const team = queue.pop();
+        if (!team) return;
+
+        try {
+          const res = await api.post('/api/rpc/command/delete-team?_fmt=json', {
+            data: { id: team.id },
+          });
+
+          if (!res.ok()) {
+            console.warn(`⚠️ Failed deleting ${team.name}`);
+            continue;
+          }
+
+          console.log(`🗑️ Deleted ${team.name}`);
+        } catch (err) {
+          console.warn(`⚠️ Error deleting ${team.name}`, err);
+        }
+      }
     });
+
+    await Promise.all(workers);
+
+    console.log('✅ Global teardown complete');
+  } catch (error) {
+    console.error('❌ Global teardown failed:', error);
   } finally {
-    await browser.close();
+    await api.dispose();
   }
 }

--- a/tests/global.teardown.ts
+++ b/tests/global.teardown.ts
@@ -1,6 +1,6 @@
 import { request } from '@playwright/test';
 
-const AUTOTEST_REGEX = /autotest/i;
+const AUTOTEST_REGEX = /^at-/;
 const CONCURRENCY = 15;
 const MAX_RETRIES = 3;
 
@@ -31,7 +31,8 @@ async function deleteWithRetry(api: any, team: Team): Promise<boolean> {
 }
 
 export default async function globalTeardown() {
-  const { BASE_URL, LOGIN_EMAIL, LOGIN_PWD, TEST_RUN_ID } = process.env;
+  const { BASE_URL, LOGIN_EMAIL, LOGIN_PWD, TEST_RUN_ID, FULL_CLEANUP } =
+    process.env;
   if (!BASE_URL || !LOGIN_EMAIL || !LOGIN_PWD || !TEST_RUN_ID)
     throw new Error(
       'Missing env vars: BASE_URL, LOGIN_EMAIL, LOGIN_PWD, TEST_RUN_ID',
@@ -47,19 +48,34 @@ export default async function globalTeardown() {
       data: { email: LOGIN_EMAIL, password: LOGIN_PWD },
     });
     if (!loginRes.ok()) throw new Error(`Login failed: ${loginRes.status()}`);
-    console.log('🌍 Cleaning autotest teams...');
 
-    const teams: Team[] = await (await api.get(API.GET_TEAMS)).json();
-    const targets = teams.filter(
-      (t) =>
-        !t.isDefault && AUTOTEST_REGEX.test(t.name) && t.name.includes(TEST_RUN_ID),
-    );
+    const isFullCleanup = FULL_CLEANUP === 'true';
     console.log(
-      `🧹 Found ${targets.length} autotest team(s) for run ${TEST_RUN_ID}`,
+      isFullCleanup
+        ? '🌍 Full cleanup mode — deleting ALL autotest teams...'
+        : `🌍 Cleaning autotest teams for run ${TEST_RUN_ID}...`,
+    );
+
+    const teamsRes = await api.get(API.GET_TEAMS);
+    const teams: Team[] = await teamsRes.json();
+
+    const targets = isFullCleanup
+      ? teams.filter((t) => !t.isDefault && AUTOTEST_REGEX.test(t.name))
+      : teams.filter(
+          (t) =>
+            !t.isDefault &&
+            AUTOTEST_REGEX.test(t.name) &&
+            t.name.includes(TEST_RUN_ID),
+        );
+
+    console.log(
+      isFullCleanup
+        ? `🧹 Found ${targets.length} autotest team(s) across all runs`
+        : `🧹 Found ${targets.length} autotest team(s) for run ${TEST_RUN_ID}`,
     );
 
     if (!targets.length) {
-      console.log(`✅ Nothing to clean up for run ${TEST_RUN_ID}`);
+      console.log('✅ Nothing to clean up');
       return;
     }
 

--- a/tests/global.teardown.ts
+++ b/tests/global.teardown.ts
@@ -2,85 +2,83 @@ import { request } from '@playwright/test';
 
 const AUTOTEST_REGEX = /autotest/i;
 const CONCURRENCY = 15;
+const MAX_RETRIES = 3;
+
+const API = {
+  LOGIN: '/api/rpc/command/login-with-password?_fmt=json',
+  GET_TEAMS: '/api/rpc/command/get-teams?_fmt=json',
+  DELETE_TEAM: '/api/rpc/command/delete-team?_fmt=json',
+} as const;
+
+interface Team {
+  id: string;
+  name: string;
+  isDefault: boolean;
+}
+
+async function deleteWithRetry(api: any, team: Team): Promise<boolean> {
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const res = await api.post(API.DELETE_TEAM, { data: { id: team.id } });
+      if (res.ok()) return true;
+    } catch {
+      // network hiccup — retry
+    }
+    if (attempt < MAX_RETRIES)
+      console.warn(`⚠️ Retry ${attempt}/${MAX_RETRIES} for "${team.name}"`);
+  }
+  return false;
+}
 
 export default async function globalTeardown() {
-  console.log('🌍 Cleaning autotest teams via API...');
+  const { BASE_URL, LOGIN_EMAIL, LOGIN_PWD, TEST_RUN_ID } = process.env;
+  if (!BASE_URL || !LOGIN_EMAIL || !LOGIN_PWD || !TEST_RUN_ID)
+    throw new Error(
+      'Missing env vars: BASE_URL, LOGIN_EMAIL, LOGIN_PWD, TEST_RUN_ID',
+    );
 
   const api = await request.newContext({
-    baseURL: process.env.BASE_URL?.replace(/\/$/, ''),
-    extraHTTPHeaders: {
-      'Content-Type': 'application/json',
-    },
+    baseURL: BASE_URL.replace(/\/$/, ''),
+    extraHTTPHeaders: { 'Content-Type': 'application/json' },
   });
 
   try {
-    // Login
-    const loginResponse = await api.post(
-      '/api/rpc/command/login-with-password?_fmt=json',
-      {
-        data: {
-          email: process.env.LOGIN_EMAIL,
-          password: process.env.LOGIN_PWD,
-        },
-      },
+    const loginRes = await api.post(API.LOGIN, {
+      data: { email: LOGIN_EMAIL, password: LOGIN_PWD },
+    });
+    if (!loginRes.ok()) throw new Error(`Login failed: ${loginRes.status()}`);
+    console.log('🌍 Cleaning autotest teams...');
+
+    const teams: Team[] = await (await api.get(API.GET_TEAMS)).json();
+    const targets = teams.filter(
+      (t) =>
+        !t.isDefault && AUTOTEST_REGEX.test(t.name) && t.name.includes(TEST_RUN_ID),
+    );
+    console.log(
+      `🧹 Found ${targets.length} autotest team(s) for run ${TEST_RUN_ID}`,
     );
 
-    if (!loginResponse.ok()) {
-      throw new Error(`Login failed: ${loginResponse.status()}`);
-    }
-
-    console.log('✅ Logged in via API');
-
-    // Fetch teams (GET request)
-    const teamsResponse = await api.get('/api/rpc/command/get-teams?_fmt=json');
-
-    if (!teamsResponse.ok()) {
-      throw new Error(`Failed fetching teams: ${teamsResponse.status()}`);
-    }
-
-    const teams = await teamsResponse.json();
-
-    const autotestTeams = teams.filter(
-      (team: any) => !team.isDefault && AUTOTEST_REGEX.test(team.name),
-    );
-
-    console.log(`🧹 Found ${autotestTeams.length} autotest teams`);
-
-    if (!autotestTeams.length) {
-      console.log('✅ Nothing to clean');
+    if (!targets.length) {
+      console.log(`✅ Nothing to clean up for run ${TEST_RUN_ID}`);
       return;
     }
 
-    // Delete with concurrency
-    const queue = [...autotestTeams];
+    const failed: string[] = [];
+    for (let i = 0; i < targets.length; i += CONCURRENCY) {
+      await Promise.all(
+        targets.slice(i, i + CONCURRENCY).map(async (team) => {
+          const ok = await deleteWithRetry(api, team);
+          ok ? console.log(`🗑️ Deleted "${team.name}"`) : failed.push(team.name);
+        }),
+      );
+    }
 
-    const workers = Array.from({ length: CONCURRENCY }).map(async () => {
-      while (queue.length) {
-        const team = queue.pop();
-        if (!team) return;
+    if (failed.length)
+      throw new Error(
+        `Failed to delete ${failed.length} team(s): ${failed.join(', ')}`,
+      );
 
-        try {
-          const res = await api.post('/api/rpc/command/delete-team?_fmt=json', {
-            data: { id: team.id },
-          });
-
-          if (!res.ok()) {
-            console.warn(`⚠️ Failed deleting ${team.name}`);
-            continue;
-          }
-
-          console.log(`🗑️ Deleted ${team.name}`);
-        } catch (err) {
-          console.warn(`⚠️ Error deleting ${team.name}`, err);
-        }
-      }
-    });
-
-    await Promise.all(workers);
-
-    console.log('✅ Global teardown complete');
-  } catch (error) {
-    console.error('❌ Global teardown failed:', error);
+    console.log('✅ Teardown complete');
   } finally {
     await api.dispose();
   }

--- a/tests/global.teardown.ts
+++ b/tests/global.teardown.ts
@@ -1,8 +1,11 @@
 import { request } from '@playwright/test';
+import type { APIRequestContext } from '@playwright/test';
+import { readFileSync, unlinkSync, existsSync } from 'fs';
 
 const AUTOTEST_REGEX = /^at-/;
 const CONCURRENCY = 15;
 const MAX_RETRIES = 3;
+const RUN_ID_FILE = '.test-run-id';
 
 const API = {
   LOGIN: '/api/rpc/command/login-with-password?_fmt=json',
@@ -16,7 +19,16 @@ interface Team {
   isDefault: boolean;
 }
 
-async function deleteWithRetry(api: any, team: Team): Promise<boolean> {
+/**
+ * Attempts to delete a team via the API, retrying up to MAX_RETRIES times
+ * on network failures or non-ok responses.
+ *
+ * @returns true if the team was deleted successfully, false if all attempts failed
+ */
+async function deleteWithRetry(
+  api: APIRequestContext,
+  team: Team,
+): Promise<boolean> {
   for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
     try {
       const res = await api.post(API.DELETE_TEAM, { data: { id: team.id } });
@@ -30,10 +42,67 @@ async function deleteWithRetry(api: any, team: Team): Promise<boolean> {
   return false;
 }
 
+/**
+ * Resolves the TEST_RUN_ID to use for scoped cleanup.
+ *
+ * Priority:
+ *  1. process.env.TEST_RUN_ID — set by CI or propagated from globalSetup
+ *  2. .test-run-id file — written by globalSetup as a fallback for
+ *     cases where env vars don't persist across Node processes (e.g. Playwright workers)
+ *
+ * @returns the run ID string, or undefined if neither source is available
+ */
+function resolveRunId(): string | undefined {
+  if (process.env.TEST_RUN_ID) return process.env.TEST_RUN_ID;
+  if (existsSync(RUN_ID_FILE)) return readFileSync(RUN_ID_FILE, 'utf-8').trim();
+  return undefined;
+}
+
+/**
+ * Filters the full list of teams down to those that should be deleted.
+ *
+ * Two modes:
+ *  - Full cleanup (FULL_CLEANUP=true): deletes all non-default teams matching
+ *    the `at-` prefix, regardless of run. Use for manual recovery or nightly CI jobs.
+ *  - Scoped cleanup (default): deletes only teams from the current run,
+ *    matched by both the `at-` prefix and the TEST_RUN_ID suffix.
+ */
+function resolveTargets(
+  teams: Team[],
+  isFullCleanup: boolean,
+  runId?: string,
+): Team[] {
+  if (isFullCleanup)
+    return teams.filter((t) => !t.isDefault && AUTOTEST_REGEX.test(t.name));
+
+  return teams.filter(
+    (t) =>
+      !t.isDefault &&
+      AUTOTEST_REGEX.test(t.name) &&
+      !!runId &&
+      t.name.includes(runId),
+  );
+}
+
+/**
+ * Global teardown — runs once after all Playwright tests complete.
+ *
+ * Deletes autotest teams created during the test run to keep the environment clean.
+ * Supports two cleanup modes controlled by env vars:
+ *
+ *  - Default: scoped to the current TEST_RUN_ID (safe for parallel CI runs)
+ *  - FULL_CLEANUP=true: deletes all `at-` prefixed teams across all runs
+ *
+ * Teams are deleted in parallel batches (CONCURRENCY) with per-team retry
+ * logic (MAX_RETRIES). Any teams that fail all retries are reported and
+ * cause the teardown to throw so the failure is visible in CI.
+ */
 export default async function globalTeardown() {
-  const { BASE_URL, LOGIN_EMAIL, LOGIN_PWD, TEST_RUN_ID, FULL_CLEANUP } =
-    process.env;
-  if (!BASE_URL || !LOGIN_EMAIL || !LOGIN_PWD || !TEST_RUN_ID)
+  const { BASE_URL, LOGIN_EMAIL, LOGIN_PWD, FULL_CLEANUP } = process.env;
+  const isFullCleanup = FULL_CLEANUP === 'true';
+  const TEST_RUN_ID = resolveRunId();
+
+  if (!BASE_URL || !LOGIN_EMAIL || !LOGIN_PWD || (!TEST_RUN_ID && !isFullCleanup))
     throw new Error(
       'Missing env vars: BASE_URL, LOGIN_EMAIL, LOGIN_PWD, TEST_RUN_ID',
     );
@@ -49,7 +118,6 @@ export default async function globalTeardown() {
     });
     if (!loginRes.ok()) throw new Error(`Login failed: ${loginRes.status()}`);
 
-    const isFullCleanup = FULL_CLEANUP === 'true';
     console.log(
       isFullCleanup
         ? '🌍 Full cleanup mode — deleting ALL autotest teams...'
@@ -57,16 +125,10 @@ export default async function globalTeardown() {
     );
 
     const teamsRes = await api.get(API.GET_TEAMS);
+    if (!teamsRes.ok()) throw new Error(`Get teams failed: ${teamsRes.status()}`);
     const teams: Team[] = await teamsRes.json();
 
-    const targets = isFullCleanup
-      ? teams.filter((t) => !t.isDefault && AUTOTEST_REGEX.test(t.name))
-      : teams.filter(
-          (t) =>
-            !t.isDefault &&
-            AUTOTEST_REGEX.test(t.name) &&
-            t.name.includes(TEST_RUN_ID),
-        );
+    const targets = resolveTargets(teams, isFullCleanup, TEST_RUN_ID);
 
     console.log(
       isFullCleanup
@@ -97,5 +159,7 @@ export default async function globalTeardown() {
     console.log('✅ Teardown complete');
   } finally {
     await api.dispose();
+    // Remove the run ID file to avoid stale fallback on subsequent runs
+    if (existsSync(RUN_ID_FILE)) unlinkSync(RUN_ID_FILE);
   }
 }

--- a/tests/tokens/token-group/token-group-options.spec.ts
+++ b/tests/tokens/token-group/token-group-options.spec.ts
@@ -36,11 +36,6 @@ mainTest.beforeEach(async ({ page, browserName }) => {
   await tokensPage.clickTokensTab();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe('Context menu > Delete', () => {
   mainTest.beforeEach(async () => {
     await tokensPage.clickTokensTab();

--- a/tests/tokens/token-group/token-group.spec.ts
+++ b/tests/tokens/token-group/token-group.spec.ts
@@ -35,11 +35,6 @@ mainTest.beforeEach(async ({ page, browserName }) => {
   await mainPage.clickMoveButton();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
   mainTest(
     qase([2728], 'Display token pill for single-segment token name'),


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/task/685

## Description

Refactors teardown strategy to improve reliability across local and CI environments.

## Solution

Run ID persistence
- Generates a unique `TEST_RUN_ID` per run using `randomUUID().slice(0, 8)`
- Persists the run ID to `.test-run-id` file as a fallback for teardown
- Respects `TEST_RUN_ID` if already injected by CI (e.g. GitHub Actions)

Updated cleanup logic
- Updated `AUTOTEST_REGEX` from `/autotest/i` to `/^at-/` to match new prefix
- Reads `TEST_RUN_ID` from `process.env` with fallback to `.test-run-id` file, fixing a latent bug where env vars set in setup don't persist to teardown in separate Node processes
- Added `FULL_CLEANUP=true` opt-in mode to delete all `at-` prefixed teams across all runs, useful for manual recovery after CI crashes
- Cleans up `.test-run-id` file after successful teardown

- Added `.test-run-id` to avoid committing ephemeral run state
- Deleted afterEach in tests/tokens/token-group/ spec files so I can test properly teams deletion for the specific run.

| Mode | Filter | When to use |
|---|---|---|
| Default | `at-` prefix + `TEST_RUN_ID` | After every run (`globalTeardown`) |
| `FULL_CLEANUP=true` | `at-` prefix only | Manual for local executions |

## How to test

- [ ] Check the code
- [ ] The tests run OK

## Testing in CI

**Default teardown by run:**

I have tested running two executions in parallel and each one has its own test ID:

<img width="354" height="304" alt="image" src="https://github.com/user-attachments/assets/bd0576b8-9d59-4be5-941f-29b376180f07" />

<img width="380" height="63" alt="image" src="https://github.com/user-attachments/assets/4be675c7-ea9e-4243-8fa1-71948f326320" />

**Manual teardown to delete all teams tested locally:**

<img width="478" height="474" alt="image" src="https://github.com/user-attachments/assets/497ce42d-59f4-4c8e-8f13-2d7b9699a1ba" />



