### PR TITLE
feat(tokens): implement tests for typography tokens in design tab

### DIFF
--- a/pages/workspace/design-panel-page.js
+++ b/pages/workspace/design-panel-page.js
@@ -37,7 +37,9 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
     this.openTokenListButton = page.locator(
       'div[aria-label="Open token list"] button',
     );
-    this.detachTokenButton = page.getByRole('button', { name: 'Detach token' });
+    this.detachTokenButton = this.rightSidebar.getByRole('button', {
+      name: 'Detach token',
+    });
     this.resizeBoardToFitButton = page.getByRole('button', {
       name: 'Resize board to fit content',
     });
@@ -314,6 +316,12 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
     });
 
     //Design panel - Text section
+    this.textSectionRegion = this.rightSidebar.getByRole('region', {
+      name: 'Text section',
+    });
+    this.textOptionsFull = this.textSectionRegion.locator(
+      '.main_ui_workspace_sidebar_options_menus_typography__text-options-full-size',
+    );
     this.textUpperCaseIcon = page.getByTestId('text-transform-uppercase');
     this.textLowerCaseIcon = page.getByTestId('text-transform-lowercase');
     this.textTitleCaseIcon = page.getByTestId('text-transform-capitalize');
@@ -359,6 +367,17 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
       exact: true,
     });
     this.typographyTokenButton = this.rightSidebar.getByLabel('typography');
+    this.typographyErrorDot = this.textSectionRegion.locator(
+      '.main_ui_workspace_sidebar_options_menus_token_typography_row__error-dot',
+    );
+    this.typographyOpenTokenListButton = this.textSectionRegion.getByRole('button', {
+      name: 'Open token list',
+    });
+    this.typographyListBox = this.textSectionRegion.getByRole('listbox');
+    this.typographySearchTokenListInput = this.typographyListBox.getByRole(
+      'textbox',
+      { name: 'Search by token name' },
+    );
 
     //Design panel - Export section
     this.exportSection = page.getByText('Export', { exact: true });
@@ -1928,7 +1947,7 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
   }
 
   async hoverTypographyToken() {
-    await this.typographyTokenButton.hover();
+    await this.typographyTokenButton.first().hover();
   }
 
   async isTypographyTokenModalByNameVisible(name) {
@@ -2011,10 +2030,34 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
       : await expect(await this.textUnderline).not.toBeChecked();
   }
 
+  async isTextUnderlineDisabled(disabled = true) {
+    disabled
+      ? await expect(
+          await this.textUnderline,
+          `Text underline is disabled`,
+        ).toBeDisabled()
+      : await expect(
+          await this.textUnderline,
+          `Text underline is not disabled`,
+        ).not.toBeDisabled();
+  }
+
   async isTextStrikethroughChecked(checked = true) {
     checked
       ? await expect(await this.textStrikethrough).toBeChecked()
       : await expect(await this.textStrikethrough).not.toBeChecked();
+  }
+
+  async isTextStrikethroughDisabled(disabled = true) {
+    disabled
+      ? await expect(
+          await this.textStrikethrough,
+          `Text strikethrough is disabled`,
+        ).toBeDisabled()
+      : await expect(
+          await this.textStrikethrough,
+          `Text strikethrough is not disabled`,
+        ).not.toBeDisabled();
   }
 
   async isFlexElementWidth100BtnVisible(visible = true) {
@@ -2157,6 +2200,24 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
   }
 
   /**
+   * @param {string} tokenName - Token name
+   */
+  async isTokenNotExistOrDeletedTooltipVisible(tokenName) {
+    const tooltipError = this.rightSidebar.getByLabel(
+      `{${tokenName}} token does not exist or has been deleted.`,
+    );
+
+    await expect(
+      this.typographyErrorDot,
+      `Error dot for token ${tokenName} is visible`,
+    ).toBeVisible();
+    await expect(
+      tooltipError,
+      `Tooltip for token ${tokenName} is visible`,
+    ).toBeVisible();
+  }
+
+  /**
    * @param {string} messageText - Message text
    */
   async checkTooltipInFillColorInput(messageText) {
@@ -2178,5 +2239,54 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
 
   async hasStrokeGapInputValue(value) {
     await expect(this.strokeGapInput).toHaveValue(value);
+  }
+
+  getTypographyTokenOptionFromListByName(tokenName) {
+    return this.typographyListBox.getByRole('option', {
+      name: tokenName,
+      exact: true,
+    });
+  }
+
+  async openTypographyTokenList(value) {
+    await this.typographyOpenTokenListButton.click();
+    await expect(this.typographyListBox).toBeVisible();
+  }
+
+  async searchTypographyTokens(value) {
+    await this.openTypographyTokenList(value);
+    await this.typographySearchTokenListInput.type(value);
+  }
+
+  async areTypographyTokenFromListVisible(values) {
+    for (const value of values) {
+      const token = this.getTypographyTokenOptionFromListByName(value);
+      await expect(
+        token,
+        `Token ${value} is visible in typography token list`,
+      ).toBeVisible();
+    }
+  }
+
+  async searchAndApplyTypographyTokenFromTokensList(value) {
+    await this.searchTypographyTokens(value);
+    const token = this.getTypographyTokenOptionFromListByName(value);
+    await expect(
+      token,
+      `Token ${value} is visible in typography token list`,
+    ).toBeVisible();
+    await token.click();
+  }
+
+  async textOptionsAreVisible(visible = true) {
+    visible
+      ? await expect(
+          await this.textOptionsFull,
+          `Text options are visible`,
+        ).toBeVisible()
+      : await expect(
+          await this.textOptionsFull,
+          `Text options are not visible`,
+        ).not.toBeVisible();
   }
 };

