### PR TITLE
fix(tokens): update tooltip in token in design tab when the reference is broken

### DIFF
--- a/pages/workspace/design-panel-page.js
+++ b/pages/workspace/design-panel-page.js
@@ -2132,9 +2132,9 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
    */
   async isNotTokenValidReferencedButtonVisible(tokenName) {
     const notValidReferencedButton = this.page.getByRole('button', {
-      name: `Reference in {${tokenName}} is not valid or is not in any active set`,
+      name: `Reference in {${tokenName}} is not valid or is not in any active set.`,
     });
-    await expect(this.notValidReferencedButton).toBeVisible();
+    await expect(notValidReferencedButton).toBeVisible();
   }
 
   /**

--- a/tests/tokens/token-group/token-group-options.spec.ts
+++ b/tests/tokens/token-group/token-group-options.spec.ts
@@ -174,13 +174,13 @@ mainTest.describe('Context menu > Delete', () => {
       );
 
       await mainTest.step(
-        `Verify "${secondaryToken.name}" is highlighted as invalid and shows "Reference is not valid or is not in any active set" tooltip`,
+        `Verify "${secondaryToken.name}" is highlighted as invalid and shows correct tooltip`,
         async () => {
           await tokensPage.tokensComp.checkInvalidTokenCount(1);
           await tokensPage.tokensComp.invalidToken.hover();
           await expect(tokensPage.tokensComp.invalidToken).toHaveAttribute(
             'title',
-            'Reference is not valid or is not in any active set',
+            `Reference in {${secondaryToken.name}} is not valid or is not in any active set.`,
           );
         },
       );

--- a/tests/tokens/tokens-in-design-tab.spec.ts
+++ b/tests/tokens/tokens-in-design-tab.spec.ts
@@ -190,7 +190,7 @@ mainTest.describe(() => {
       );
 
       await mainTest.step('Hover in token value and check tooltip', async () => {
-        const errorMessage: string = `Reference in {${dimensionTokenB.name}} is not valid or is not in any active set`;
+        const errorMessage: string = `Reference in {${dimensionTokenB.name}} is not valid or is not in any active set.`;
         await designPanelPage.hoverOnTokenPill(ariaLabel);
         await designPanelPage.isTokenPillTooltipVisible(errorMessage);
       });


### PR DESCRIPTION
# Done Definition Checks

## Description

This PR updates tooltips in token in design tab when the reference is broken

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots
- [ ] The tests run OK

## Screenshots 📸 
<img width="1980" height="796" alt="token" src="https://github.com/user-attachments/assets/e849ded0-e548-4a41-a20f-19d8c809a99a" />
<img width="1968" height="1096" alt="token2" src="https://github.com/user-attachments/assets/d4018e76-8993-4ea2-880f-32f7d4025912" />
