### PR TITLE
fix(design-panel-page): fix typography options button

### DIFF
--- a/pages/workspace/design-panel-page.js
+++ b/pages/workspace/design-panel-page.js
@@ -344,7 +344,7 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
     this.textStrikethrough = page.getByTestId('line-through-text-decoration');
     this.textTypographyMenuButton = this.designTabpanel
       .locator('div[class*="element-set-actions"]')
-      .getByRole('button', { name: 'labels.open' });
+      .getByRole('button', { name: 'Open' });
     this.typographyEntry = this.designTabpanel.locator(
       'div[class*="typography-entry"]',
     );


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/task/1569

## Description

Refactor typography locator to fix Letter Spacing token value can be override by Assets > Typography style (Qase ID: 2501).

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots
- [ ] The tests run OK

## Test Execution Results in CI

<img width="1022" height="353" alt="image" src="https://github.com/user-attachments/assets/41580337-c79a-4df3-85d8-52d051a24ee8" />
