### PR TITLE
feat(ci): add opencode-agent workflow for PR reviews

### DIFF
--- a/.github/workflows/opencode-agent.yml
+++ b/.github/workflows/opencode-agent.yml
@@ -1,0 +1,32 @@
+name: OpenCode Agent
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  opencode:
+    if: contains(github.event.comment.body, 'opencode')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run OpenCode Agent
+        uses: anomalyco/opencode/github@main
+        with:
+          model: ${{ env.OPENCODE_MODEL }}
+          use_github_token: true
+        env:
+          OPENCODE_MODEL: >-
+            ${{ contains(github.event.comment.body, '--model deepseek') && 'opencode/deepseek-v4-flash-free' ||
+                contains(github.event.comment.body, '--model mimo') && 'opencode/mimo-v2.5-free' ||
+                contains(github.event.comment.body, '--model nemotron') && 'opencode/nemotron-3-ultra-free' ||
+                contains(github.event.comment.body, '--model big-pickle') && 'opencode/big-pickle' ||
+                contains(github.event.comment.body, '--model north') && 'opencode/north-mini-code-free' ||
+                'opencode/mimo-v2.5-free' }}


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)
https://tree.taiga.io/project/kaleidos-qa/us/1508

## Description

This PR adds a GitHub Actions workflow to enable the **OpenCode Agent** for automated code reviews in pull requests.

**What?** A new workflow file `.github/workflows/opencode-agent.yml` that listens for `opencode` comments in PRs and runs the OpenCode Agent using free models from OpenCode Zen.

- Added `.github/workflows/opencode-agent.yml` workflow
- Supports 5 free models via `--model` flag: mimo, deepseek, nemotron, big-pickle, north
- Default model: `opencode/mimo-v2.5-free`
- Uses `GITHUB_TOKEN` for authentication (no API key required)

## How to test

- [x] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [x] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK