### PR TITLE
refactor(tests): remove delete teams from spec files

### DIFF
--- a/tests/action-menu/copy-link.spec.ts
+++ b/tests/action-menu/copy-link.spec.ts
@@ -42,10 +42,6 @@ mainTest.beforeEach(async ({ page, browserName }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
   mainTest(
     qase([2036], 'Share link of two Boards to a user from your team'),

--- a/tests/action-menu/copy-paste-properties.spec.ts
+++ b/tests/action-menu/copy-paste-properties.spec.ts
@@ -45,15 +45,7 @@ mainTest.beforeEach(async ({ page, browserName }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
-  mainTest.afterEach(async () => {
-    await mainPage.backToDashboardFromFileEditor();
-  });
-
   mainTest.describe(() => {
     mainTest.beforeEach(async () => {
       await mainPage.createDefaultRectangleByCoordinates(100, 100);

--- a/tests/action-menu/paste-replace.spec.ts
+++ b/tests/action-menu/paste-replace.spec.ts
@@ -30,11 +30,6 @@ mainTest.beforeEach(async ({ page, browserName }) => {
   await layersPanelPage.isLayerNameDisplayed('Ellipse');
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(qase([2940], 'Paste to Replace on single selected shape'), async () => {
   await mainTest.step('Select Rectangle and copy', async () => {
     await layersPanelPage.selectLayerByName('Rectangle');

--- a/tests/assets/assets-colors.spec.ts
+++ b/tests/assets/assets-colors.spec.ts
@@ -36,11 +36,6 @@ mainTest.beforeEach(async ({ page, browserName }) => {
   await mainPage.clickMoveButton();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(qase([932], 'Filter Colors from All Assets drop-down'), async () => {
   await mainTest.step('Open assets tab and filter by Colors', async () => {
     await assetsPanelPage.clickAssetsTab();

--- a/tests/assets/assets-shortcuts-panel.spec.ts
+++ b/tests/assets/assets-shortcuts-panel.spec.ts
@@ -25,11 +25,6 @@ mainTest.beforeEach(async ({ page, browserName }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(qase([1020], 'Open panel main menu - help&info'), async () => {
   await mainTest.step('Open shortcuts panel via main menu', async () => {
     await mainPage.clickMainMenuButton();

--- a/tests/assets/assets-typographies.spec.ts
+++ b/tests/assets/assets-typographies.spec.ts
@@ -25,11 +25,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(qase([947], 'Filter Typographies from All Assets drop-down'), async () => {
   await mainTest.step('Open assets tab and filter by Typographies', async () => {
     await assetsPanelPage.clickAssetsTab();

--- a/tests/assets/library-backup-page.spec.ts
+++ b/tests/assets/library-backup-page.spec.ts
@@ -61,8 +61,3 @@ mainTest.beforeEach(async ({ page }) => {
   await dashboardPage.openFileWithName('New File 2');
   await pagesPanelPage.isSecondPageNameDisplayed('Main components');
 });
-
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});

--- a/tests/assets/shared-libraries/shared-libraries.spec.ts
+++ b/tests/assets/shared-libraries/shared-libraries.spec.ts
@@ -37,10 +37,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
   const team1 = teamName;
   const team2 = teamName2;
@@ -78,11 +74,6 @@ mainTest.describe(() => {
     await dashboardPage.clickOnMoveButton();
     await teamPage.isTeamSelected(team2);
     await dashboardPage.isSharedLibraryIconDisplayed();
-  });
-
-  mainTest.afterEach(async () => {
-    await teamPage.page.waitForTimeout(1000);
-    await teamPage.deleteTeam(team2);
   });
 });
 
@@ -220,10 +211,6 @@ mainTest.describe(() => {
       );
     },
   );
-
-  mainTest.afterEach(async () => {
-    await mainPage.backToDashboardFromFileEditor();
-  });
 });
 
 mainTest.describe(() => {
@@ -320,10 +307,6 @@ mainTest.describe(() => {
       );
     },
   );
-
-  mainTest.afterEach(async () => {
-    await mainPage.backToDashboardFromFileEditor();
-  });
 });
 
 mainTest.describe(() => {

--- a/tests/color/color-picker.spec.ts
+++ b/tests/color/color-picker.spec.ts
@@ -32,11 +32,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.clickMoveButton();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(qase([1029], 'Open color picker from Stroke menu'), async () => {
   await mainTest.step('Create default closed path', async () => {
     await mainPage.createDefaultClosedPath();

--- a/tests/components/copy-components/delete-copy-components.spec.ts
+++ b/tests/components/copy-components/delete-copy-components.spec.ts
@@ -27,11 +27,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(qase(1496, 'Undo deleted component'), async ({ browserName }) => {
   await mainTest.step('Create rectangle and copy component', async () => {
     await mainPage.createDefaultRectangleByCoordinates(200, 300);

--- a/tests/components/main-components/component-grid-layout.spec.ts
+++ b/tests/components/main-components/component-grid-layout.spec.ts
@@ -38,11 +38,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
   mainTest.beforeEach(async () => {
     await mainTest.slow();

--- a/tests/components/main-components/context-menu/context-menu-options-annotations.spec.ts
+++ b/tests/components/main-components/context-menu/context-menu-options-annotations.spec.ts
@@ -31,11 +31,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
   let inspectPanelPage: InspectPanelPage;
 

--- a/tests/components/main-components/context-menu/context-menu-options.spec.ts
+++ b/tests/components/main-components/context-menu/context-menu-options.spec.ts
@@ -37,11 +37,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
   mainTest.beforeEach(async () => {
     await mainTest.slow();

--- a/tests/components/main-components/create-main-components.spec.ts
+++ b/tests/components/main-components/create-main-components.spec.ts
@@ -37,11 +37,6 @@ mainTest.beforeEach(async ({ page, browserName }) => {
   await mainPage.clickMoveButton();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(qase([1273], 'Create component shape'), async () => {
   await mainTest.step('Create rectangle and component', async () => {
     await mainPage.createDefaultRectangleByCoordinates(200, 300);

--- a/tests/components/main-components/delete-main-components.spec.ts
+++ b/tests/components/main-components/delete-main-components.spec.ts
@@ -27,11 +27,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(qase([1456], 'Delete component Assets tab'), async () => {
   await mainTest.step('Create rectangle component', async () => {
     await mainPage.createDefaultRectangleByCoordinates(200, 300);

--- a/tests/components/main-components/flex-layout-cases.spec.ts
+++ b/tests/components/main-components/flex-layout-cases.spec.ts
@@ -24,11 +24,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
   mainTest.beforeEach(
     'Add a flex layout board, rectangle and ellipse components',

--- a/tests/components/main-components/update-main-components.spec.ts
+++ b/tests/components/main-components/update-main-components.spec.ts
@@ -34,11 +34,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(qase([1275], 'Update main component'), async () => {
   await mainTest.step('Create rectangle component and duplicate it', async () => {
     await mainPage.createDefaultRectangleByCoordinates(200, 300);

--- a/tests/components/variants/add-remove-variants.spec.ts
+++ b/tests/components/variants/add-remove-variants.spec.ts
@@ -39,11 +39,6 @@ mainTest.beforeEach(async ({ page, browserName }) => {
   await mainPage.waitForChangeIsSaved();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(qase([2398], 'Add Variant to a component on the canvas'), async () => {
   await mainPage.clickViewportTwice();
   await mainPage.createDefaultRectangleByCoordinates(600, 300);

--- a/tests/components/variants/connection-with-child-components.spec.js
+++ b/tests/components/variants/connection-with-child-components.spec.js
@@ -30,11 +30,6 @@ mainTest.beforeEach(async ({ page }) => {
   await teamPage.createTeam(teamName);
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(
   qase(
     [2430],

--- a/tests/components/variants/variants-creation.spec.ts
+++ b/tests/components/variants/variants-creation.spec.ts
@@ -37,11 +37,6 @@ mainTest.beforeEach(async ({ page, browserName }) => {
   await mainPage.clickMoveButton();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(qase([2440], 'Create variants by design panel'), async () => {
   await mainPage.createDefaultRectangleByCoordinates(200, 300);
   await mainPage.createComponentViaRightClick();

--- a/tests/components/variants/variants-property.spec.ts
+++ b/tests/components/variants/variants-property.spec.ts
@@ -34,11 +34,6 @@ mainTest.beforeEach(async ({ page }) => {
   await teamPage.createTeam(teamName);
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(
   qase(
     [2441],

--- a/tests/composition/composition-board.spec.ts
+++ b/tests/composition/composition-board.spec.ts
@@ -32,11 +32,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.clickMoveButton();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(qase([216], 'Change color background'), async () => {
   await designPanelPage.clickCanvasBackgroundColorIcon();
   await colorPalettePage.setHex('#304d6a');

--- a/tests/composition/composition-comments.spec.js
+++ b/tests/composition/composition-comments.spec.js
@@ -44,11 +44,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
   mainTest.beforeEach(async () => {
     const commentText = 'Test Comment';

--- a/tests/composition/composition-curve.spec.js
+++ b/tests/composition/composition-curve.spec.js
@@ -23,11 +23,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
   mainTest(qase([483], 'Create curve line (Toolbar)'), async () => {
     await mainPage.clickCreateCurveButton();

--- a/tests/composition/composition-ellipse.spec.js
+++ b/tests/composition/composition-ellipse.spec.js
@@ -32,11 +32,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(qase([328], 'Create Ellipse (Shortcut E)'), async () => {
   await mainTest.step(
     'Press E shortcut and verify ellipse tool is active',

--- a/tests/composition/composition-flex-layout.spec.ts
+++ b/tests/composition/composition-flex-layout.spec.ts
@@ -28,11 +28,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
   mainTest.beforeEach(async () => {
     await mainPage.createDefaultBoardByCoordinates(200, 300);

--- a/tests/composition/composition-grid-layout.spec.js
+++ b/tests/composition/composition-grid-layout.spec.js
@@ -39,13 +39,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async ({ page }) => {
-  const teamPage = new TeamPage(page);
-  const mainPage = new MainPage(page);
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
   mainTest.beforeEach(async () => {
     await mainPage.createDefaultBoardByCoordinates(200, 300);

--- a/tests/composition/composition-path-node-panel.spec.js
+++ b/tests/composition/composition-path-node-panel.spec.js
@@ -21,11 +21,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
   mainTest.beforeEach(async () => {
     await mainPage.clickCreateEllipseButton();

--- a/tests/composition/composition-path.spec.js
+++ b/tests/composition/composition-path.spec.js
@@ -32,11 +32,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(qase([487], 'Create Path (Toolbar) - closed'), async () => {
   await mainPage.createDefaultClosedPath();
   await mainPage.isCreatedLayerVisible();

--- a/tests/composition/composition-rectangle.spec.js
+++ b/tests/composition/composition-rectangle.spec.js
@@ -32,11 +32,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(qase([275], 'Create Rectangle (Shortcut R)'), async () => {
   await mainTest.step(
     'Press R shortcut and verify rectangle tool is active',

--- a/tests/composition/image/image-composition.spec.ts
+++ b/tests/composition/image/image-composition.spec.ts
@@ -32,11 +32,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.clickMoveButton();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe('PNG image', () => {
   mainTest.beforeEach(async () => {
     await mainPage.uploadImage('images/images.png');

--- a/tests/composition/image/image-import.spec.ts
+++ b/tests/composition/image/image-import.spec.ts
@@ -28,11 +28,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.clickMoveButton();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(
   qase(
     [2286],

--- a/tests/composition/image/image-options.spec.ts
+++ b/tests/composition/image/image-options.spec.ts
@@ -29,11 +29,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.clickMoveButton();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe('PNG image', () => {
   mainTest.beforeEach(async () => {
     await mainPage.uploadImage('images/images.png');

--- a/tests/composition/text/composition-text.spec.ts
+++ b/tests/composition/text/composition-text.spec.ts
@@ -31,11 +31,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
   mainTest.beforeEach(async () => {
     await mainPage.createDefaultTextLayer();

--- a/tests/composition/text/text-creation.spec.ts
+++ b/tests/composition/text/text-creation.spec.ts
@@ -22,11 +22,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(qase([377], 'Create Text(Toolbar)'), async () => {
   await mainPage.createDefaultTextLayer();
   await mainPage.isCreatedLayerVisible();

--- a/tests/composition/text/text-options.spec.ts
+++ b/tests/composition/text/text-options.spec.ts
@@ -25,11 +25,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
   mainTest.beforeEach(async () => {
     await mainPage.createDefaultTextLayer();

--- a/tests/composition/text/text-search.spec.ts
+++ b/tests/composition/text/text-search.spec.ts
@@ -27,11 +27,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
   mainTest.beforeEach(async () => {
     await mainPage.createDefaultTextLayer();

--- a/tests/dashboard/dashboard-files.spec.ts
+++ b/tests/dashboard/dashboard-files.spec.ts
@@ -22,10 +22,6 @@ mainTest.beforeEach(async ({ page }) => {
   await dashboardPage.hideLibrariesAndTemplatesCarrousel();
 });
 
-mainTest.afterEach(async () => {
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe('Drafts management', () => {
   mainTest(
     qase(

--- a/tests/dashboard/dashboard-fonts.spec.js
+++ b/tests/dashboard/dashboard-fonts.spec.js
@@ -16,10 +16,6 @@ mainTest.beforeEach(async ({ page }) => {
   await teamPage.isTeamSelected(teamName);
 });
 
-mainTest.afterEach(async () => {
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(qase(1152, 'DA-66 Upload single font'), async () => {
   await dashboardPage.openSidebarItem('Fonts');
   await dashboardPage.uploadFont('fonts/Pacifico.ttf');

--- a/tests/dashboard/dashboard-import.spec.ts
+++ b/tests/dashboard/dashboard-import.spec.ts
@@ -22,10 +22,6 @@ mainTest.beforeEach(async ({ page }) => {
   await dashboardPage.hideLibrariesAndTemplatesCarrousel();
 });
 
-mainTest.afterEach(async () => {
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(qase(71, 'Import file to Drafts .penpot'), async () => {
   await dashboardPage.openSidebarItem('Drafts');
   await dashboardPage.importFileFromProjectPage('documents/QA test file v1.penpot');

--- a/tests/dashboard/dashboard-libraries.spec.ts
+++ b/tests/dashboard/dashboard-libraries.spec.ts
@@ -36,10 +36,6 @@ mainTest.beforeEach(async ({ page }) => {
   await dashboardPage.hideLibrariesAndTemplatesCarrousel();
 });
 
-mainTest.afterEach(async () => {
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
   mainTest.beforeEach(async () => {
     await dashboardPage.createFileViaPlaceholder();

--- a/tests/dashboard/dashboard-search.spec.ts
+++ b/tests/dashboard/dashboard-search.spec.ts
@@ -22,10 +22,6 @@ mainTest.beforeEach(async ({ page }) => {
   await dashboardPage.hideLibrariesAndTemplatesCarrousel();
 });
 
-mainTest.afterEach(async () => {
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(qase(1148, 'Search file from Drafts'), async () => {
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.clickPencilBoxButton();

--- a/tests/dashboard/teams/teams-invitations.spec.ts
+++ b/tests/dashboard/teams/teams-invitations.spec.ts
@@ -247,20 +247,6 @@ mainTest.describe(
         );
       },
     );
-
-    mainTest.afterEach(
-      `Logout, login with main account, switch to to "${team}" and delete it`,
-      async () => {
-        await profilePage.logout();
-        await loginPage.isLoginPageOpened();
-        await loginPage.enterEmailAndClickOnContinue(process.env.LOGIN_EMAIL);
-        await loginPage.enterPwd(process.env.LOGIN_PWD);
-        await loginPage.clickLoginButton();
-        await dashboardPage.isDashboardOpenedAfterLogin();
-        await teamPage.switchTeam(team);
-        await teamPage.deleteTeam(team);
-      },
-    );
   },
 );
 

--- a/tests/dashboard/teams/teams-permissions.spec.js
+++ b/tests/dashboard/teams/teams-permissions.spec.js
@@ -763,18 +763,4 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       );
     },
   );
-
-  mainTest.afterEach(
-    `Logout, login with main account, switch team and delete`,
-    async () => {
-      await profilePage.logout();
-      await loginPage.isLoginPageOpened();
-      await loginPage.enterEmailAndClickOnContinue(process.env.LOGIN_EMAIL);
-      await loginPage.enterPwd(process.env.LOGIN_PWD);
-      await loginPage.clickLoginButton();
-      await dashboardPage.isDashboardOpenedAfterLogin();
-      await teamPage.switchTeam(team);
-      await teamPage.deleteTeam(team);
-    },
-  );
 });

--- a/tests/dashboard/trash/dashboard-trash.spec.ts
+++ b/tests/dashboard/trash/dashboard-trash.spec.ts
@@ -36,10 +36,6 @@ mainTest.describe('As Owner', () => {
     await dashboardPage.hideLibrariesAndTemplatesCarrousel();
   });
 
-  mainTest.afterEach(async () => {
-    await teamPage.deleteTeam(teamName);
-  });
-
   mainTest(
     qase(
       [2692, 2709, 2687],

--- a/tests/panels-features/history/panels-features-history-panel.spec.ts
+++ b/tests/panels-features/history/panels-features-history-panel.spec.ts
@@ -32,11 +32,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(qase(874, 'Check if the status at header is "Saved"'), async () => {
   await mainPage.clickCreateEllipseButton();
   await mainPage.clickViewportTwice();

--- a/tests/panels-features/history/panels-features-history-preview-version.spec.ts
+++ b/tests/panels-features/history/panels-features-history-preview-version.spec.ts
@@ -28,11 +28,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(
   qase(
     [2901, 2903, 2904],

--- a/tests/panels-features/main-menu/panels-features-main-menu-edit.spec.ts
+++ b/tests/panels-features/main-menu/panels-features-main-menu-edit.spec.ts
@@ -32,11 +32,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.openFindAndReplaceViaShortcut();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(qase(2882, 'Replace All updates text content on canvas'), async () => {
   const contentText = 'Test';
   const replaceContentText = 'Bar';

--- a/tests/panels-features/main-menu/panels-features-main-menu-file.spec.ts
+++ b/tests/panels-features/main-menu/panels-features-main-menu-file.spec.ts
@@ -25,11 +25,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.clickMoveButton();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(qase(1911, 'Download Penpot file (.penpot)'), async () => {
   await mainPage.clickMainMenuButton();
   await mainPage.clickFileMainMenuItem();

--- a/tests/panels-features/main-menu/panels-features-main-menu-view.spec.ts
+++ b/tests/panels-features/main-menu/panels-features-main-menu-view.spec.ts
@@ -32,11 +32,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.clickMoveButton();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(
   qase(817, "Hide/show grids via shortcut CTRL '"),
   async ({ browserName }) => {

--- a/tests/panels-features/panels-features-export.spec.ts
+++ b/tests/panels-features/panels-features-export.spec.ts
@@ -24,11 +24,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(qase(897, 'Add export setting via design panel'), async () => {
   await mainPage.clickCreateRectangleButton();
   await mainPage.clickViewportTwice();

--- a/tests/panels-features/panels-features-fill.spec.js
+++ b/tests/panels-features/panels-features-fill.spec.js
@@ -25,11 +25,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
   mainTest.beforeEach(async () => {
     await mainPage.clickCreateBoardButton();

--- a/tests/panels-features/panels-features-grid.spec.js
+++ b/tests/panels-features/panels-features-grid.spec.js
@@ -23,11 +23,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
   mainTest.beforeEach(async () => {
     await mainPage.clickCreateBoardButton();

--- a/tests/panels-features/panels-features-inspect.spec.ts
+++ b/tests/panels-features/panels-features-inspect.spec.ts
@@ -46,11 +46,6 @@ mainTest.beforeEach(
   },
 );
 
-mainTest.afterEach('Delete team', async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(qase(2654, 'Computed panel - Shows raw property values'), async () => {
   const colorToken: MainToken<TokenClass> = {
     class: TokenClass.Color,

--- a/tests/panels-features/panels-features-pages.spec.ts
+++ b/tests/panels-features/panels-features-pages.spec.ts
@@ -38,11 +38,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(qase(832, 'Create new page'), async () => {
   await mainTest.step('Add a new page', async () => {
     await pagesPanelPage.clickAddPageButton();

--- a/tests/panels-features/panels-features-prototype.spec.js
+++ b/tests/panels-features/panels-features-prototype.spec.js
@@ -26,11 +26,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
   mainTest.beforeEach(async () => {
     await mainPage.createDefaultBoardByCoordinates(900, 100);

--- a/tests/panels-features/panels-features-zoom.spec.js
+++ b/tests/panels-features/panels-features-zoom.spec.js
@@ -22,11 +22,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.clickMoveButton();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(qase(850, 'Zoom via top right menu'), async ({ page }) => {
   await mainPage.increaseZoom(1);
   await mainPage.clickViewportOnce();

--- a/tests/plugins/plugins.spec.js
+++ b/tests/plugins/plugins.spec.js
@@ -20,11 +20,6 @@ mainTest.beforeEach(async ({ page }) => {
   await pluginsPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await pluginsPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(
   qase([1837, 1838, 1839, 1842, 1844], 'Install, open and delete a plugin'),
   async () => {

--- a/tests/tokens/export.spec.ts
+++ b/tests/tokens/export.spec.ts
@@ -29,11 +29,6 @@ mainTest.beforeEach(async ({ page }) => {
   await tokensPage.toolsComp.clickOnTokenToolsButton();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(
   qase(2266, 'Export tokens multi-file folder (no token, set or theme)'),
   async () => {

--- a/tests/tokens/import.spec.ts
+++ b/tests/tokens/import.spec.ts
@@ -35,11 +35,6 @@ mainTest.beforeEach(async ({ page }) => {
   await dashboardPage.isHeaderDisplayed('Projects');
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(qase(2213, 'Import tokens'), async () => {
   await mainTest.step('Import tokens JSON file', async () => {
     await dashboardPage.createFileViaPlaceholder();

--- a/tests/tokens/object-specific.spec.ts
+++ b/tests/tokens/object-specific.spec.ts
@@ -22,11 +22,6 @@ mainTest.beforeEach(async ({ page }) => {
   await dashboardPage.isHeaderDisplayed('Projects');
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
   let mainPage: MainPage;
   let dashboardPage: DashboardPage;

--- a/tests/tokens/rename-and-remap.spec.ts
+++ b/tests/tokens/rename-and-remap.spec.ts
@@ -34,11 +34,6 @@ mainTest.beforeEach(async ({ page }) => {
   await dashboardPage.isHeaderDisplayed('Projects');
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
   mainTest.beforeEach(async () => {
     await dashboardPage.createFileViaPlaceholder();

--- a/tests/tokens/sets.spec.ts
+++ b/tests/tokens/sets.spec.ts
@@ -32,11 +32,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.clickMoveButton();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(qase(2102, 'Create a set via "create one" link'), async () => {
   const name = 'Mobile';
 

--- a/tests/tokens/themes.spec.ts
+++ b/tests/tokens/themes.spec.ts
@@ -33,11 +33,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.clickMoveButton();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(qase(2167, 'Create theme via "create one" link'), async () => {
   await mainTest.step('Open Tokens panel', async () => {
     await tokensPage.clickTokensTab();

--- a/tests/tokens/token-types/border-radius-token.spec.ts
+++ b/tests/tokens/token-types/border-radius-token.spec.ts
@@ -30,11 +30,6 @@ mainTest.beforeEach(async ({ page, browserName }) => {
   await mainPage.clickMoveButton();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
   let tokensPage: TokensPage;
   let mainPage: MainPage;

--- a/tests/tokens/token-types/color-token.spec.ts
+++ b/tests/tokens/token-types/color-token.spec.ts
@@ -36,11 +36,6 @@ mainTest.beforeEach(
   },
 );
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
   let mainPage: MainPage;
   let tokensPage: TokensPage;

--- a/tests/tokens/token-types/dimensions-token.spec.ts
+++ b/tests/tokens/token-types/dimensions-token.spec.ts
@@ -33,11 +33,6 @@ mainTest.beforeEach(async ({ page, browserName }) => {
   await mainPage.clickMoveButton();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(
   qase(2218, 'Apply "X/Y axis" dimension token to a text (by right click)'),
   async () => {

--- a/tests/tokens/token-types/font-size-token.spec.ts
+++ b/tests/tokens/token-types/font-size-token.spec.ts
@@ -42,11 +42,6 @@ mainTest.beforeEach(async ({ page, browserName }) => {
   await mainPage.clickMoveButton();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
   let mainPage: MainPage;
   let tokensPage: TokensPage;

--- a/tests/tokens/token-types/font-weight-token.spec.ts
+++ b/tests/tokens/token-types/font-weight-token.spec.ts
@@ -30,11 +30,6 @@ mainTest.beforeEach(async ({ page, browserName }) => {
   await mainPage.clickMoveButton();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
   let mainPage: MainPage;
   let tokensPage: TokensPage;

--- a/tests/tokens/token-types/letter-spacing-token.spec.ts
+++ b/tests/tokens/token-types/letter-spacing-token.spec.ts
@@ -32,11 +32,6 @@ mainTest.beforeEach(async ({ page, browserName }) => {
   await mainPage.clickMoveButton();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
   let mainPage: MainPage;
   let tokensPage: TokensPage;

--- a/tests/tokens/token-types/number-token.spec.ts
+++ b/tests/tokens/token-types/number-token.spec.ts
@@ -33,11 +33,6 @@ mainTest.beforeEach(async ({ page, browserName }) => {
   await mainPage.clickMoveButton();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(
   qase(
     2485,

--- a/tests/tokens/token-types/opacity-token.spec.ts
+++ b/tests/tokens/token-types/opacity-token.spec.ts
@@ -31,11 +31,6 @@ mainTest.beforeEach(async ({ page, browserName }) => {
   await mainPage.clickMoveButton();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(
   qase(2172, 'Apply default "opacity" token to an image (by left click)'),
   async () => {

--- a/tests/tokens/token-types/rotation-token.spec.ts
+++ b/tests/tokens/token-types/rotation-token.spec.ts
@@ -34,11 +34,6 @@ mainTest.beforeEach(async ({ page, browserName }) => {
   await mainPage.clickMoveButton();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(
   qase(2175, 'Apply default "rotation" token to a text (by left click)'),
   async ({ browserName }) => {

--- a/tests/tokens/token-types/shadow-token.spec.ts
+++ b/tests/tokens/token-types/shadow-token.spec.ts
@@ -35,11 +35,6 @@ mainTest.beforeEach('Create a team and a file', async ({ page, browserName }) =>
   await mainPage.clickMoveButton();
 });
 
-mainTest.afterEach('Back to Dashboard and delete team created', async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
   mainTest.beforeEach(
     'Create a rectangle and click on Tokens tab',

--- a/tests/tokens/token-types/spacing-token.spec.ts
+++ b/tests/tokens/token-types/spacing-token.spec.ts
@@ -34,11 +34,6 @@ mainTest.beforeEach(async ({ page, browserName }) => {
   await mainPage.clickMoveButton();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(
   qase(2202, 'Apply default "all gaps" token to a grid board (by left click)'),
   async () => {

--- a/tests/tokens/token-types/stroke-width-token.spec.ts
+++ b/tests/tokens/token-types/stroke-width-token.spec.ts
@@ -34,11 +34,6 @@ mainTest.beforeEach(async ({ page, browserName }) => {
   await mainPage.clickMoveButton();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(
   qase(2215, 'Apply default "stroke width" token to a path (by left click)'),
   async () => {

--- a/tests/tokens/token-types/text-case-token.spec.ts
+++ b/tests/tokens/token-types/text-case-token.spec.ts
@@ -36,11 +36,6 @@ mainTest.beforeEach(async ({ page, browserName }) => {
   await mainPage.clickMoveButton();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(
   qase(2522, 'Apply a capitalize text case token to a uppercase text layer'),
   async () => {

--- a/tests/tokens/token-types/text-decoration-token.spec.ts
+++ b/tests/tokens/token-types/text-decoration-token.spec.ts
@@ -31,11 +31,6 @@ mainTest.beforeEach(async ({ page }) => {
   await mainPage.clickMoveButton();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
   const decorationToken: MainToken<TokenClass> = {
     class: TokenClass.TextDecoration,

--- a/tests/tokens/token-types/typography-tokens.spec.ts
+++ b/tests/tokens/token-types/typography-tokens.spec.ts
@@ -33,11 +33,6 @@ mainTest.beforeEach(async ({ page, browserName }) => {
   await mainPage.clickMoveButton();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
   let mainPage: MainPage;
   let tokensPage: TokensPage;

--- a/tests/tokens/tokens-in-design-tab.spec.ts
+++ b/tests/tokens/tokens-in-design-tab.spec.ts
@@ -32,11 +32,6 @@ mainTest.beforeEach(async ({ page }) => {
   await dashboardPage.isHeaderDisplayed('Projects');
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
   mainTest.beforeEach(async () => {
     await dashboardPage.createFileViaPlaceholder();

--- a/tests/tokens/tokens-management.spec.ts
+++ b/tests/tokens/tokens-management.spec.ts
@@ -33,11 +33,6 @@ mainTest.beforeEach(async ({ page, browserName }) => {
   await mainPage.clickMoveButton();
 });
 
-mainTest.afterEach(async () => {
-  await mainPage.backToDashboardFromFileEditor();
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest(
   qase(2224, 'Apply 2 different kind of tokens overriding the same shape property'),
   async () => {

--- a/tests/view-mode/view-mode.spec.js
+++ b/tests/view-mode/view-mode.spec.js
@@ -62,15 +62,7 @@ mainTest.beforeEach(async ({ page, browserName }) => {
   await mainPage.isMainPageLoaded();
 });
 
-mainTest.afterEach(async () => {
-  await teamPage.deleteTeam(teamName);
-});
-
 mainTest.describe(() => {
-  mainTest.afterEach(async () => {
-    await mainPage.backToDashboardFromFileEditor();
-  });
-
   mainTest(
     qase([685], 'Click view mode (From right top click) - no boards created'),
     async () => {


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/us/1377

## Description

Remove delete teams from each spec file and delegate in teardown.

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Test Execution Results in CI

**Failed tests non related to changes**

<img width="1021" height="543" alt="image" src="https://github.com/user-attachments/assets/4bca8874-2a4b-48a0-a73e-b62d2c640d2e" />

