### PR TITLE
fix(onboarding): update onboarding modal locators and assertions

### DIFF
--- a/pages/dashboard/dashboard-page.js
+++ b/pages/dashboard/dashboard-page.js
@@ -197,6 +197,9 @@ exports.DashboardPage = class DashboardPage extends BasePage {
     this.noLibrariesText = page.getByText('No libraries yet.');
 
     // Onboarding Modal
+    this.onboardingModalContainer = page.locator(
+      '.main_ui_onboarding_questions__modal-container',
+    );
     this.onboardingContinueBtn = page.locator(
       'button[class="main_ui_onboarding_newsletter__accept-btn"]',
     );
@@ -939,6 +942,13 @@ exports.DashboardPage = class DashboardPage extends BasePage {
     );
   }
 
+  async isOnboardingModalNotVisible() {
+    await expect(
+      this.onboardingModalContainer,
+      `Onboarding modal should not be visible`,
+    ).not.toBeVisible();
+  }
+
   async clickOnLetsGoBtn() {
     await this.onboardingLetsGoBtn.click();
   }
@@ -1067,6 +1077,7 @@ exports.DashboardPage = class DashboardPage extends BasePage {
     await this.clickOnNextButton();
     await this.selectGetStartedQuestion('Prototyping');
     await this.clickOnStartButton();
+    await this.isOnboardingModalNotVisible();
   }
 
   async isOnboardingFirstQuestionsVisible() {

--- a/pages/dashboard/dashboard-page.js
+++ b/pages/dashboard/dashboard-page.js
@@ -237,7 +237,7 @@ exports.DashboardPage = class DashboardPage extends BasePage {
     );
     this.onboardingCreateTeamButton = page
       .getByRole('button')
-      .filter({ hasText: 'Create team & invite' });
+      .filter({ hasText: 'Create team' });
     this.selectedRadioButtonLabel = page
       .locator('label[class*="components_forms__radio-label checked"]')
       .first();
@@ -990,7 +990,6 @@ exports.DashboardPage = class DashboardPage extends BasePage {
   async clickOnStartButton() {
     await expect(this.startButton).not.toHaveAttribute('disabled');
     await this.startButton.click();
-    await expect(this.startButton).toBeHidden();
   }
 
   async fillSecondOnboardPage(branding, visual, wireframes) {
@@ -1064,8 +1063,7 @@ exports.DashboardPage = class DashboardPage extends BasePage {
     await this.clickOnNextButton();
     await this.selectFigmaTool();
     await this.clickOnNextButton();
-    await this.selectDropdownOptions('Testing before self-hosting');
-    await this.selectTeamSize('11-30');
+    await this.selectDropdownOptions('Just me');
     await this.clickOnNextButton();
     await this.selectGetStartedQuestion('Prototyping');
     await this.clickOnStartButton();


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/us/1356

## Description

Recent changes to the onboarding modal are preventing tests from continuing after creating a new account. This PR updates locators and assertion methods to fix the failing tests.

## Solution

- Refactored locators.
- Updated the onboarding modal method to select the "Just me" option in the company size dropdown.
- Added a new assertion to verify the onboarding modal is closed instead of checking whether the "Start" button is not visible.

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Test Execution Results in CI

**Note: failures non related to changes**

<img width="1009" height="922" alt="image" src="https://github.com/user-attachments/assets/6dc2b4d5-11ae-4819-9eaf-cbb063de1bde" />

<img width="1017" height="317" alt="image" src="https://github.com/user-attachments/assets/fc70fe20-b169-4a77-b395-1852f34a1eb1" />

