### PR TITLE
refactor(tests): remove redundant grid layout copy-paste test [1977]

### DIFF
--- a/tests/action-menu/copy-paste-properties.spec.ts
+++ b/tests/action-menu/copy-paste-properties.spec.ts
@@ -179,24 +179,6 @@ mainTest.describe(() => {
     },
   );
 
-  mainTest(
-    qase([1977], 'Copy paste properties of Grid layout to another Board'),
-    async () => {
-      await mainPage.createDefaultBoardByCoordinates(100, 100);
-      await mainPage.addGridLayoutViaRightClick();
-      await mainPage.clickCreatedBoardTitleOnCanvas();
-      await designPanelPage.changeLayoutAlignment('Center', false);
-      await mainPage.waitForChangeIsSaved();
-
-      await mainPage.clickShortcutCtrlAltC();
-
-      await mainPage.createDefaultBoardByCoordinates(100, 700, true);
-      await mainPage.clickShortcutCtrlAltV();
-
-      await designPanelPage.isLayoutAlignmentSelected('Center', false);
-    },
-  );
-
   mainTest(qase([1978], 'Copy paste typography property'), async () => {
     await mainPage.createDefaultTextLayerByCoordinates(100, 100);
     await assetsPanelPage.selectFont('Sofia');


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

[Taiga Ticket: 1657](https://tree.taiga.io/project/kaleidos-qa/task/1657)

## Description

![Cleaning GIF](https://media.giphy.com/media/IzBpqKzHLtfTa/giphy.gif)

This PR resolves cleanup of a redundant non-regression test in the `action-menu` suite.

**Change:** Removed test `[1977] "Copy paste properties of Grid layout to another Board"` from `copy-paste-properties.spec.ts`.

**Reasoning:**

- `[1977]` was marked as Non-regression in Qase, meaning it doesn't cover a main flow of a core feature — evaluated per the team criteria (main flow / significant UX contribution / previously defective flow → Regression).
- `[1977]` and `[1976]` ("Copy paste properties of Flex layout to another Board") follow the identical mechanism: create board → apply layout → copy properties (`Ctrl+Alt+C`) → create second board → paste (`Ctrl+Alt+V`) → verify alignment propagated. The only difference is the Grid vs. Flex layout type.
- Since Grid and Flex layouts share the same copy/paste properties propagation logic, `[1976]` already exercises this code path end-to-end. `[1977]` was a redundant duplicate testing the same mechanism with a different layout type, adding maintenance cost without additional coverage.
- Kept as Non-regression (no reclassification needed) — just removed as redundant coverage already provided by `[1976]`.

## How to test

- [x] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [x] It complies with the test conventions
- [ ] There are no missing snapshots
- [ ] The tests run OK