--- a/pages/workspace/design-panel-page.js
+++ b/pages/workspace/design-panel-page.js
@@ -2248,13 +2248,13 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
     });
   }
 
-  async openTypographyTokenList(value) {
+  async openTypographyTokenList() {
     await this.typographyOpenTokenListButton.click();
     await expect(this.typographyListBox).toBeVisible();
   }
 
   async searchTypographyTokens(value) {
-    await this.openTypographyTokenList(value);
+    await this.openTypographyTokenList();
     await this.typographySearchTokenListInput.type(value);
   }
 

--- a/tests/tokens/tokens-in-design-tab.spec.ts
+++ b/tests/tokens/tokens-in-design-tab.spec.ts
@@ -9,6 +9,7 @@ import { LayersPanelPage } from '@pages/workspace/layers-panel-page';
 import { createTeamName } from 'helpers/teams/create-team-name';
 import { MainToken } from '@pages/workspace/tokens/token-components/main-tokens-component';
 import { TokenClass } from '@pages/workspace/tokens/token-components/tokens-base-component';
+import { TypographyToken } from '@pages/workspace/tokens/token-components/typography-tokens-component';
 
 const teamName = createTeamName();
 const ariaLabel: string = 'Width';
@@ -32,225 +33,333 @@ mainTest.beforeEach(async ({ page }) => {
   await dashboardPage.isHeaderDisplayed('Projects');
 });
 
-mainTest.describe(() => {
-  mainTest.beforeEach(async () => {
-    await dashboardPage.createFileViaPlaceholder();
-    await mainPage.isMainPageLoaded();
+mainTest.describe('Numeric inputs', () => {
+  mainTest.describe(() => {
+    mainTest.beforeEach(async () => {
+      await dashboardPage.createFileViaPlaceholder();
+      await mainPage.isMainPageLoaded();
+    });
+
+    mainTest.describe(() => {
+      mainTest.beforeEach(async () => {
+        await tokensPage.clickTokensTab();
+        await tokensPage.toolsComp.clickOnTokenToolsButton();
+        await tokensPage.toolsComp.importTokens(
+          'documents/tokens-for-each-category.json',
+        );
+        await tokensPage.setsComp.isSetNameVisible('Global');
+      });
+
+      mainTest(
+        qase(
+          [2905, 2873],
+          'Selecting a token via the Token Icon and detaching via the detach button ',
+        ),
+        async () => {
+          const tokenName: string = 'SIZING-2';
+          const tokenValue: string = '2';
+
+          await mainTest.step(
+            '(2905) Selecting a token via the Token Icon updates the input value applied to a shape',
+            async () => {
+              await mainTest.step('Create rectangle', async () => {
+                await tokensPage.createDefaultRectangleByCoordinates(100, 200);
+              });
+
+              await mainTest.step('Hover on Width field in Design tab', async () => {
+                await designPanelPage.hoverOnWidthForLayer();
+              });
+
+              await mainTest.step('Open token list in Width field', async () => {
+                const widthFieldIndex = 1;
+                await designPanelPage.openTokenListByIndex(widthFieldIndex);
+              });
+
+              await mainTest.step('Select token in token list by name', async () => {
+                await designPanelPage.selectTokenInTokenListByName(tokenName);
+              });
+
+              await mainTest.step('Check applied token', async () => {
+                await designPanelPage.checkSizeWidth(tokenValue);
+              });
+
+              await mainTest.step(
+                'Hover in token value, check tooltip and detach token button',
+                async () => {
+                  await designPanelPage.hoverOnTokenPill(ariaLabel);
+                  await designPanelPage.isTokenPillTooltipVisible(tokenName);
+                  await designPanelPage.isDetachTokenButtonVisible();
+                },
+              );
+
+              await mainTest.step('Check applied token in Token tab', async () => {
+                await tokensPage.tokensComp.expandTokenByName(TokenClass.Sizing);
+                await tokensPage.tokensComp.isTokenAppliedWithName(tokenName);
+              });
+            },
+          );
+
+          await mainTest.step(
+            '(2873) Detaching via detach button removes token and displays raw value in the numeric input',
+            async () => {
+              await mainTest.step('Detach token', async () => {
+                await designPanelPage.clickOnDetachTokenButton();
+                await designPanelPage.checkSizeWidth(tokenValue);
+              });
+
+              await mainTest.step('Check unapplied token in Token tab', async () => {
+                await tokensPage.tokensComp.isTokenAppliedWithName(tokenName, false);
+              });
+
+              await mainTest.step('Edit width', async () => {
+                const newWidthValue: string = '10';
+                await designPanelPage.changeWidthForLayer(newWidthValue);
+                await designPanelPage.checkSizeWidth(newWidthValue);
+              });
+            },
+          );
+        },
+      );
+    });
+
+    mainTest(
+      qase(2865, 'Broken token references are clearly displayed with a red dot'),
+      async () => {
+        const dimensionTokenA: MainToken<TokenClass> = {
+          class: TokenClass.Dimension,
+          name: 'dimension-A',
+          value: '550.5',
+        };
+
+        const dimensionTokenB: MainToken<TokenClass> = {
+          class: TokenClass.Dimension,
+          name: 'dimension-B',
+          value: '{dimension-A}',
+        };
+
+        await mainTest.step('Create a dimension token', async () => {
+          await tokensPage.clickTokensTab();
+          await tokensPage.tokensComp.createTokenViaAddButtonAndSave(
+            dimensionTokenA,
+          );
+          await tokensPage.tokensComp.isTokenVisibleWithName(dimensionTokenA.name);
+        });
+
+        await mainTest.step(
+          'Create another dimension token referencing the first one',
+          async () => {
+            await tokensPage.tokensComp.createTokenViaAddButtonAndSave(
+              dimensionTokenB,
+            );
+            await tokensPage.tokensComp.isTokenVisibleWithName(dimensionTokenB.name);
+          },
+        );
+
+        await mainTest.step('Create rectangle', async () => {
+          await tokensPage.createDefaultRectangleByCoordinates(100, 200);
+        });
+
+        await mainTest.step('Open token list in Width field', async () => {
+          const widthFieldIndex = 0;
+          await designPanelPage.openTokenListByIndex(widthFieldIndex);
+        });
+
+        await mainTest.step(
+          'Select the second token in token list by name',
+          async () => {
+            await designPanelPage.selectTokenInTokenListByName(dimensionTokenB.name);
+          },
+        );
+
+        await mainTest.step('Check applied token', async () => {
+          await designPanelPage.checkSizeWidth(dimensionTokenA.value);
+        });
+
+        await mainTest.step('Delete the referenced token', async () => {
+          await tokensPage.tokensComp.deleteToken(dimensionTokenA.name);
+          await tokensPage.tokensComp.isTokenVisibleWithName(
+            dimensionTokenA.name,
+            false,
+          );
+        });
+
+        await mainTest.step(
+          'Check value and not valid reference in input',
+          async () => {
+            await designPanelPage.checkSizeWidth(dimensionTokenA.value);
+            await designPanelPage.isNotTokenValidReferencedButtonVisible(
+              dimensionTokenB.name,
+            );
+          },
+        );
+
+        await mainTest.step('Hover in token value and check tooltip', async () => {
+          const errorMessage: string = `Reference in {${dimensionTokenB.name}} is not valid or is not in any active set.`;
+          await designPanelPage.hoverOnTokenPill(ariaLabel);
+          await designPanelPage.isTokenPillTooltipVisible(errorMessage);
+        });
+      },
+    );
   });
 
   mainTest.describe(() => {
+    const hexColor: string = '#ec9090';
+    const setName: string = 'Light';
+
     mainTest.beforeEach(async () => {
-      await tokensPage.clickTokensTab();
-      await tokensPage.toolsComp.clickOnTokenToolsButton();
-      await tokensPage.toolsComp.importTokens(
-        'documents/tokens-for-each-category.json',
+      await dashboardPage.openSidebarItem('Drafts');
+      await dashboardPage.importFileFromProjectPage(
+        'documents/num-inputs-in-set-themes.penpot',
       );
-      await tokensPage.setsComp.isSetNameVisible('Global');
+      await dashboardPage.isFilePresent('num inputs in set/themes');
+      await dashboardPage.openFileWithName('num inputs in set/themes');
+      await mainPage.isMainPageLoaded();
+      await layersPanelPage.selectLayerByName('Rectangle');
+      await tokensPage.clickTokensTab();
     });
 
     mainTest(
       qase(
-        [2905, 2873],
-        'Selecting a token via the Token Icon and detaching via the detach button ',
+        2891,
+        'Token pill updates displayed value after token value change in active token set',
       ),
       async () => {
-        const tokenName: string = 'SIZING-2';
-        const tokenValue: string = '2';
+        const newHexColor: string = '#f1d0d0';
 
         await mainTest.step(
-          '(2905) Selecting a token via the Token Icon updates the input value applied to a shape',
+          'Hover on fill color input and check token value in tootltip message',
           async () => {
-            await mainTest.step('Create rectangle', async () => {
-              await tokensPage.createDefaultRectangleByCoordinates(100, 200);
-            });
+            const messageText = `Resolved value: ${hexColor}`;
+            await designPanelPage.checkTooltipInFillColorInput(messageText);
+          },
+        );
 
-            await mainTest.step('Hover on Width field in Design tab', async () => {
-              await designPanelPage.hoverOnWidthForLayer();
-            });
+        await mainTest.step('Click on the Mode/Light token set', async () => {
+          await tokensPage.setsComp.isSetNameVisible(setName);
+          await tokensPage.setsComp.clickSetItemButton(setName);
+        });
 
-            await mainTest.step('Open token list in Width field', async () => {
-              const widthFieldIndex = 1;
-              await designPanelPage.openTokenListByIndex(widthFieldIndex);
-            });
+        await mainTest.step('Change color token value', async () => {
+          const colorToken: MainToken<TokenClass> = {
+            class: TokenClass.Color,
+            name: 'red',
+            value: newHexColor,
+          };
+          await tokensPage.tokensComp.expandTokenByName(TokenClass.Color);
+          await tokensPage.tokensComp.editTokenViaRightClickAndSave(colorToken);
+          await mainPage.waitForChangeIsSaved();
+        });
 
-            await mainTest.step('Select token in token list by name', async () => {
-              await designPanelPage.selectTokenInTokenListByName(tokenName);
-            });
+        await mainTest.step(
+          'Hover on fill color input and check token value in tootltip message',
+          async () => {
+            const messageText = `Resolved value: ${newHexColor}`;
+            await designPanelPage.checkTooltipInFillColorInput(messageText);
+          },
+        );
+      },
+    );
 
-            await mainTest.step('Check applied token', async () => {
-              await designPanelPage.checkSizeWidth(tokenValue);
-            });
+    mainTest(
+      qase(
+        2893,
+        'Token pill shows unresolved state when token set becomes inactive',
+      ),
+      async () => {
+        const tokenName: string = 'red';
 
-            await mainTest.step(
-              'Hover in token value, check tooltip and detach token button',
-              async () => {
-                await designPanelPage.hoverOnTokenPill(ariaLabel);
-                await designPanelPage.isTokenPillTooltipVisible(tokenName);
-                await designPanelPage.isDetachTokenButtonVisible();
-              },
-            );
+        await mainTest.step(
+          'Hover on fill color input and check token value in tootltip message',
+          async () => {
+            const messageText = `Resolved value: ${hexColor}`;
+            await designPanelPage.checkTooltipInFillColorInput(messageText);
+          },
+        );
 
-            await mainTest.step('Check applied token in Token tab', async () => {
-              await tokensPage.tokensComp.expandTokenByName(TokenClass.Sizing);
-              await tokensPage.tokensComp.isTokenAppliedWithName(tokenName);
-            });
+        await mainTest.step('Deactivate the Mode/Light set', async () => {
+          await tokensPage.setsComp.isSetNameVisible(setName);
+          await tokensPage.setsComp.clickOnSetCheckboxByName(setName);
+        });
+
+        await mainTest.step(
+          'Check not in any active set red dot in input',
+          async () => {
+            await designPanelPage.isNotTokenInAnyActiveSetButtonVisible(tokenName);
           },
         );
 
         await mainTest.step(
-          '(2873) Detaching via detach button removes token and displays raw value in the numeric input',
+          'Hover on fill color input and check error in tootltip message',
           async () => {
-            await mainTest.step('Detach token', async () => {
-              await designPanelPage.clickOnDetachTokenButton();
-              await designPanelPage.checkSizeWidth(tokenValue);
-            });
-
-            await mainTest.step('Check unapplied token in Token tab', async () => {
-              await tokensPage.tokensComp.isTokenAppliedWithName(tokenName, false);
-            });
-
-            await mainTest.step('Edit width', async () => {
-              const newWidthValue: string = '10';
-              await designPanelPage.changeWidthForLayer(newWidthValue);
-              await designPanelPage.checkSizeWidth(newWidthValue);
-            });
+            const messageText: string = `{${tokenName}} token is not in any active set or has an invalid value.`;
+            await designPanelPage.checkTooltipInFillColorInput(messageText);
           },
         );
       },
     );
   });
-
-  mainTest(
-    qase([2865], 'Broken token references are clearly displayed with a red dot'),
-    async () => {
-      const dimensionTokenA: MainToken<TokenClass> = {
-        class: TokenClass.Dimension,
-        name: 'dimension-A',
-        value: '550.5',
-      };
-
-      const dimensionTokenB: MainToken<TokenClass> = {
-        class: TokenClass.Dimension,
-        name: 'dimension-B',
-        value: '{dimension-A}',
-      };
-
-      await mainTest.step('Create a dimension token', async () => {
-        await tokensPage.clickTokensTab();
-        await tokensPage.tokensComp.createTokenViaAddButtonAndSave(dimensionTokenA);
-        await tokensPage.tokensComp.isTokenVisibleWithName(dimensionTokenA.name);
-      });
-
-      await mainTest.step(
-        'Create another dimension token referencing the first one',
-        async () => {
-          await tokensPage.tokensComp.createTokenViaAddButtonAndSave(
-            dimensionTokenB,
-          );
-          await tokensPage.tokensComp.isTokenVisibleWithName(dimensionTokenB.name);
-        },
-      );
-
-      await mainTest.step('Create rectangle', async () => {
-        await tokensPage.createDefaultRectangleByCoordinates(100, 200);
-      });
-
-      await mainTest.step('Open token list in Width field', async () => {
-        const widthFieldIndex = 0;
-        await designPanelPage.openTokenListByIndex(widthFieldIndex);
-      });
-
-      await mainTest.step(
-        'Select the second token in token list by name',
-        async () => {
-          await designPanelPage.selectTokenInTokenListByName(dimensionTokenB.name);
-        },
-      );
-
-      await mainTest.step('Check applied token', async () => {
-        await designPanelPage.checkSizeWidth(dimensionTokenA.value);
-      });
-
-      await mainTest.step('Delete the referenced token', async () => {
-        await tokensPage.tokensComp.deleteToken(dimensionTokenA.name);
-        await tokensPage.tokensComp.isTokenVisibleWithName(
-          dimensionTokenA.name,
-          false,
-        );
-      });
-
-      await mainTest.step(
-        'Check value and not valid reference in input',
-        async () => {
-          await designPanelPage.checkSizeWidth(dimensionTokenA.value);
-          await designPanelPage.isNotTokenValidReferencedButtonVisible(
-            dimensionTokenB.name,
-          );
-        },
-      );
-
-      await mainTest.step('Hover in token value and check tooltip', async () => {
-        const errorMessage: string = `Reference in {${dimensionTokenB.name}} is not valid or is not in any active set.`;
-        await designPanelPage.hoverOnTokenPill(ariaLabel);
-        await designPanelPage.isTokenPillTooltipVisible(errorMessage);
-      });
-    },
-  );
 });
 
-mainTest.describe(() => {
-  const hexColor: string = '#ec9090';
-  const setName: string = 'Light';
-
-  mainTest.beforeEach(async () => {
-    await dashboardPage.openSidebarItem('Drafts');
-    await dashboardPage.importFileFromProjectPage(
-      'documents/num-inputs-in-set-themes.penpot',
-    );
-    await dashboardPage.isFilePresent('num inputs in set/themes');
-    await dashboardPage.openFileWithName('num inputs in set/themes');
+mainTest.describe('Typography token', () => {
+  mainTest.beforeEach(async ({ page }) => {
+    await dashboardPage.createFileViaPlaceholder();
     await mainPage.isMainPageLoaded();
-    await layersPanelPage.selectLayerByName('Rectangle');
-    await tokensPage.clickTokensTab();
+    await mainPage.createDefaultTextLayerByCoordinates(500, 500);
+    await tokensPage.tokensTab.click();
   });
 
-  mainTest(
-    qase(
-      [2891],
-      'Token pill updates displayed value after token value change in active token set',
-    ),
-    async () => {
-      const newHexColor: string = '#f1d0d0';
+  const TYPO_TOKEN: TypographyToken<TokenClass> = {
+    class: TokenClass.Typography,
+    name: 'typography',
+    fontFamily: 'Karla',
+    fontWeight: '500 Italic',
+    fontSize: '18px',
+    lineHeight: '1.5px',
+    letterSpacing: '0.5',
+    textDecoration: 'strike-through',
+    textCase: 'uppercase',
+    description: 'Autotest typography token',
+  };
 
+  const TYPO_TOKEN_2: TypographyToken<TokenClass> = {
+    class: TokenClass.Typography,
+    name: 'typography_2',
+    fontFamily: 'Karla',
+    fontWeight: '400 Italic',
+    fontSize: '15',
+    lineHeight: '2',
+    letterSpacing: '0.5',
+    textDecoration: 'underline',
+    textCase: 'uppercase',
+    description: 'Autotest typography token',
+  };
+
+  mainTest(
+    qase(3017, 'Unresolved token state displayed when applied token is deleted'),
+    async () => {
       await mainTest.step(
-        'Hover on fill color input and check token value in tootltip message',
+        'Create a typography token and apply it to a text layer',
         async () => {
-          const messageText = `Resolved value: ${hexColor}`;
-          await designPanelPage.checkTooltipInFillColorInput(messageText);
+          await tokensPage.tokensComp.clickOnAddTokenAndFillData(TYPO_TOKEN);
+          await tokensPage.tokensComp.baseComp.clickOnSaveButton();
+          await mainPage.waitForChangeIsSaved();
+          await tokensPage.tokensComp.isTokenVisibleWithName(TYPO_TOKEN.name);
+          await tokensPage.tokensComp.clickOnTokenWithName(TYPO_TOKEN.name);
         },
       );
 
-      await mainTest.step('Click on the Mode/Light token set', async () => {
-        await tokensPage.setsComp.isSetNameVisible(setName);
-        await tokensPage.setsComp.clickSetItemButton(setName);
-      });
-
-      await mainTest.step('Change color token value', async () => {
-        const colorToken: MainToken<TokenClass> = {
-          class: TokenClass.Color,
-          name: 'red',
-          value: newHexColor,
-        };
-        await tokensPage.tokensComp.expandTokenByName(TokenClass.Color);
-        await tokensPage.tokensComp.editTokenViaRightClickAndSave(colorToken);
-        await mainPage.waitForChangeIsSaved();
+      await mainTest.step('Delete token', async () => {
+        await tokensPage.tokensComp.deleteToken(TYPO_TOKEN.name);
+        await tokensPage.tokensComp.isTokenVisibleWithName(TYPO_TOKEN.name, false);
       });
 
       await mainTest.step(
-        'Hover on fill color input and check token value in tootltip message',
+        'Reselect layer and assert design tab displays an unresolved token state',
         async () => {
-          const messageText = `Resolved value: ${newHexColor}`;
-          await designPanelPage.checkTooltipInFillColorInput(messageText);
+          await designPanelPage.hoverTypographyToken();
+          await designPanelPage.isTokenNotExistOrDeletedTooltipVisible(
+            TYPO_TOKEN.name,
+          );
         },
       );
     },
@@ -258,39 +367,104 @@ mainTest.describe(() => {
 
   mainTest(
     qase(
-      [2893],
-      'Token pill shows unresolved state when token set becomes inactive',
+      [3020, 3021],
+      'Applying typography token from filtered search results applies correct token / Detach typography token',
     ),
     async () => {
-      const tokenName: string = 'red';
-
       await mainTest.step(
-        'Hover on fill color input and check token value in tootltip message',
+        '(3020) Applying typography token from filtered search results applies correct token',
         async () => {
-          const messageText = `Resolved value: ${hexColor}`;
-          await designPanelPage.checkTooltipInFillColorInput(messageText);
+          await mainTest.step(
+            'Create two typography tokens and select layer',
+            async () => {
+              await mainTest.step(
+                'Create a FIRST typography token and apply it to a text layer',
+                async () => {
+                  await tokensPage.tokensComp.clickOnAddTokenAndFillData(TYPO_TOKEN);
+                  await tokensPage.tokensComp.baseComp.clickOnSaveButton();
+                  await mainPage.waitForChangeIsSaved();
+                  await tokensPage.tokensComp.isTokenVisibleWithName(
+                    TYPO_TOKEN.name,
+                  );
+                },
+              );
+
+              await mainTest.step(
+                'Create a SECOND typography token and apply it to a text layer',
+                async () => {
+                  await tokensPage.tokensComp.clickOnAddTokenAndFillData(
+                    TYPO_TOKEN_2,
+                  );
+                  await tokensPage.tokensComp.baseComp.clickOnSaveButton();
+                  await mainPage.waitForChangeIsSaved();
+                  await tokensPage.tokensComp.isTokenVisibleWithName(
+                    TYPO_TOKEN_2.name,
+                  );
+                },
+              );
+
+              await mainTest.step('Select text layer', async () => {
+                await layersPanelPage.openLayersTab();
+                await layersPanelPage.selectLayerByName('Hello world!');
+              });
+            },
+          );
+
+          await mainTest.step(
+            `From Design tab, open tokens list, apply ${TYPO_TOKEN_2.name} and assert text options are not visible and underline/strike through are disabled`,
+            async () => {
+              await designPanelPage.searchAndApplyTypographyTokenFromTokensList(
+                TYPO_TOKEN_2.name,
+              );
+              await designPanelPage.textOptionsAreVisible(false);
+              await designPanelPage.openTextMoreOptionsBlock();
+              await designPanelPage.isTextUnderlineDisabled();
+              await designPanelPage.isTextStrikethroughDisabled();
+            },
+          );
+
+          await mainTest.step(
+            'Assert typography values from typography token modal',
+            async () => {
+              await designPanelPage.hoverAndAssertTypographyTokenValues(
+                TYPO_TOKEN_2.name,
+                {
+                  fontFamily: TYPO_TOKEN_2.fontFamily,
+                  fontSize: TYPO_TOKEN_2.fontSize,
+                  fontWeight: TYPO_TOKEN_2.fontWeight,
+                  letterSpacing: TYPO_TOKEN_2.letterSpacing,
+                  textCase: TYPO_TOKEN_2.textCase,
+                  textDecoration: TYPO_TOKEN_2.textDecoration,
+                  lineHeight: TYPO_TOKEN_2.lineHeight,
+                },
+              );
+            },
+          );
         },
       );
 
-      await mainTest.step('Deactivate the Mode/Light set', async () => {
-        await tokensPage.setsComp.isSetNameVisible(setName);
-        await tokensPage.setsComp.clickOnSetCheckboxByName(setName);
+      await mainTest.step('(3021) Detach typography token', async () => {
+        await mainTest.step(
+          `Hover over typography token and click detach button`,
+          async () => {
+            await designPanelPage.clickOnDetachTokenButton();
+            await designPanelPage.textOptionsAreVisible();
+          },
+        );
+
+        await mainTest.step(
+          `Assert typography values have not changed`,
+          async () => {
+            await designPanelPage.checkFontName(TYPO_TOKEN_2.fontFamily);
+            await designPanelPage.checkFontStyle(TYPO_TOKEN_2.fontWeight);
+            await designPanelPage.checkFontSize(TYPO_TOKEN_2.fontSize);
+            await designPanelPage.checkLetterSpacing(TYPO_TOKEN_2.letterSpacing);
+            await designPanelPage.checkTextCase(TYPO_TOKEN_2.textCase);
+            await designPanelPage.checkTextLineHeight(TYPO_TOKEN_2.lineHeight);
+            await designPanelPage.isTextUnderlineChecked();
+          },
+        );
       });
-
-      await mainTest.step(
-        'Check not in any active set red dot in input',
-        async () => {
-          await designPanelPage.isNotTokenInAnyActiveSetButtonVisible(tokenName);
-        },
-      );
-
-      await mainTest.step(
-        'Hover on fill color input and check error in tootltip message',
-        async () => {
-          const messageText: string = `{${tokenName}} token is not in any active set or has an invalid value.`;
-          await designPanelPage.checkTooltipInFillColorInput(messageText);
-        },
-      );
     },
   );
 });

--- a/tests/tokens/tokens-in-design-tab.spec.ts
+++ b/tests/tokens/tokens-in-design-tab.spec.ts
@@ -354,7 +354,7 @@ mainTest.describe('Typography token', () => {
       });
 
       await mainTest.step(
-        'Reselect layer and assert design tab displays an unresolved token state',
+        'Assert design tab displays an unresolved token state',
         async () => {
           await designPanelPage.hoverTypographyToken();
           await designPanelPage.isTokenNotExistOrDeletedTooltipVisible(
@@ -377,17 +377,12 @@ mainTest.describe('Typography token', () => {
           await mainTest.step(
             'Create two typography tokens and select layer',
             async () => {
-              await mainTest.step(
-                'Create a FIRST typography token and apply it to a text layer',
-                async () => {
-                  await tokensPage.tokensComp.clickOnAddTokenAndFillData(TYPO_TOKEN);
-                  await tokensPage.tokensComp.baseComp.clickOnSaveButton();
-                  await mainPage.waitForChangeIsSaved();
-                  await tokensPage.tokensComp.isTokenVisibleWithName(
-                    TYPO_TOKEN.name,
-                  );
-                },
-              );
+              await mainTest.step('Create a FIRST typography token', async () => {
+                await tokensPage.tokensComp.clickOnAddTokenAndFillData(TYPO_TOKEN);
+                await tokensPage.tokensComp.baseComp.clickOnSaveButton();
+                await mainPage.waitForChangeIsSaved();
+                await tokensPage.tokensComp.isTokenVisibleWithName(TYPO_TOKEN.name);
+              });
 
               await mainTest.step(
                 'Create a SECOND typography token and apply it to a text layer',
@@ -444,13 +439,10 @@ mainTest.describe('Typography token', () => {
       );
 
       await mainTest.step('(3021) Detach typography token', async () => {
-        await mainTest.step(
-          `Hover over typography token and click detach button`,
-          async () => {
-            await designPanelPage.clickOnDetachTokenButton();
-            await designPanelPage.textOptionsAreVisible();
-          },
-        );
+        await mainTest.step(`Click on detach button`, async () => {
+          await designPanelPage.clickOnDetachTokenButton();
+          await designPanelPage.textOptionsAreVisible();
+        });
 
         await mainTest.step(
           `Assert typography values have not changed`,

--- a/tests/tokens/tokens-in-design-tab.spec.ts
+++ b/tests/tokens/tokens-in-design-tab.spec.ts
@@ -451,7 +451,7 @@ mainTest.describe('Typography token', () => {
             await designPanelPage.checkFontStyle(TYPO_TOKEN_2.fontWeight);
             await designPanelPage.checkFontSize(TYPO_TOKEN_2.fontSize);
             await designPanelPage.checkLetterSpacing(TYPO_TOKEN_2.letterSpacing);
-            await designPanelPage.checkTextCase(TYPO_TOKEN_2.textCase);
+            await designPanelPage.checkTextCase('Upper');
             await designPanelPage.checkTextLineHeight(TYPO_TOKEN_2.lineHeight);
             await designPanelPage.isTextUnderlineChecked();
           },


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/task/1633

## Description

Implements new tests for typography tokens management in Design tab:

<img width="761" height="290" alt="image" src="https://github.com/user-attachments/assets/2a15e921-caca-48d2-ad4f-ea3c82deb65f" />

## Solution

- Adds new tests in tokens-in-design-tab spec file.
- Refactors spec file to add two separated describe blocks for numeric inputs and for typography.
- Adds new methods to be used in tests and refactors existing ones for easier debugging and traceability.
- Refactors existing locators in DesignPanelPage.

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots
- [ ] The tests run OK

## Test Execution Results in CI

Non-related failure.

<img width="1037" height="271" alt="image" src="https://github.com/user-attachments/assets/cb9cfc15-e41f-4f42-b160-02c9c55cee8b" />

