### PR TITLE
fix(typography-tokens): fix locators and tests

### DIFF
--- a/pages/workspace/design-panel-page.js
+++ b/pages/workspace/design-panel-page.js
@@ -10,6 +10,7 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
     super(page);
 
     //Design panel
+    this.rightSidebar = this.page.getByTestId('right-sidebar');
     this.designTabpanel = page.getByRole('tabpanel', { name: 'design' });
     this.canvasBackgroundColorIcon = page
       .locator('div[class*="page__element-set"] div[class*="color-bullet-wrapper"]')
@@ -281,7 +282,6 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
     });
 
     //Design panel - Stroke section
-    this.rightSidebar = this.page.getByTestId('right-sidebar');
     this.strokeSectionContainer = this.rightSidebar.locator(
       '[aria-label="Stroke section"]',
     );
@@ -355,6 +355,7 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
     this.typographyAssetAg = this.designTabpanel.getByText('Ag', {
       exact: true,
     });
+    this.typographyTokenButton = this.rightSidebar.getByLabel('typography');
 
     //Design panel - Export section
     this.exportSection = page.getByText('Export', { exact: true });
@@ -466,6 +467,10 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
       exact: true,
     });
     this.variantPropertySwitch = this.componentBlockOnDesignTab.getByRole('switch');
