### PR TITLE
fix(tokens-in-design-tab): update tooltip message

### DIFF
--- a/pages/workspace/design-panel-page.js
+++ b/pages/workspace/design-panel-page.js
@@ -2136,7 +2136,7 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
    */
   async isNotTokenInAnyActiveSetButtonVisible(tokenName) {
     const notInAnyActiveSetButton = this.page.getByRole('button', {
-      name: `{${tokenName}} is not in any active set or has an invalid value`,
+      name: `{${tokenName}} token is not in any active set or has an invalid value`,
     });
     await expect(notInAnyActiveSetButton).toBeVisible();
   }

--- a/tests/tokens/tokens-in-design-tab.spec.ts
+++ b/tests/tokens/tokens-in-design-tab.spec.ts
@@ -284,7 +284,7 @@ mainTest.describe(() => {
       await mainTest.step(
         'Hover on fill color input and check error in tootltip message',
         async () => {
-          const messageText: string = `{${tokenName}} is not in any active set or has an invalid value.`;
+          const messageText: string = `{${tokenName}} token is not in any active set or has an invalid value.`;
           await designPanelPage.checkTooltipInFillColorInput(messageText);
         },
       );


### PR DESCRIPTION
# Done Definition Checks

## Description

This PR add "token" word to tooltips.
There isn't test execution because PRE hasn't been updated yet (related to [this issue](https://github.com/penpot/penpot/issues/10471)).

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots
- [ ] The tests run OK

