### PR TITLE
fix(ci): correct opencode workflow configuration

### DIFF
--- a/.github/workflows/opencode-agent.yml
+++ b/.github/workflows/opencode-agent.yml
@@ -30,7 +30,6 @@ jobs:
       - name: Run OpenCode Agent
         uses: anomalyco/opencode/github@latest
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENCODE_MODEL: >-
             ${{ contains(github.event.comment.body, '--model deepseek') && 'opencode/deepseek-v4-flash-free' ||
                 contains(github.event.comment.body, '--model mimo') && 'opencode/mimo-v2.5-free' ||

--- a/.github/workflows/opencode-agent.yml
+++ b/.github/workflows/opencode-agent.yml
@@ -3,26 +3,34 @@ name: OpenCode Agent
 on:
   issue_comment:
     types: [created]
+  pull_request_review_comment:
+    types: [created]
 
 permissions:
+  id-token: write
   contents: read
   pull-requests: write
   issues: write
 
 jobs:
   opencode:
-    if: contains(github.event.comment.body, 'opencode')
+    if: >
+      (contains(github.event.comment.body, '/oc') ||
+       contains(github.event.comment.body, '/opencode')) &&
+      github.actor != 'github-actions[bot]' &&
+      github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
 
       - name: Run OpenCode Agent
-        uses: anomalyco/opencode/github@main
-        with:
-          model: ${{ env.OPENCODE_MODEL }}
-          use_github_token: true
+        uses: anomalyco/opencode/github@latest
         env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENCODE_MODEL: >-
             ${{ contains(github.event.comment.body, '--model deepseek') && 'opencode/deepseek-v4-flash-free' ||
                 contains(github.event.comment.body, '--model mimo') && 'opencode/mimo-v2.5-free' ||
@@ -30,3 +38,6 @@ jobs:
                 contains(github.event.comment.body, '--model big-pickle') && 'opencode/big-pickle' ||
                 contains(github.event.comment.body, '--model north') && 'opencode/north-mini-code-free' ||
                 'opencode/mimo-v2.5-free' }}
+        with:
+          model: ${{ env.OPENCODE_MODEL }}
+          use_github_token: true

--- a/.github/workflows/opencode-agent.yml
+++ b/.github/workflows/opencode-agent.yml
@@ -1,6 +1,8 @@
 name: OpenCode Agent
 
 on:
+  issue_comment:
+    types: [created]
   pull_request_review_comment:
     types: [created]
 

--- a/.github/workflows/opencode-agent.yml
+++ b/.github/workflows/opencode-agent.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Run OpenCode Agent
         uses: anomalyco/opencode/github@latest
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENCODE_MODEL: >-
             ${{ contains(github.event.comment.body, '--model mimo') && 'opencode/mimo-v2.5-free' ||
                 contains(github.event.comment.body, '--model nemotron') && 'opencode/nemotron-3-ultra-free' ||

--- a/.github/workflows/opencode-agent.yml
+++ b/.github/workflows/opencode-agent.yml
@@ -1,8 +1,6 @@
 name: OpenCode Agent
 
 on:
-  issue_comment:
-    types: [created]
   pull_request_review_comment:
     types: [created]
 

--- a/.github/workflows/opencode-agent.yml
+++ b/.github/workflows/opencode-agent.yml
@@ -31,12 +31,9 @@ jobs:
         uses: anomalyco/opencode/github@latest
         env:
           OPENCODE_MODEL: >-
-            ${{ contains(github.event.comment.body, '--model deepseek') && 'opencode/deepseek-v4-flash-free' ||
-                contains(github.event.comment.body, '--model mimo') && 'opencode/mimo-v2.5-free' ||
+            ${{ contains(github.event.comment.body, '--model mimo') && 'opencode/mimo-v2.5-free' ||
                 contains(github.event.comment.body, '--model nemotron') && 'opencode/nemotron-3-ultra-free' ||
-                contains(github.event.comment.body, '--model big-pickle') && 'opencode/big-pickle' ||
-                contains(github.event.comment.body, '--model north') && 'opencode/north-mini-code-free' ||
-                'opencode/mimo-v2.5-free' }}
+                'opencode/deepseek-v4-flash-free' }}
         with:
           model: ${{ env.OPENCODE_MODEL }}
           use_github_token: true


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

_N/A_

## Description

This PR fixes the OpenCode Agent workflow that was failing with `Unable to resolve action anomalyco/opencode@main`.

**What?** Updated `.github/workflows/opencode-agent.yml` with correct configuration based on official OpenCode GitHub docs.

**Why?** The workflow was failing because:
1. Action reference `@main` doesn't exist — correct is `@latest`
2. Missing `id-token: write` permission required for OIDC authentication
3. Trigger keywords needed to be `/oc` or `/opencode` (with slash)
4. Missing `persist-credentials: false` in checkout step

**How?** Applied fixes from https://opencode.ai/docs/github:

## Solution

- Changed action reference from `@main` to `@latest`
- Added `id-token: write` permission
- Added `pull_request_review_comment` trigger
- Updated trigger to `/oc` or `/opencode` (with slash)
- Added `persist-credentials: false` to checkout
- Added bot actor filtering (github-actions, dependabot)

## How to test

- [x] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [x] It complies with the test conventions
- [ ] There are no missing snapshots for win32 (x3 browsers)
- [ ] The tests run OK

## Screenshots 📸 (optional)

_N/A_

## Anything Else? (optional)

After merging, test by commenting `/opencode explain this PR` on any open PR.