+  }
+
+  getTypographyTokenModal(tokenName) {
+    return this.page.getByRole('tooltip').getByText(`Name: ${tokenName}`);
   }
 
   async isFlexElementSectionOpened() {
@@ -1909,6 +1914,78 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
     visible
       ? await expect(this.typographyAssetAg).toBeVisible(visible)
       : await expect(this.typographyAssetAg).not.toBeVisible(visible);
+  }
+
+  async hoverTypographyToken() {
+    await this.typographyTokenButton.hover();
+  }
+
+  async isTypographyTokenModalByNameVisible(name) {
+    await expect(this.getTypographyTokenModal(name)).toBeVisible();
+  }
+
+  async hoverAndAssertTypographyTokenValues(
+    name,
+    {
+      fontFamily,
+      fontSize,
+      fontWeight,
+      letterSpacing,
+      textCase,
+      textDecoration,
+      lineHeight,
+    } = {},
+  ) {
+    const typographyModal = this.getTypographyTokenModal(name);
+
+    await this.hoverTypographyToken();
+
+    if (fontFamily !== undefined) {
+      await expect(
+        typographyModal.getByText(`- font-family: "${fontFamily}"`, { exact: true }),
+        `Font Family is: ${fontFamily}`,
+      ).toBeVisible();
+    }
+    if (fontSize !== undefined) {
+      await expect(
+        typographyModal.getByText(`- font-size: ${fontSize}`, { exact: true }),
+        `Font Size is: ${fontSize}`,
+      ).toBeVisible();
+    }
+    if (fontWeight !== undefined) {
+      await expect(
+        typographyModal.getByText(`- font-weight: ${fontWeight}`, { exact: true }),
+        `Font Weight is: ${fontWeight}`,
+      ).toBeVisible();
+    }
+    if (letterSpacing !== undefined) {
+      await expect(
+        typographyModal.getByText(`- letter-spacing: ${letterSpacing}`, {
+          exact: true,
+        }),
+        `Letter Spacing is: ${letterSpacing}`,
+      ).toBeVisible();
+    }
+    if (textCase !== undefined) {
+      await expect(
+        typographyModal.getByText(`- text-case: ${textCase}`, { exact: true }),
+        `Text Case is: ${textCase}`,
+      ).toBeVisible();
+    }
+    if (textDecoration !== undefined) {
+      await expect(
+        typographyModal.getByText(`- text-decoration: ${textDecoration}`, {
+          exact: true,
+        }),
+        `Text Decoration is: ${textDecoration}`,
+      ).toBeVisible();
+    }
+    if (lineHeight !== undefined) {
+      await expect(
+        typographyModal.getByText(`- line-height: ${lineHeight}`, { exact: true }),
+        `Line Height is: ${lineHeight}`,
+      ).toBeVisible();
+    }
   }
 
   async checkTextCase(value) {

--- a/pages/workspace/design-panel-page.js
+++ b/pages/workspace/design-panel-page.js
@@ -1,4 +1,4 @@
-const { expect } = require('@playwright/test');
+const { expect, test } = require('@playwright/test');
 const { BasePage } = require('../base-page');
 const { mainTest } = require('../../fixtures');
 
@@ -1937,54 +1937,46 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
     } = {},
   ) {
     const typographyModal = this.getTypographyTokenModal(name);
-
     await this.hoverTypographyToken();
 
-    if (fontFamily !== undefined) {
-      await expect(
-        typographyModal.getByText(`- font-family: "${fontFamily}"`, { exact: true }),
-        `Font Family is: ${fontFamily}`,
-      ).toBeVisible();
-    }
-    if (fontSize !== undefined) {
-      await expect(
-        typographyModal.getByText(`- font-size: ${fontSize}`, { exact: true }),
-        `Font Size is: ${fontSize}`,
-      ).toBeVisible();
-    }
-    if (fontWeight !== undefined) {
-      await expect(
-        typographyModal.getByText(`- font-weight: ${fontWeight}`, { exact: true }),
-        `Font Weight is: ${fontWeight}`,
-      ).toBeVisible();
-    }
-    if (letterSpacing !== undefined) {
-      await expect(
-        typographyModal.getByText(`- letter-spacing: ${letterSpacing}`, {
-          exact: true,
-        }),
-        `Letter Spacing is: ${letterSpacing}`,
-      ).toBeVisible();
-    }
-    if (textCase !== undefined) {
-      await expect(
-        typographyModal.getByText(`- text-case: ${textCase}`, { exact: true }),
-        `Text Case is: ${textCase}`,
-      ).toBeVisible();
-    }
-    if (textDecoration !== undefined) {
-      await expect(
-        typographyModal.getByText(`- text-decoration: ${textDecoration}`, {
-          exact: true,
-        }),
-        `Text Decoration is: ${textDecoration}`,
-      ).toBeVisible();
-    }
-    if (lineHeight !== undefined) {
-      await expect(
-        typographyModal.getByText(`- line-height: ${lineHeight}`, { exact: true }),
-        `Line Height is: ${lineHeight}`,
-      ).toBeVisible();
+    const tokenValues = [
+      {
+        label: 'Font Family',
+        value: fontFamily,
+        line: (v) => `- font-family: "${v}"`,
+      },
+      { label: 'Font Size', value: fontSize, line: (v) => `- font-size: ${v}` },
+      {
+        label: 'Font Weight',
+        value: fontWeight,
+        line: (v) => `- font-weight: ${v}`,
+      },
+      {
+        label: 'Letter Spacing',
+        value: letterSpacing,
+        line: (v) => `- letter-spacing: ${v}`,
+      },
+      { label: 'Text Case', value: textCase, line: (v) => `- text-case: ${v}` },
+      {
+        label: 'Text Decoration',
+        value: textDecoration,
+        line: (v) => `- text-decoration: ${v}`,
+      },
+      {
+        label: 'Line Height',
+        value: lineHeight,
+        line: (v) => `- line-height: ${v}`,
+      },
+    ];
+
+    for (const { label, value, line } of tokenValues) {
+      if (value === undefined) continue;
+
+      await test.step(`Assert ${label} is: ${value}`, async () => {
+        await expect(
+          typographyModal.getByText(line(value), { exact: true }),
+        ).toBeVisible();
+      });
     }
   }
 

--- a/tests/tokens/token-types/typography-tokens.spec.ts
+++ b/tests/tokens/token-types/typography-tokens.spec.ts
@@ -78,28 +78,29 @@ mainTest.describe(() => {
         },
       );
 
-      const UPDATED_TOKEN: TypographyToken<TokenClass> = {
-        class: TokenClass.Typography,
-        name: TYPO_TOKEN.name,
-        fontWeight: 'thin',
-        fontSize: '16',
-        textDecoration: 'underline',
-        lineHeight: '24',
-      };
-      const THIN_FONT_WEIGHT_VALUE = '200';
-
       await mainTest.step('2586 Edit a typography token', async () => {
+        const UPDATED_TOKEN: TypographyToken<TokenClass> = {
+          class: TokenClass.Typography,
+          name: TYPO_TOKEN.name,
+          fontWeight: 'Medium',
+          fontSize: '16',
+          textDecoration: 'underline',
+          lineHeight: '24',
+        };
+
         await tokensPage.tokensComp.editTokenViaRightClickAndSave(UPDATED_TOKEN);
         await mainPage.waitForChangeIsSaved();
         await tokensPage.tokensComp.isTokenAppliedWithName(UPDATED_TOKEN.name);
+        await designPanelPage.hoverAndAssertTypographyTokenValues(TYPO_TOKEN.name, {
+          fontFamily: TYPO_TOKEN.fontFamily,
+          fontSize: UPDATED_TOKEN.fontSize,
+          fontWeight: UPDATED_TOKEN.fontWeight,
+          letterSpacing: TYPO_TOKEN.letterSpacing,
+          textCase: TYPO_TOKEN.textCase,
+          textDecoration: UPDATED_TOKEN.textDecoration,
+          lineHeight: UPDATED_TOKEN.lineHeight,
+        });
 
-        await designPanelPage.checkTextCase(TYPO_TOKEN.textCase);
-        await designPanelPage.checkLetterSpacing(TYPO_TOKEN.letterSpacing);
-        await designPanelPage.checkFontName(TYPO_TOKEN.fontFamily);
-
-        await designPanelPage.checkFontSize(UPDATED_TOKEN.fontSize);
-        await designPanelPage.checkTextLineHeight(UPDATED_TOKEN.lineHeight);
-        await designPanelPage.checkFontStyle(THIN_FONT_WEIGHT_VALUE);
         await designPanelPage.clickOnTextAlignOptionsButton();
         await designPanelPage.isTextUnderlineChecked();
       });
@@ -112,6 +113,7 @@ mainTest.describe(() => {
       };
       const RESOLVED_FONT_SIZE_1 = '120';
       const RESOLVED_LINE_HEIGHT_1 = '1.5';
+
       const TOKEN_2: TypographyToken<TokenClass> = {
         class: TokenClass.Typography,
         name: TYPO_TOKEN.name,
@@ -119,6 +121,7 @@ mainTest.describe(() => {
         lineHeight: '103px%',
       };
       const RESOLVED_LINE_HEIGHT_2 = '1.03';
+
       const TOKEN_3: TypographyToken<TokenClass> = {
         class: TokenClass.Typography,
         name: TYPO_TOKEN.name,
@@ -126,6 +129,7 @@ mainTest.describe(() => {
         lineHeight: '17px',
       };
       const RESOLVED_LINE_HEIGHT_3 = '0.94';
+
       const TOKEN_4: TypographyToken<TokenClass> = {
         class: TokenClass.Typography,
         name: TYPO_TOKEN.name,
@@ -137,8 +141,10 @@ mainTest.describe(() => {
       await mainTest.step('2592 Validate Typography Token Units', async () => {
         await tokensPage.tokensComp.editTokenViaRightClickAndSave(TOKEN_1);
         await mainPage.waitForChangeIsSaved();
-        await designPanelPage.checkFontSize(RESOLVED_FONT_SIZE_1);
-        await designPanelPage.checkTextLineHeight(RESOLVED_LINE_HEIGHT_1);
+        await designPanelPage.hoverAndAssertTypographyTokenValues(TYPO_TOKEN.name, {
+          fontSize: RESOLVED_FONT_SIZE_1,
+          lineHeight: RESOLVED_LINE_HEIGHT_1,
+        });
       });
 
       await mainTest.step(
@@ -146,13 +152,30 @@ mainTest.describe(() => {
         async () => {
           await tokensPage.tokensComp.editTokenViaRightClickAndSave(TOKEN_2);
           await mainPage.waitForChangeIsSaved();
-          await designPanelPage.checkTextLineHeight(RESOLVED_LINE_HEIGHT_2);
+          await designPanelPage.hoverAndAssertTypographyTokenValues(
+            TYPO_TOKEN.name,
+            {
+              lineHeight: RESOLVED_LINE_HEIGHT_2,
+            },
+          );
+
           await tokensPage.tokensComp.editTokenViaRightClickAndSave(TOKEN_3);
           await mainPage.waitForChangeIsSaved();
-          await designPanelPage.checkTextLineHeight(RESOLVED_LINE_HEIGHT_3);
+          await designPanelPage.hoverAndAssertTypographyTokenValues(
+            TYPO_TOKEN.name,
+            {
+              lineHeight: RESOLVED_LINE_HEIGHT_3,
+            },
+          );
+
           await tokensPage.tokensComp.editTokenViaRightClickAndSave(TOKEN_4);
           await mainPage.waitForChangeIsSaved();
-          await designPanelPage.checkTextLineHeight(RESOLVED_LINE_HEIGHT_4);
+          await designPanelPage.hoverAndAssertTypographyTokenValues(
+            TYPO_TOKEN.name,
+            {
+              lineHeight: RESOLVED_LINE_HEIGHT_4,
+            },
+          );
         },
       );
     },
@@ -218,8 +241,13 @@ mainTest.describe(() => {
           await tokensPage.tokensComp.clickOnTokenWithName(TYPO_TOKEN.name);
           // Validates assets are detached after applying the typography token
           await designPanelPage.isTypographyAssetAgVisible(false);
-          await designPanelPage.checkFontName(TYPO_TOKEN.fontFamily);
-          await designPanelPage.checkLetterSpacing(TYPO_TOKEN.letterSpacing);
+          await designPanelPage.hoverAndAssertTypographyTokenValues(
+            TYPO_TOKEN.name,
+            {
+              fontFamily: TYPO_TOKEN.fontFamily,
+              letterSpacing: TYPO_TOKEN.letterSpacing,
+            },
+          );
         },
       );
 

--- a/tests/tokens/token-types/typography-tokens.spec.ts
+++ b/tests/tokens/token-types/typography-tokens.spec.ts
@@ -128,7 +128,7 @@ mainTest.describe(() => {
         fontSize: '18px',
         lineHeight: '17px',
       };
-      const RESOLVED_LINE_HEIGHT_3 = '0.94';
+      const RESOLVED_LINE_HEIGHT_3 = '0.9444444444444444';
 
       const TOKEN_4: TypographyToken<TokenClass> = {
         class: TokenClass.Typography,


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/task/1605
https://tree.taiga.io/project/kaleidos-qa/task/1604

## Description

Due to recent changes in the Design tab and Typography tokens, when a Typography token is created and applied to a text element, its values are now displayed when hovering over the applied token in the Design tab.

<img width="305" height="481" alt="image" src="https://github.com/user-attachments/assets/033dbb9a-8625-4ff0-9751-d0d41739ae3f" />

## Solution

Refactored locators and spec files to use the new methods in tests.

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots
- [ ] The tests run OK

## Test Execution Results in CI

<img width="1112" height="405" alt="image" src="https://github.com/user-attachments/assets/1e6d48ed-cfb5-4c5b-b275-fe3b8969951c" />

Failure due to a potential bug as the Line Height value seems not being properly calculated. But checked with the team and it is an enhancement not a bug so the test value has been updated.

<img width="1920" height="969" alt="image" src="https://github.com/user-attachments/assets/452fefa6-baa9-4f6f-802b-a0aa77dbc430" />
