### PR TITLE
fix(tokens): update font weight fallback value

### DIFF
--- a/tests/tokens/token-types/font-weight-token.spec.ts
+++ b/tests/tokens/token-types/font-weight-token.spec.ts
@@ -95,7 +95,7 @@ mainTest.describe(() => {
       );
 
       await mainTest.step(
-        `Apply "${fontWeightToken2.name}" with non-existing style and verify fallback value "400 Italic"`,
+        `Apply "${fontWeightToken2.name}" with non-existing style and verify fallback value "600 Italic"`,
         async () => {
           await mainPage.clickViewportOnce();
           await layersPanelPage.openLayersTab();
@@ -107,7 +107,7 @@ mainTest.describe(() => {
           );
           await mainPage.waitForChangeIsSaved();
           await tokensPage.tokensComp.isTokenAppliedWithName(fontWeightToken2.name);
-          await designPanelPage.checkFontStyle('400 Italic');
+          await designPanelPage.checkFontStyle('600 Italic');
         },
       );
     },


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/task/1517

## Description

Updating fallback value for Font Weight token per this comment as it is now expected https://github.com/penpot/penpot/issues/10494#issuecomment-4844317663.

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots
- [ ] The tests run OK

## Test Execution Results

<img width="421" height="208" alt="image" src="https://github.com/user-attachments/assets/91323eb9-2791-4e45-9bc9-a2bfa1e9b49d" />

