### PR TITLE
feat(mcp): add new automated test for mcp from toolbar

### DIFF
--- a/pages/dashboard/dashboard-page.js
+++ b/pages/dashboard/dashboard-page.js
@@ -235,9 +235,7 @@ exports.DashboardPage = class DashboardPage extends BasePage {
     this.onboardingContinueCreateTeamBtn = page
       .getByRole('button')
       .filter({ hasText: 'Create team' });
-    this.onboardingContinueWithoutTeamBtn = page
-      .getByRole('button')
-      .filter({ hasText: 'Continue without team' });
+    this.onboardingContinueWithoutTeamBtn = page.getByText('Continue without team');
     this.onboardingInviteInput = page.locator(
       'input[class*="components_forms__inside-input"]',
     );

--- a/pages/profile-page.js
+++ b/pages/profile-page.js
@@ -564,7 +564,7 @@ exports.ProfilePage = class ProfilePage extends BasePage {
    * Waits for the profile-props POST that specifically toggles mcp-enabled
    * to the expected boolean value. Whitespace/quoting-tolerant match.
    */
-  _waitForMCPPropsUpdate(expectedValue) {
+  waitForMCPPropsUpdate(expectedValue) {
     const pattern = new RegExp(`~?:?mcp-enabled["']?\\s*:\\s*${expectedValue}`);
 
     return this.page.waitForResponse((res) => {
@@ -591,7 +591,7 @@ exports.ProfilePage = class ProfilePage extends BasePage {
     await expect(this.disableMCPWithKeyStatusSwitch).toBeVisible();
 
     await Promise.all([
-      this._waitForMCPPropsUpdate(true),
+      this.waitForMCPPropsUpdate(true),
       this.disableMCPWithKeyStatusSwitch.click(),
     ]);
   }
@@ -607,7 +607,7 @@ exports.ProfilePage = class ProfilePage extends BasePage {
     await expect(this.enableMCPStatusSwitch).toBeVisible();
 
     await Promise.all([
-      this._waitForMCPPropsUpdate(false),
+      this.waitForMCPPropsUpdate(false),
       this.enableMCPStatusSwitch.click(),
     ]);
   }

--- a/pages/profile-page.js
+++ b/pages/profile-page.js
@@ -533,17 +533,17 @@ exports.ProfilePage = class ProfilePage extends BasePage {
   }
 
   async disableMCPServer() {
-    await expect(this.enableMCPStatusSwitch).toBeVisible();
+    await this.enableMCPStatusSwitch.waitFor({ state: 'visible' });
     await this.disableMCPfromToggleSwitch();
     await expect(this.MCPServerDisabledMessage).toBeVisible();
-    await expect(this.disableMCPWithKeyStatusSwitch).toBeVisible();
+    await this.disableMCPWithKeyStatusSwitch.waitFor({ state: 'visible' });
   }
 
   async enableMCPServerWithKey() {
-    await expect(this.disableMCPWithKeyStatusSwitch).toBeVisible();
+    await this.disableMCPWithKeyStatusSwitch.waitFor({ state: 'visible' });
     await this.enableMCPfromToggleSwitch();
     await expect(this.MCPServerEnabledMessage).toBeVisible();
-    await expect(this.enableMCPStatusSwitch).toBeVisible();
+    await this.enableMCPStatusSwitch.waitFor({ state: 'visible' });
   }
 
   async deleteMCPKey() {

--- a/pages/profile-page.js
+++ b/pages/profile-page.js
@@ -534,14 +534,14 @@ exports.ProfilePage = class ProfilePage extends BasePage {
 
   async disableMCPServer() {
     await expect(this.enableMCPStatusSwitch).toBeVisible();
-    await this.enableMCPStatusSwitch.click();
+    await this.disableMCPfromToggleSwitch();
     await expect(this.MCPServerDisabledMessage).toBeVisible();
     await expect(this.disableMCPWithKeyStatusSwitch).toBeVisible();
   }
 
   async enableMCPServerWithKey() {
     await expect(this.disableMCPWithKeyStatusSwitch).toBeVisible();
-    await this.disableMCPWithKeyStatusSwitch.click();
+    await this.enableMCPfromToggleSwitch();
     await expect(this.MCPServerEnabledMessage).toBeVisible();
     await expect(this.enableMCPStatusSwitch).toBeVisible();
   }
@@ -558,5 +558,57 @@ exports.ProfilePage = class ProfilePage extends BasePage {
     await expect(this.integrationsHeader).toBeVisible();
     await expect(this.MCPKey).not.toBeVisible();
     await expect(this.disableMCPWithoutKeyStatusSwitch).toBeVisible();
+  }
+
+  /**
+   * Waits for the profile-props POST that specifically toggles mcp-enabled
+   * to the expected boolean value. Whitespace/quoting-tolerant match.
+   */
+  _waitForMCPPropsUpdate(expectedValue) {
+    const pattern = new RegExp(`~?:?mcp-enabled["']?\\s*:\\s*${expectedValue}`);
+
+    return this.page.waitForResponse((res) => {
+      if (
+        !res.url().includes('/api/main/methods/update-profile-props') ||
+        res.request().method() !== 'POST'
+      ) {
+        return false;
+      }
+
+      const postData = res.request().postData() || '';
+      return pattern.test(postData);
+    });
+  }
+
+  /**
+   * Ensures MCP ends up ON. No-ops if already on.
+   */
+  async enableMCPfromToggleSwitch() {
+    if (await this.enableMCPStatusSwitch.isVisible()) {
+      return;
+    }
+
+    await expect(this.disableMCPWithKeyStatusSwitch).toBeVisible();
+
+    await Promise.all([
+      this._waitForMCPPropsUpdate(true),
+      this.disableMCPWithKeyStatusSwitch.click(),
+    ]);
+  }
+
+  /**
+   * Ensures MCP ends up OFF. No-ops if already off.
+   */
+  async disableMCPfromToggleSwitch() {
+    if (await this.disableMCPWithKeyStatusSwitch.isVisible()) {
+      return;
+    }
+
+    await expect(this.enableMCPStatusSwitch).toBeVisible();
+
+    await Promise.all([
+      this._waitForMCPPropsUpdate(false),
+      this.enableMCPStatusSwitch.click(),
+    ]);
   }
 };

--- a/pages/workspace/main-page.js
+++ b/pages/workspace/main-page.js
@@ -18,6 +18,9 @@ exports.MainPage = class MainPage extends BasePage {
     this.uploadImageSelector = page.locator('#image-upload');
     this.createCurveButton = page.getByTestId('curve-btn');
     this.createPathButton = page.getByTestId('path-btn');
+    this.MCPButton = page.getByRole('button', { name: 'MCP' });
+    this.connectHereMCPButton = page.getByRole('menuitem', { name: 'Connect here' });
+    this.connectedMCPButton = page.getByText('MCP connected');
     this.colorsPaletteButton = page.locator('button[title^="Color Palette"]');
     this.mainToolBar = page.locator(
       '[class*="main-toolbar"] button[class*="toolbar-handler"]',
@@ -1268,5 +1271,21 @@ exports.MainPage = class MainPage extends BasePage {
 
   async openFindAndReplaceViaShortcut() {
     await this.page.keyboard.press('Control+H');
+  }
+
+  async clickMCPButtonFromToolbar() {
+    await this.MCPButton.click();
+  }
+
+  async connectMCPButtonFromToolbar() {
+    await this.clickMCPButtonFromToolbar();
+    await this.connectHereMCPButton.click();
+  }
+
+  async isMCPConnectedButtonVisible() {
+    await expect(
+      this.connectedMCPButton,
+      `MCP Connected button is visible`,
+    ).toBeVisible();
   }
 };

--- a/pages/workspace/main-page.js
+++ b/pages/workspace/main-page.js
@@ -1283,9 +1283,6 @@ exports.MainPage = class MainPage extends BasePage {
   }
 
   async isMCPConnectedButtonVisible() {
-    await expect(
-      this.connectedMCPButton,
-      `MCP Connected button is visible`,
-    ).toBeVisible();
+    await this.connectedMCPButton.waitFor({ state: 'visible' });
   }
 };

--- a/pages/workspace/main-page.js
+++ b/pages/workspace/main-page.js
@@ -1283,6 +1283,6 @@ exports.MainPage = class MainPage extends BasePage {
   }
 
   async isMCPConnectedButtonVisible() {
-    await this.connectedMCPButton.waitFor({ state: 'visible' });
+    await this.connectedMCPButton.waitFor({ state: 'visible', timeout: 30000 });
   }
 };

--- a/pages/workspace/main-page.js
+++ b/pages/workspace/main-page.js
@@ -1283,6 +1283,6 @@ exports.MainPage = class MainPage extends BasePage {
   }
 
   async isMCPConnectedButtonVisible() {
-    await this.connectedMCPButton.waitFor({ state: 'visible', timeout: 30000 });
+    await this.connectedMCPButton.waitFor({ state: 'visible', timeout: 60000 });
   }
 };

--- a/tests/your-account/integrations/mcp-server.spec.ts
+++ b/tests/your-account/integrations/mcp-server.spec.ts
@@ -14,7 +14,7 @@ integrationsTest.beforeEach(async ({ page }) => {
 
 integrationsTest(
   qase(
-    [2771, 2770, 2775, 2782, 2783, 2784, 2787, 2791],
+    [2771, 2770, 2775, 2782, 2783, 2784, 2787, 2791, 3065],
     'Enable MCP generating key, disable MCP, enable MCP with an existing key and delete key',
   ),
   async ({ profilePage }: { profilePage: ProfilePage }) => {

--- a/tests/your-account/integrations/mcp-server.spec.ts
+++ b/tests/your-account/integrations/mcp-server.spec.ts
@@ -133,6 +133,33 @@ integrationsTest(
       },
     );
 
+    await integrationsTest.step(
+      '3065 Connect with the MCP Server from the MCP button in workspace toolbar',
+      async () => {
+        await integrationsTest.step(
+          'Disconnect from the MCP Workspace menu',
+          async () => {
+            await mainPage.clickDisconnectMCPServerMenuSubItem();
+          },
+        );
+
+        await integrationsTest.step(
+          'Click MCP button from toolbar and click Connect here',
+          async () => {
+            await mainPage.connectMCPButtonFromToolbar();
+            await mainPage.clickMCPButtonFromToolbar();
+          },
+        );
+
+        await integrationsTest.step(
+          'Assert MCP Connected message is visible',
+          async () => {
+            await mainPage.isMCPConnectedButtonVisible();
+          },
+        );
+      },
+    );
+
     await integrationsTest.step('2775 Delete MCP key', async () => {
       await integrationsTest.step(
         'Go back to the integrations page from file editor',

--- a/tests/your-account/integrations/mcp-server.spec.ts
+++ b/tests/your-account/integrations/mcp-server.spec.ts
@@ -147,13 +147,14 @@ integrationsTest(
           'Click MCP button from toolbar and click Connect here',
           async () => {
             await mainPage.connectMCPButtonFromToolbar();
-            await mainPage.clickMCPButtonFromToolbar();
           },
         );
 
         await integrationsTest.step(
           'Assert MCP Connected message is visible',
           async () => {
+            await mainPage.reloadPage();
+            await mainPage.clickMCPButtonFromToolbar();
             await mainPage.isMCPConnectedButtonVisible();
           },
         );


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/task/1374

## Description

Adds a new test for MCP to validate MCP connection from toolbar. This has been implemented in 2.16.1 version and is already in production.

https://app.qase.io/case/PENPOT-3065

Includes a change in CONTINUE WITHOUT TEAM option in the on-boarding modal when creating a new account due to latest changes.

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Test Execution Results in CI

<img width="1014" height="301" alt="image" src="https://github.com/user-attachments/assets/d8182932-aa61-4b12-8fb8-9bb6bdba655a" />
