### PR TITLE
feat(qase): add helper to check non-regression test cases

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,9 @@ REFRESH_TOKEN="" # Gmail Refresh Token for email access
 CLIENT_ID="" # Gmail Client ID for email access
 CLIENT_SECRET="" # Gmail Client Secret for email access
 STRIPE_SK="" # Stripe Secret Key for payment processing
+
+######################
+## Qase             ##
+######################
+
+QASE_TOKEN="" # Qase API token (https://app.qase.io/user/api/token)

--- a/README.md
+++ b/README.md
@@ -141,7 +141,24 @@ To exclude performance tests from the periodical regression test run the followi
 Note: The above scripts should be executed via the command line. Do not run them directly from the _package.json_,
 because in such way performance tests are not ignored.
 
-**10. Running tests via GitHub Actions.**
+**10. Check Qase non-regression tests.**
+
+A script is available to check which test cases in Qase are non-regression:
+
+1. Get your Qase API token from [Qase API Tokens](https://app.qase.io/user/api/token) and add it to `.env`:
+
+   ```
+   QASE_TOKEN=your_token_here
+   ```
+
+2. Edit `helpers/check-qase-non-regression.ts` and add your test case IDs to the `IDS` array.
+
+3. Run:
+   ```
+   npx ts-node helpers/check-qase-non-regression.ts
+   ```
+
+**11. Running tests via GitHub Actions.**
 
 On _Settings > Environments_ page 2 environments were created: _PRE_ and _PRO_.
 For each environment the appropriate secrets were added:

--- a/helpers/check-qase-non-regression.ts
+++ b/helpers/check-qase-non-regression.ts
@@ -1,0 +1,64 @@
+/**
+ * Check Qase test cases and print only non-regression ones.
+ *
+ * Qase test case types:
+ * - 0: Not set
+ * - 1: Other
+ * - 2: Smoke
+ * - 3: Regression
+ * - 4: Security
+ * - 5: Usability
+ * - 6: Performance
+ * - 7: Acceptance
+ * - 8: Functional
+ * - 9: Compatibility
+ * - 10: Integration
+ * - 11: Exploratory
+ *
+ * Usage: npx ts-node check-qase-non-regression.ts.
+ *
+ * After running the script you will see the output in the console,
+ * showing the test case IDs and their status (NON-REGRESSION or NOT FOUND).
+ */
+import { config } from 'dotenv';
+import { QaseApi } from 'qaseio';
+
+config();
+
+/** Qase API token. Get one at https://app.qase.io/user/api/token */
+const TOKEN = process.env.QASE_TOKEN;
+if (!TOKEN) {
+  console.error('QASE_TOKEN not set in .env');
+  process.exit(1);
+}
+
+const api = new QaseApi({ token: TOKEN });
+const projectCode = 'PENPOT';
+
+/** Qase test case IDs to check */
+const IDS: number[] = [
+  // Fill this array with Qase test case IDs to check
+];
+
+(async () => {
+  if (IDS.length === 0) {
+    console.error('No IDs to check. Fill the IDS array.');
+    process.exit(1);
+  }
+
+  for (const id of IDS) {
+    try {
+      const res = await api.cases.getCase(projectCode, id);
+      const tc = res.data?.result;
+      if (!tc) {
+        console.log(`PENPOT-${id}: NOT FOUND`);
+        continue;
+      }
+      /** Type 3 = Regression, skip it */
+      if (tc.type === 3) continue;
+      console.log(`PENPOT-${id}: NON-REGRESSION`);
+    } catch (e: any) {
+      console.log(`PENPOT-${id}: ERROR — ${e.message}`);
+    }
+  }
+})();

--- a/helpers/check-qase-non-regression.ts
+++ b/helpers/check-qase-non-regression.ts
@@ -15,7 +15,8 @@
  * - 10: Integration
  * - 11: Exploratory
  *
- * Usage: npx ts-node check-qase-non-regression.ts.
+ * Usage: npx ts-node helpers/check-qase-non-regression.ts
+ * from the root of the project.
  *
  * After running the script you will see the output in the console,
  * showing the test case IDs and their status (NON-REGRESSION or NOT FOUND).


### PR DESCRIPTION
## Taiga URL (optional)

[Taiga Task: 1672](https://tree.taiga.io/project/kaleidos-qa/task/1672)

## Description

![testing gif](https://media.giphy.com/media/gw3IWyGkC0rsazTi/giphy.gif)

This PR resolves the need for a quick way to check if Qase test cases are regression or non-regression.

What? A helper script that queries the Qase API and prints only non-regression test cases from a given list of IDs.
Why? Manually checking each test case in Qase is slow and error-prone when dealing with large lists.
How? Uses the existing `qaseio` package to fetch test case metadata and filters by type (type 3 = Regression).

## Solution

Added `helpers/check-qase-non-regression.ts` — a standalone script that:
- Reads `QASE_TOKEN` from `.env`
- Fetches each test case via Qase API
- Skips regression tests (type 3) and prints the rest

Also updated:
- `.env.example` — added `QASE_TOKEN` variable
- `README.md` — added section 10 with usage instructions

## How to test

- [x] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [x] It complies with the test conventions
- [ ] There are no missing snapshots
- [ ] The tests run OK

## Result

<img width="767" height="475" alt="image" src="https://github.com/user-attachments/assets/3cca0ce8-3621-45ca-b58f-3dfc29a52cb5" />
