### PR TITLE
feat(comments): Hide/show comments via Shortcuts

### DIFF
--- a/pages/workspace/comments-panel-page.js
+++ b/pages/workspace/comments-panel-page.js
@@ -95,6 +95,14 @@ exports.CommentsPanelPage = class CommentsPanelPage extends BasePage {
       .filter({ hasText: 'Show only your mentions' });
   }
 
+  async pressCommentsPanelShortcut() {
+    await this.page.keyboard.press('C');
+  }
+
+  async pressHideCommentsShortcut() {
+    await this.page.keyboard.press('Control+Shift+C');
+  }
+
   async clickCreateCommentButton() {
     await this.commentsButton.click();
   }

--- a/tests/composition/composition-comments.spec.ts
+++ b/tests/composition/composition-comments.spec.ts
@@ -55,11 +55,14 @@ mainTest.describe(() => {
   });
 
   mainTest(
-    qase([1219, 3069], 'Create comment (Toolbar) and Hide/Show it from Main Menu'),
+    qase(
+      [1219, 3069, 3074],
+      'Create comment (Toolbar) and Hide/Show it from Main Menu/Shortkey',
+    ),
     async ({ page }) => {
-      await mainTest.step('1219, Create comment (Toolbar)', async () => {
-        const comment = 'Test Comment';
+      const comment = 'Test Comment';
 
+      await mainTest.step('1219, Create comment (Toolbar)', async () => {
         await mainTest.step(
           'Verify comment is displayed in pop-up and panel',
           async () => {
@@ -112,6 +115,24 @@ mainTest.describe(() => {
           await commentsPanelPage.isCommentAvatarImageVisible(true);
         });
       });
+
+      await mainTest.step(
+        "3074, Pressing 'C' shows comments from hidden state",
+        async () => {
+          await mainTest.step('Hide comments using the shortcut', async () => {
+            await commentsPanelPage.pressHideCommentsShortcut();
+
+            await mainPage.isCommentVisibilityToastVisible('Comments hidden');
+            await commentsPanelPage.isCommentAvatarImageVisible(false);
+          });
+
+          await mainTest.step("Press the 'C' key", async () => {
+            await commentsPanelPage.pressCommentsPanelShortcut();
+
+            await commentsPanelPage.isCommentDisplayedInCommentsPanel(comment);
+          });
+        },
+      );
     },
   );
 


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

[Taiga Ticket: 1627](https://tree.taiga.io/project/kaleidos-qa/task/1627) 

## Description

This PR adds a new test to hide comments from the workspace and display them by entering the comments panel. Both using the shortcuts. 
[PENPOT-3074](https://app.qase.io/case/PENPOT-3074)

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots
- [ ] The tests run OK

## Screenshots 📸 (optional)

Run x10 times to ensure it's not flaky remotely.

<img width="749" height="559" alt="image" src="https://github.com/user-attachments/assets/f7845119-5a02-46f2-a0b8-77621df8fb19" />
