### PR TITLE
fix(send-notification): remove browser-name from Mattermost message args

### DIFF
--- a/.github/actions/send-notification/action.yml
+++ b/.github/actions/send-notification/action.yml
@@ -37,15 +37,15 @@ runs:
         # Generate the message content and save to output
         if [ -n "$FOLDER_PATH" ]; then
           if [ "$IS_MANUAL" = "true" ] && [ -n "$USERNAME" ]; then
-            MESSAGE=$(npx ts-node -e "require('./helpers/mattermost.helper.js').generateMessage('${{ inputs.browser-name }}', '$FOLDER_PATH', '$REPEAT_EACH', true, '$USERNAME')")
+            MESSAGE=$(npx ts-node -e "require('./helpers/mattermost.helper.js').generateMessage('$FOLDER_PATH', '$REPEAT_EACH', true, '$USERNAME')")
           else
-            MESSAGE=$(npx ts-node -e "require('./helpers/mattermost.helper.js').generateMessage('${{ inputs.browser-name }}', '$FOLDER_PATH', null, false, null)")
+            MESSAGE=$(npx ts-node -e "require('./helpers/mattermost.helper.js').generateMessage('$FOLDER_PATH', null, false, null)")
           fi
         else
           if [ "$IS_MANUAL" = "true" ] && [ -n "$USERNAME" ]; then
-            MESSAGE=$(npx ts-node -e "require('./helpers/mattermost.helper.js').generateMessage('${{ inputs.browser-name }}', null, '$REPEAT_EACH', true, '$USERNAME')")
+            MESSAGE=$(npx ts-node -e "require('./helpers/mattermost.helper.js').generateMessage(null, '$REPEAT_EACH', true, '$USERNAME')")
           else
-            MESSAGE=$(npx ts-node -e "require('./helpers/mattermost.helper.js').generateMessage('${{ inputs.browser-name }}', null, null, false, null)")
+            MESSAGE=$(npx ts-node -e "require('./helpers/mattermost.helper.js').generateMessage(null, null, false, null)")
           fi
         fi
 


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

[Taiga Ticket: 1491](https://tree.taiga.io/project/kaleidos-qa/us/1491)

## Description

This PR fixes the Mattermost notification showing `@true` instead of the actual username when a manual workflow run finishes.

## Solution

Removed the extra `browser-name` argument from all 4 `generateMessage` calls in `.github/actions/send-notification/action.yml`, aligning the arguments with the function signature.

## How to test

- [x] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [x] It complies with the test conventions
- [ ] There are no missing snapshots
- [x] The tests run OK

## Screenshots 📸 (optional)
<img width="1565" height="351" alt="image" src="https://github.com/user-attachments/assets/20127ae3-2331-4952-b6dd-9caf20c85f85" />

