### PR TITLE
chore(github): updates Daily action to execute at 22:50 PM

### DIFF
--- a/.github/workflows/playwright_pre_daily.yml
+++ b/.github/workflows/playwright_pre_daily.yml
@@ -1,7 +1,7 @@
 name: Daily Penpot Regression Tests on PRE
 on:
-  schedule: ## run tests at 01:00am UTC on every day-of-week from Monday through Friday
-    - cron: '00 1 * * 1-5'
+  schedule: ## run tests at 20:50 UTC (22:50 UTC+2) on every day-of-week from Monday through Friday
+    - cron: '50 20 * * 1-5'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL

[Taiga Ticket: 1653](https://tree.taiga.io/project/kaleidos-qa/us/1653)

## Description

This PR updates the scheduled time for the Daily Penpot Regression Tests on PRE action to run effectively at 23:30 local time UTC+2 (from 3:40 AM before). 

We'll try to have the reports ready before we start working, addressing the GitHub delays. 
It's everything described in the task.

## Solution

* We'll try with this scheduled time first, trying to avoid the GitHub delays.
* We'll check it tomorrow.

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots
- [ ] The tests run OK

## Screenshots 📸 (optional)

<img width="830" height="266" alt="image" src="https://github.com/user-attachments/assets/8d57dad5-9d8f-4daa-b58b-bb5cc7dc1997" />