### PR TITLE
fix(test): 1312 solved drag&drop flakiness

### DIFF
--- a/helpers/drag-and-drop.ts
+++ b/helpers/drag-and-drop.ts
@@ -1,0 +1,41 @@
+import { Locator, Page } from '@playwright/test';
+
+/**
+ * Drags `source` and drops it onto `target` at the given position relative
+ * to `target`'s top-left corner.
+ *
+ * Locator.dragTo() moves the pointer to the drop point in a single jump -
+ * one mousemove event. Playwright's own docs on manual dragging
+ * (https://playwright.dev/docs/input#dragging-manually) note that pages
+ * relying on the dragover event need at least two pointer moves at the drop
+ * point to fire it reliably. Penpot's canvas is one of those pages: with
+ * only one move, a dropped shape can end up selected in the data model
+ * (visible in the design/layers panel) while its selection-outline overlay
+ * never renders.
+ *
+ * The fix is to land on the drop point, nudge off it by a couple of
+ * pixels, then move back onto it - three real, distinct pointer moves
+ * instead of one. Moving through other UI on the way to the drop point
+ * (e.g. interpolating the whole path from source to target) was tried
+ * first and made the shape land elsewhere, presumably by crossing other
+ * interactive canvas controls mid-drag - so the jiggle happens only once
+ * already at the drop point.
+ */
+export async function dragAndDropOnCanvas(
+  page: Page,
+  source: Locator,
+  target: Locator,
+  x: number,
+  y: number,
+) {
+  await source.hover();
+  await page.mouse.down();
+  await target.hover({ position: { x, y } });
+  const targetBox = await target.boundingBox();
+  if (!targetBox) {
+    throw new Error('Cannot compute bounding box of drag-and-drop target');
+  }
+  await page.mouse.move(targetBox.x + x + 2, targetBox.y + y + 2, { steps: 3 });
+  await page.mouse.move(targetBox.x + x, targetBox.y + y, { steps: 3 });
+  await page.mouse.up();
+}

--- a/pages/workspace/assets-panel-page.js
+++ b/pages/workspace/assets-panel-page.js
@@ -1,5 +1,6 @@
 const { BasePage } = require('../base-page');
 const { expect } = require('@playwright/test');
+const { dragAndDropOnCanvas } = require('helpers/drag-and-drop');
 
 exports.AssetsPanelPage = class AssetsPanelPage extends BasePage {
   /**
@@ -439,9 +440,13 @@ exports.AssetsPanelPage = class AssetsPanelPage extends BasePage {
   }
 
   async dragComponentOnCanvas(x, y) {
-    await this.assetComponentLabel.dragTo(this.viewport, {
-      targetPosition: { x: x, y: y },
-    });
+    await dragAndDropOnCanvas(
+      this.page,
+      this.assetComponentLabel,
+      this.viewport,
+      x,
+      y,
+    );
   }
 
   async expandComponentsBlockOnAssetsTab() {

--- a/tests/components/main-components/create-main-components.spec.ts
+++ b/tests/components/main-components/create-main-components.spec.ts
@@ -73,6 +73,7 @@ mainTest(
     await mainTest.step('Verify component on canvas and layers panel', async () => {
       await layersPanelPage.openLayersTab();
       await mainPage.hideRulersViaMainMenu();
+      await mainPage.waitForChangeIsSaved();
       await expect(
         mainPage.viewport,
         'Viewport should match screenshot with copy of main component on canvas',


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

[Taiga Ticket: 1655](https://tree.taiga.io/project/kaleidos-qa/task/1655)

## Description

This PR fixes `Drag a component from assets tab and drop into workspace` (Qase 1312), which was [failing](https://kaleidos-qa-reports.s3.eu-west-1.amazonaws.com/run-28901665570/index.html#?testId=4ee720e29729fe270d2e-10e9efef0500232adcdd) in the reports.

## Problem

Playwright's `Locator.dragTo()` moves the pointer to the drop point in a single jump (one `mousemove` event). 

Penpot's canvas needs at least [two real pointer moves](https://playwright.dev/docs/input#dragging-manually) at the drop point to reliably render the selection-outline overlay after a drop — with only one, the shape can end up selected in data but never visually outlined. 

A human drag always produces many intermediate pointer events, which is why this was invisible in manual testing.

## Solution

- Added `helpers/drag-and-drop.ts` (`dragAndDropOnCanvas`): lands on the drop point, jiggles off it by a couple of pixels, then moves back — giving the app real, distinct pointer-move events instead of one. `AssetsPanelPage.dragComponentOnCanvas()` now uses it.
- Added `waitForChangeIsSaved()` before the final screenshot in the test itself, closing a separate small flake where the assertion could race the drop's save-confirmation round trip.

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots
- [ ] The tests run OK

## Screenshots 📸 (optional)

60+ consecutive local repeats of the target test with no failures, plus repeat runs of two other tests that share the same drag helper with position-sensitive assertions (Qase 1526/1527), confirming no regression in drop accuracy.
<img width="895" height="181" alt="image" src="https://github.com/user-attachments/assets/b2e97e77-c3ee-4085-a856-8a0b8bacf3f9" />


The same test, repeated 20 times locally from the `main` branch, fails frequently.
<img width="923" height="181" alt="image" src="https://github.com/user-attachments/assets/52a4352b-4f05-41a0-81d0-29898932a559" />


20 remote runs, being flaky at worst.
<img width="896" height="145" alt="image" src="https://github.com/user-attachments/assets/fcf68343-6585-4df4-bc87-9d47e8a6f677" />

