### PR TITLE
feat(comments): Hide/show comments via Main Menu/Shortcut

### DIFF
--- a/pages/workspace/comments-panel-page.js
+++ b/pages/workspace/comments-panel-page.js
@@ -191,6 +191,12 @@ exports.CommentsPanelPage = class CommentsPanelPage extends BasePage {
     await expect(this.commentResolvedThreadIcon).not.toBeVisible();
   }
 
+  async isCommentAvatarImageVisible(visible = true) {
+    visible
+      ? await expect(this.commentAvatarImage).toBeVisible()
+      : await expect(this.commentAvatarImage).not.toBeVisible();
+  }
+
   async isCommentUnreadThreadIconVisible(visible = true) {
     visible
       ? await expect(this.commentUnreadThreadIcon.first()).toBeVisible()

--- a/pages/workspace/main-page.js
+++ b/pages/workspace/main-page.js
@@ -583,8 +583,7 @@ exports.MainPage = class MainPage extends BasePage {
   }
 
   async hideRulersViaMainMenu() {
-    await this.clickMainMenuButton();
-    await this.clickViewMainMenuItem();
+    await this.clickOnMainThenViewMenuItem();
     await this.clickHideRulersMainMenuSubItem();
   }
 

--- a/pages/workspace/main-page.js
+++ b/pages/workspace/main-page.js
@@ -108,6 +108,12 @@ exports.MainPage = class MainPage extends BasePage {
     this.showGuidesMainMenuSubItem = page
       .getByRole('menuitem')
       .filter({ hasText: 'Show pixel grid' });
+    this.hideCommentsMainMenuSubItem = page
+      .getByRole('menuitem')
+      .filter({ hasText: 'Hide comments' });
+    this.showCommentsMainMenuSubItem = page
+      .getByRole('menuitem')
+      .filter({ hasText: 'Show comments' });
     this.selectAllMainMenuSubItem = page
       .getByRole('menuitem')
       .filter({ hasText: 'Select all' });
@@ -543,6 +549,11 @@ exports.MainPage = class MainPage extends BasePage {
     await this.viewMainMenuItem.click();
   }
 
+  async clickOnMainThenViewMenuItem() {
+    await this.clickMainMenuButton();
+    await this.clickViewMainMenuItem();
+  }
+
   async clickFileMainMenuItem() {
     await this.fileMainMenuItem.click();
   }
@@ -583,6 +594,23 @@ exports.MainPage = class MainPage extends BasePage {
 
   async clickShowGuidesMainMenuSubItem() {
     await this.showGuidesMainMenuSubItem.click();
+  }
+
+  async clickOnHideCommentsFromMainMenu() {
+    await this.clickOnMainThenViewMenuItem();
+    await this.hideCommentsMainMenuSubItem.click();
+  }
+
+  async clickOnShowCommentsFromMainMenu() {
+    await this.clickOnMainThenViewMenuItem();
+    await this.showCommentsMainMenuSubItem.click();
+  }
+
+  async isCommentVisibilityToastVisible(toastMessage) {
+    const commentsVisibilityToast = this.page.getByText(toastMessage, {
+      exact: true,
+    });
+    await expect(commentsVisibilityToast).toBeVisible();
   }
 
   async clickSelectAllMainMenuSubItem() {

--- a/tests/composition/composition-comments.spec.ts
+++ b/tests/composition/composition-comments.spec.ts
@@ -54,39 +54,66 @@ mainTest.describe(() => {
     await commentsPanelPage.isCommentDisplayedInPopUp(commentText);
   });
 
-  mainTest(qase([1219], 'Create comment (Toolbar)'), async ({ page }) => {
-    const comment = 'Test Comment';
+  mainTest(
+    qase([1219, 3069], 'Create comment (Toolbar) and Hide/Show it from Main Menu'),
+    async ({ page }) => {
+      await mainTest.step('1219, Create comment (Toolbar)', async () => {
+        const comment = 'Test Comment';
 
-    await mainTest.step(
-      'Verify comment is displayed in pop-up and panel',
-      async () => {
-        await commentsPanelPage.isCommentDisplayedInPopUp(comment);
-        await commentsPanelPage.isCommentDisplayedInCommentsPanel(comment);
+        await mainTest.step(
+          'Verify comment is displayed in pop-up and panel',
+          async () => {
+            await commentsPanelPage.isCommentDisplayedInPopUp(comment);
+            await commentsPanelPage.isCommentDisplayedInCommentsPanel(comment);
 
-        await mainPage.hideRulersViaMainMenu();
-        await expect(page).toHaveScreenshot('comment-opened-pop-up.png', {
-          mask: mainPage.maskViewport({ usersSection: true }, [
-            commentsPanelPage.commentsAuthorSection,
-            commentsPanelPage.commentAvatarImage,
-          ]),
+            await mainPage.hideRulersViaMainMenu();
+            await expect(page).toHaveScreenshot('comment-opened-pop-up.png', {
+              mask: mainPage.maskViewport({ usersSection: true }, [
+                commentsPanelPage.commentsAuthorSection,
+                commentsPanelPage.commentAvatarImage,
+              ]),
+            });
+          },
+        );
+
+        await mainTest.step(
+          'Close pop-up and verify thread icon is displayed',
+          async () => {
+            await mainPage.clickViewportOnce();
+            await commentsPanelPage.isCommentThreadIconDisplayed();
+            await expect(page).toHaveScreenshot('comment-closed-pop-up.png', {
+              mask: mainPage.maskViewport({ usersSection: true }, [
+                commentsPanelPage.commentsAuthorSection,
+                commentsPanelPage.commentAvatarImage,
+              ]),
+            });
+          },
+        );
+      });
+
+      await mainTest.step('3069, Hide/show comments via main menu', async () => {
+        await mainTest.step('Exit from the comments panel', async () => {
+          await commentsPanelPage.clickCreateCommentButton();
         });
-      },
-    );
 
-    await mainTest.step(
-      'Close pop-up and verify thread icon is displayed',
-      async () => {
-        await mainPage.clickViewportOnce();
-        await commentsPanelPage.isCommentThreadIconDisplayed();
-        await expect(page).toHaveScreenshot('comment-closed-pop-up.png', {
-          mask: mainPage.maskViewport({ usersSection: true }, [
-            commentsPanelPage.commentsAuthorSection,
-            commentsPanelPage.commentAvatarImage,
-          ]),
+        await mainTest.step('Click on Main menu/View/Hide comments', async () => {
+          await commentsPanelPage.isCommentAvatarImageVisible(true);
+
+          await mainPage.clickOnHideCommentsFromMainMenu();
+          await mainPage.clickViewportByCoordinates(800, 800);
+          await mainPage.isCommentVisibilityToastVisible('Comments hidden');
+          await commentsPanelPage.isCommentAvatarImageVisible(false);
         });
-      },
-    );
-  });
+
+        await mainTest.step('Click on Main menu/View/Show comments', async () => {
+          await mainPage.clickOnShowCommentsFromMainMenu();
+          await mainPage.clickViewportByCoordinates(800, 800);
+          await mainPage.isCommentVisibilityToastVisible('Comments visible');
+          await commentsPanelPage.isCommentAvatarImageVisible(true);
+        });
+      });
+    },
+  );
 
   mainTest(
     qase([1226], 'Reply comment with valid text using Latin alphabet'),

--- a/tests/panels-features/main-menu/panels-features-main-menu-view.spec.ts
+++ b/tests/panels-features/main-menu/panels-features-main-menu-view.spec.ts
@@ -62,8 +62,7 @@ mainTest(qase(816, 'Hide/show rulers via main menu'), async () => {
   await expect(mainPage.viewport).toHaveScreenshot('viewport-hidden-rulers.png', {
     mask: mainPage.maskViewport(),
   });
-  await mainPage.clickMainMenuButton();
-  await mainPage.clickViewMainMenuItem();
+  await mainPage.clickOnMainThenViewMenuItem();
   await mainPage.clickShowRulersMainMenuSubItem();
   await mainPage.clickViewportOnce();
   await expect(mainPage.viewport).toHaveScreenshot('viewport-default.png', {
@@ -91,8 +90,7 @@ mainTest(qase(819, 'Hide/show color palette - file library check'), async () => 
   await mainPage.clickViewportOnce();
   await mainPage.waitForChangeIsSaved();
 
-  await mainPage.clickMainMenuButton();
-  await mainPage.clickViewMainMenuItem();
+  await mainPage.clickOnMainThenViewMenuItem();
   await mainPage.clickShowColorPaletteMainMenuSubItem();
   await mainPage.isColorsPaletteDisplayed();
   await colorPalettePage.openColorPaletteMenu();
@@ -100,8 +98,7 @@ mainTest(qase(819, 'Hide/show color palette - file library check'), async () => 
   await expect(mainPage.typographiesColorsBottomPanel).toHaveScreenshot(
     'colors-file-library.png',
   );
-  await mainPage.clickMainMenuButton();
-  await mainPage.clickViewMainMenuItem();
+  await mainPage.clickOnMainThenViewMenuItem();
   await mainPage.clickHideColorPaletteMainMenuSubItem();
   await mainPage.isColorsPaletteNotDisplayed();
 });
@@ -111,14 +108,12 @@ mainTest(qase(820, 'Hide/show board names'), async () => {
   await mainPage.clickViewportTwice();
   await mainPage.waitForChangeIsSaved();
   await mainPage.isCreatedLayerVisible();
-  await mainPage.clickMainMenuButton();
-  await mainPage.clickViewMainMenuItem();
+  await mainPage.clickOnMainThenViewMenuItem();
   await mainPage.clickHideBoardNamesMainMenuSubItem();
   await expect(mainPage.viewport).toHaveScreenshot('board-hide-name.png', {
     mask: mainPage.maskViewport(),
   });
-  await mainPage.clickMainMenuButton();
-  await mainPage.clickViewMainMenuItem();
+  await mainPage.clickOnMainThenViewMenuItem();
   await mainPage.clickShowBoardNamesMainMenuSubItem();
   await expect(mainPage.viewport).toHaveScreenshot('board-show-name.png', {
     mask: mainPage.maskViewport(),
@@ -131,14 +126,12 @@ mainTest(qase(821, 'Hide/show pixel grid via main menu'), async () => {
   await expect(mainPage.viewport).toHaveScreenshot('canvas-show-pixel-grid.png', {
     mask: mainPage.maskViewport(),
   });
-  await mainPage.clickMainMenuButton();
-  await mainPage.clickViewMainMenuItem();
+  await mainPage.clickOnMainThenViewMenuItem();
   await mainPage.clickHidePixelGridMainMenuSubItem();
   await expect(mainPage.viewport).toHaveScreenshot('canvas-hide-pixel-grid.png', {
     mask: mainPage.maskViewport(),
   });
-  await mainPage.clickMainMenuButton();
-  await mainPage.clickViewMainMenuItem();
+  await mainPage.clickOnMainThenViewMenuItem();
   await mainPage.clickShowPixelGridMainMenuSubItem();
   await expect(mainPage.viewport).toHaveScreenshot('canvas-show-pixel-grid.png', {
     mask: mainPage.maskViewport(),
@@ -165,8 +158,7 @@ mainTest(qase(822, 'Hide/show UI via main menu and shortcut "/"'), async () => {
   await expect(mainPage.viewport).toHaveScreenshot('canvas-show-ui.png', {
     mask: mainPage.maskViewport(),
   });
-  await mainPage.clickMainMenuButton();
-  await mainPage.clickViewMainMenuItem();
+  await mainPage.clickOnMainThenViewMenuItem();
   await mainPage.clickShowHideUIMainMenuSubItem();
   await expect(mainPage.viewport).toHaveScreenshot('canvas-hide-ui.png', {
     mask: mainPage.maskViewport(),

--- a/tests/panels-features/panels-features-guides.spec.js
+++ b/tests/panels-features/panels-features-guides.spec.js
@@ -111,15 +111,13 @@ mainTest.describe(() => {
       await expect(mainPage.viewport).toHaveScreenshot('square-guide-default.png', {
         mask: mainPage.maskViewport(),
       });
-      await mainPage.clickMainMenuButton();
-      await mainPage.clickViewMainMenuItem();
+      await mainPage.clickOnMainThenViewMenuItem();
       await mainPage.clickHideGuidesMainMenuSubItem();
       await mainPage.waitForChangeIsSaved();
       await expect(mainPage.viewport).toHaveScreenshot('square-guide-hide.png', {
         mask: mainPage.maskViewport(),
       });
-      await mainPage.clickMainMenuButton();
-      await mainPage.clickViewMainMenuItem();
+      await mainPage.clickOnMainThenViewMenuItem();
       await mainPage.clickShowGuidesMainMenuSubItem();
       await mainPage.waitForChangeIsSaved();
       await expect(mainPage.viewport).toHaveScreenshot('square-guide-unhide.png', {
@@ -337,15 +335,13 @@ mainTest.describe(() => {
       await expect(mainPage.viewport).toHaveScreenshot('rows-guide-default.png', {
         mask: mainPage.maskViewport(),
       });
-      await mainPage.clickMainMenuButton();
-      await mainPage.clickViewMainMenuItem();
+      await mainPage.clickOnMainThenViewMenuItem();
       await mainPage.clickHideGuidesMainMenuSubItem();
       await mainPage.waitForChangeIsSaved();
       await expect(mainPage.viewport).toHaveScreenshot('rows-guide-hide.png', {
         mask: mainPage.maskViewport(),
       });
-      await mainPage.clickMainMenuButton();
-      await mainPage.clickViewMainMenuItem();
+      await mainPage.clickOnMainThenViewMenuItem();
       await mainPage.clickShowGuidesMainMenuSubItem();
       await mainPage.waitForChangeIsSaved();
       await expect(mainPage.viewport).toHaveScreenshot('rows-guide-unhide.png', {


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

[Taiga Ticket: 1627](https://tree.taiga.io/project/kaleidos-qa/task/1627)

## Description

This PR adds a new test to hide and show comments from the Main menu. [PENPOT-3069](https://app.qase.io/case/PENPOT-3069)

It also creates a method to click on the Main menu > View option, refactoring occurrences in other files

## Solution

* Reuse the context for an existing test that was already creating a comment

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots
- [ ] The tests run OK

## Screenshots 📸 (optional)

Run 5 times to ensure the toast message is not causing any flakiness.

<img width="905" height="408" alt="image" src="https://github.com/user-attachments/assets/c518e2c2-f3db-41b3-b8c1-bb96f0a0236b" />