### PR TITLE
feat(tests): Add new cut image tests

### DIFF
--- a/pages/workspace/layers-panel-page.js
+++ b/pages/workspace/layers-panel-page.js
@@ -485,13 +485,30 @@ exports.LayersPanelPage = class LayersPanelPage extends MainPage {
     await this.detachInstanceOption.click();
   }
 
-  async copyLayerViaRightClick(layerName) {
+  /**
+   * This method clicks on a layer option via right click for a given layer name and index.
+   *
+   * Allowed options (resolved as `*Option` then `*MenuItem`) are:
+   *   'copy', 'cut', 'paste', 'delete', 'duplicate', 'rename',
+   *   'detachInstance', 'showMainComponent', 'resetOverrides',
+   *   'showInAssetsPanel', 'createAnnotation',
+   *   'createComponent', 'updateMainComponent', 'restoreMainComponent',
+   *   'createMultipleComponents', 'createVariant', 'restoreVariant',
+   *   'hide', 'show', 'focusOnLayer', 'transformToPath', 'selectionToBoard',
+   *   'flipVertical', 'flipHorizontal', 'editPath', 'deleteLayer'
+   * @param {string} layerName Name of the layer
+   * @param {string} option Name of the option to click
+   * @param {number} index Index of the layer (for multiple layers with the same name)
+   */
+  async clickOnLayerOptionViaRightClickForLayer(layerName, option, index = 0) {
     const layerSel = this.page.locator('#layers').getByText(layerName);
-    await layerSel.last().click({
+    await layerSel.nth(index).click({
       button: 'right',
       force: true,
     });
-    await this.copyOption.click();
+    const locator = this[`${option}Option`] ?? this[`${option}MenuItem`];
+    if (!locator) throw new Error(`No locator found for option: "${option}"`);
+    await locator.click();
   }
 
   async selectLayerByName(layerName) {

--- a/tests/composition/composition-board.spec.ts
+++ b/tests/composition/composition-board.spec.ts
@@ -766,7 +766,7 @@ mainTest.describe(() => {
     const board1 = 'Board #1';
     await mainPage.copyLayerViaRightClick();
     await mainPage.pasteLayerViaRightClick();
-    await layersPanelPage.copyLayerViaRightClick(board1);
+    await layersPanelPage.clickOnLayerOptionViaRightClickForLayer(board1, 'copy');
     await mainPage.pasteLayerViaRightClick();
     await mainPage.pressCopyShortcut();
     await mainPage.pressPasteShortcut();

--- a/tests/composition/image/image-options.spec.ts
+++ b/tests/composition/image/image-options.spec.ts
@@ -80,24 +80,63 @@ mainTest.describe('PNG image', () => {
   });
 
   mainTest(
-    qase([466], 'Copy and Paste image (from context menu and shortcut)'),
+    qase(
+      [466, 468],
+      'Copy/Paste and Cut/Paste image (from context menu and shortcut)',
+    ),
     async () => {
-      await mainTest.step('Copy and paste image from context menu', async () => {
-        await layersPanelPage.copyLayerViaRightClick('images');
-        await mainPage.clickViewportByCoordinates(300, 300);
-        await layersPanelPage.pasteLayerViaRightClick();
-        await mainPage.waitForChangeIsSaved();
-        await layersPanelPage.isVisibleLayersCount(2);
-      });
+      await mainTest.step(
+        '466 Copy and Paste image (from context menu and shortcut)',
+        async () => {
+          await mainTest.step('Copy and paste image from context menu', async () => {
+            await layersPanelPage.clickOnLayerOptionViaRightClickForLayer(
+              'images',
+              'copy',
+              0,
+            );
+            await layersPanelPage.pasteLayerViaRightClick();
+            await mainPage.waitForChangeIsSaved();
+            await layersPanelPage.isVisibleLayersCount(2);
+          });
 
-      await mainTest.step('Copy and paste image from shortcut', async () => {
-        await layersPanelPage.selectLayerByName('images');
-        await layersPanelPage.pressCopyShortcut();
-        await mainPage.clickViewportByCoordinates(800, 800);
-        await layersPanelPage.pressPasteShortcut();
-        await mainPage.waitForChangeIsSaved();
-        await layersPanelPage.isVisibleLayersCount(3);
-      });
+          await mainTest.step('Copy and paste image from shortcut', async () => {
+            await layersPanelPage.selectLayerByName('images');
+            await layersPanelPage.pressCopyShortcut();
+            await mainPage.clickViewportByCoordinates(800, 800);
+            await layersPanelPage.pressPasteShortcut();
+            await mainPage.waitForChangeIsSaved();
+            await layersPanelPage.isVisibleLayersCount(3);
+          });
+        },
+      );
+      await mainTest.step(
+        '468 Cut image (From rightclick and Shortcut Ctrl+X)',
+        async () => {
+          await mainTest.step('Cut and paste image from context menu', async () => {
+            await layersPanelPage.clickOnLayerOptionViaRightClickForLayer(
+              'images',
+              'cut',
+              1,
+            );
+            await layersPanelPage.isVisibleLayersCount(2);
+            await mainPage.clickViewportByCoordinates(800, 600);
+            await layersPanelPage.pasteLayerViaRightClick();
+            await mainPage.waitForChangeIsSaved();
+            await layersPanelPage.isVisibleLayersCount(3);
+          });
+          await mainTest.step(
+            'Cut & paste image by shortcuts (Ctrl+X / Ctrl+V)',
+            async () => {
+              await layersPanelPage.pressCutShortcut();
+              await layersPanelPage.isVisibleLayersCount(2);
+              await mainPage.clickViewportByCoordinates(800, 300);
+              await layersPanelPage.pressPasteShortcut();
+              await mainPage.waitForChangeIsSaved();
+              await layersPanelPage.isVisibleLayersCount(3);
+            },
+          );
+        },
+      );
     },
   );
 });


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL

[Taiga Ticket: 1085](https://tree.taiga.io/project/kaleidos-qa/task/1085)

## Description

This PR adds a new test to cut and paste an image using the RMB context and keyboard shortcuts.

## Solution

* Extend a test that already existed before to reuse its context.
* Model two of the three methods to cut the image, avoiding using RMB on the Viewport to cut due to its flakiness, as the `selrect` will disappear.
* Replace the method `copyLayerViaRightClick(layerName)` with a new broader method open to other RMB options `clickOnLayerOptionViaRightClickForLayer(layerName, option, index = 0)`. For instance:  'copy', 'cut', 'paste', 'delete', etc.

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Screenshots 📸 (optional)

<img width="777" height="193" alt="image" src="https://github.com/user-attachments/assets/51d4fddc-b342-425f-aec8-4af52bbbce14" />

<img width="782" height="403" alt="image" src="https://github.com/user-attachments/assets/ac9c2e78-8c19-4714-86fa-0e5dc3888811" />

