### PR TITLE
feat(ci): add automated failure triage for freeze-week reviews

### DIFF
--- a/.github/workflows/release-triage.yml
+++ b/.github/workflows/release-triage.yml
@@ -1,0 +1,109 @@
+# .github/workflows/release-triage.yml
+#
+# Manual triage for freeze week / release promotions.
+# Actions tab -> "Release triage" -> Run workflow -> type the release tag.
+# Creates ONE Taiga user story tagged "release-<tag>" containing one task
+# per failure cluster. Re-running with the same tag adds only NEW clusters
+# to the SAME story (no duplicates) thanks to the per-release state file.
+
+name: Release triage
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag (e.g. 26.07) — story will be tagged release-<tag>'
+        required: true
+      report_run_id:
+        description: 'Override: specific run id to triage (default: last scheduled daily run on main)'
+        required: false
+      group_by:
+        description: 'Task granularity inside the release story'
+        required: false
+        default: 'cluster'
+        type: choice
+        options:
+          - cluster
+          - file
+
+permissions:
+  contents: read
+  actions: read # required for gh run list
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Resolve report to triage
+        id: report
+        run: |
+          if [ -n "${{ inputs.report_run_id }}" ]; then
+            RUN_ID="${{ inputs.report_run_id }}"
+            echo "Using manually provided run: $RUN_ID"
+          else
+            # Last finished *scheduled* daily run on main (completed, not success:
+            # the test step fails the workflow on failing nights by design)
+            RUN_ID=$(gh run list \
+              --workflow "$DAILY_WORKFLOW" \
+              --branch main \
+              --event schedule \
+              --status completed \
+              --limit 1 \
+              --json databaseId \
+              --jq '.[0].databaseId')
+            if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+              echo "No completed scheduled daily run found on main"; exit 1
+            fi
+            echo "Using last scheduled daily run on main: $RUN_ID"
+          fi
+          echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+          aws s3 cp "s3://kaleidos-qa-reports/run-$RUN_ID/results.json" results.json
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DAILY_WORKFLOW: playwright_pre_daily.yml # "Daily Penpot Regression Tests on PRE"
+
+      - name: Pull per-release triage state
+        run: |
+          mkdir -p .triage
+          aws s3 cp "s3://kaleidos-qa-reports/triage/state-release-${{ inputs.release_tag }}.json" \
+            .triage/state.json || echo "first triage for this release"
+
+      - name: Run release triage
+        run: |
+          npx tsx scripts/triage.ts \
+            --results results.json \
+            --state .triage/state.json \
+            --release "${{ inputs.release_tag }}" \
+            --group-by "${{ inputs.group_by || 'cluster' }}" \
+            --report-url "https://kaleidos-qa-reports.s3.eu-west-1.amazonaws.com/run-${{ steps.report.outputs.run_id }}/index.html"
+        env:
+          TAIGA_URL: ${{ secrets.TAIGA_URL }}
+          TAIGA_USERNAME: ${{ secrets.TAIGA_USERNAME }}
+          TAIGA_PASSWORD: ${{ secrets.TAIGA_PASSWORD }}
+          TAIGA_PROJECT: ${{ vars.TAIGA_PROJECT }}
+          TAIGA_TAGS: 'needs-triage' # release-<tag> is added automatically
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_DAILY_REPORT }}
+          DRY_RUN: '1'
+
+      - name: Push per-release triage state
+        if: always()
+        run: |
+          aws s3 cp .triage/state.json \
+            "s3://kaleidos-qa-reports/triage/state-release-${{ inputs.release_tag }}.json"
+
+      - name: Digest to job summary
+        if: always()
+        run: cat .triage/digest.md >> "$GITHUB_STEP_SUMMARY"

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,8 +22,10 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.61.1",
+        "@types/node": "^26.1.1",
         "dotenv": "^17.4.2",
-        "husky": "^9.1.7"
+        "husky": "^9.1.7",
+        "tsx": "^4.23.1"
       }
     },
     "node_modules/@babel/runtime": {
@@ -44,6 +46,422 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -104,12 +522,11 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
     },
     "node_modules/@types/node": {
-      "version": "20.11.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
-      "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
-      "peer": true,
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/acorn": {
@@ -661,6 +1078,47 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/extend": {
@@ -1640,6 +2098,38 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
@@ -1663,10 +2153,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "peer": true
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="
     },
     "node_modules/url-template": {
       "version": "2.0.8",
@@ -1745,6 +2234,188 @@
         "@jridgewell/trace-mapping": "0.3.9"
       }
     },
+    "@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "dev": true,
+      "optional": true
+    },
     "@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -1793,12 +2464,11 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
     },
     "@types/node": {
-      "version": "20.11.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
-      "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
-      "peer": true,
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "requires": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~8.3.0"
       }
     },
     "acorn": {
@@ -2161,6 +2831,40 @@
         "get-intrinsic": "^1.2.6",
         "has-tostringtag": "^1.0.2",
         "hasown": "^2.0.2"
+      }
+    },
+    "esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "requires": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "extend": {
@@ -2750,6 +3454,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
+    "tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "requires": {
+        "esbuild": "~0.28.0",
+        "fsevents": "~2.3.3"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+          "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
     "typescript": {
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
@@ -2762,10 +3485,9 @@
       "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="
     },
     "undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "peer": true
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="
     },
     "url-template": {
       "version": "2.0.8",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,10 @@
   "homepage": "https://github.com/penpot/penpotqa#readme",
   "devDependencies": {
     "@playwright/test": "^1.61.1",
+    "@types/node": "^26.1.1",
     "dotenv": "^17.4.2",
-    "husky": "^9.1.7"
+    "husky": "^9.1.7",
+    "tsx": "^4.23.1"
   },
   "dependencies": {
     "axios": "^1.18.1",

--- a/scripts/triage.ts
+++ b/scripts/triage.ts
@@ -1,0 +1,651 @@
+/**
+ * Daily test triage: Playwright results.json -> clustered failures -> Taiga tasks.
+ *
+ * Usage:
+ *   npx tsx triage.ts \
+ *     --results playwright-report/results.json \
+ *     --state .triage/state.json \
+ *     --report-url "https://<bucket>.s3.amazonaws.com/reports/${RUN_ID}/index.html"
+ *
+ * Env vars:
+ *   TAIGA_URL        e.g. https://taiga.yourcompany.com
+ *   TAIGA_USERNAME
+ *   TAIGA_PASSWORD
+ *   TAIGA_PROJECT    project slug, e.g. "penpot-qa"
+ *   DRY_RUN=1        parse + cluster + digest only, no Taiga calls
+ *
+ * Node 18+, no dependencies (uses global fetch).
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as crypto from 'node:crypto';
+
+// ---------- CLI ----------
+
+function arg(name: string, fallback?: string): string {
+  const i = process.argv.indexOf(`--${name}`);
+  if (i !== -1 && process.argv[i + 1]) return process.argv[i + 1];
+  if (fallback !== undefined) return fallback;
+  console.error(`Missing --${name}`);
+  process.exit(1);
+}
+
+const RESULTS_PATH = arg('results', 'playwright-report/results.json');
+const STATE_PATH = arg('state', '.triage/state.json');
+const REPORT_URL = arg('report-url', '');
+const RELEASE = arg('release', ''); // e.g. "26.07" -> single story tagged release-26.07 with one task per cluster
+const GROUP_BY = arg('group-by', 'cluster'); // release-mode tasks: 'cluster' (one per root cause) or 'file' (one per spec file)
+const DRY_RUN = process.env.DRY_RUN === '1';
+
+// ---------- Types ----------
+
+interface Failure {
+  testId: string; // file :: full title
+  file: string;
+  title: string;
+  qaseId?: string; // Qase case id, from annotations or title
+  error: string; // raw first error message
+  snippet: string; // first stack frame or code frame line
+  retries: number;
+  flaky: boolean; // failed then passed on retry
+}
+
+interface Cluster {
+  fingerprint: string;
+  errorSample: string;
+  files: Set<string>;
+  tests: Failure[];
+}
+
+interface StateEntry {
+  taigaRef?: number; // Taiga issue ref
+  taigaId?: number; // Taiga issue id
+  firstSeen: string;
+  lastSeen: string;
+  consecutiveRuns: number;
+  seenInLastNRuns: number[]; // 1 = failed, 0 = passed, most recent first (flakiness window)
+}
+
+type State = Record<string, StateEntry>;
+
+// ---------- Parse Playwright JSON ----------
+
+function walkSuites(suite: any, file: string, out: Failure[]) {
+  const f = suite.file ?? file;
+  for (const child of suite.suites ?? []) walkSuites(child, f, out);
+  for (const spec of suite.specs ?? []) {
+    for (const test of spec.tests ?? []) {
+      const results = test.results ?? [];
+      const last = results[results.length - 1];
+      if (!last) continue;
+
+      const everFailed = results.some(
+        (r: any) => r.status === 'failed' || r.status === 'timedOut',
+      );
+      const finallyPassed = last.status === 'passed';
+      const isFailure = test.status === 'unexpected';
+      const isFlaky = test.status === 'flaky' || (everFailed && finallyPassed);
+
+      if (!isFailure && !isFlaky) continue;
+
+      const err = results.flatMap((r: any) => r.errors ?? [])[0] ?? last.error ?? {};
+      const message: string = stripAnsi(err.message ?? 'Unknown error');
+      const stack: string = stripAnsi(err.stack ?? '');
+      const frame = firstOwnFrame(stack, f);
+
+      out.push({
+        testId: `${f} :: ${spec.title}`,
+        file: f,
+        title: spec.title,
+        qaseId: extractQaseId(spec.title, test.annotations ?? []),
+        error: message.split('\n').slice(0, 6).join('\n'),
+        snippet: frame,
+        retries: results.length - 1,
+        flaky: isFlaky && !isFailure,
+      });
+    }
+  }
+}
+
+/**
+ * Qase links live either in annotations ({type:'QaseID', description:'123'},
+ * added by qase() / playwright-qase-reporter) or in the title itself
+ * ("... (Qase ID: 123)" suffix, or a "PROJ-123:" prefix convention).
+ */
+function extractQaseId(
+  title: string,
+  annotations: Array<{ type?: string; description?: string }>,
+): string | undefined {
+  const ann = annotations.find((a) => /qase/i.test(a?.type ?? ''));
+  if (ann?.description) return String(ann.description);
+  const m =
+    title.match(/\(\s*Qase(?:\s*ID)?\s*[:=]?\s*([\w-]+)\s*\)/i) ??
+    title.match(/^([A-Z][A-Z0-9]+-\d+)\s*[:.]/);
+  return m?.[1];
+}
+
+function stripAnsi(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/\u001b\[[0-9;]*m/g, '');
+}
+
+function firstOwnFrame(stack: string, file: string): string {
+  const lines = stack.split('\n').map((l: string) => l.trim());
+  return (
+    lines.find(
+      (l: string) => l.startsWith('at ') && l.includes(path.basename(file)),
+    ) ??
+    lines.find((l: string) => l.startsWith('at ') && !l.includes('node_modules')) ??
+    ''
+  );
+}
+
+// ---------- Fingerprinting ----------
+
+/**
+ * Normalize away everything dynamic so that "the same root cause" hashes
+ * to the same fingerprint across runs and across similar tests.
+ */
+function normalizeError(msg: string): string {
+  return msg
+    .replace(/\d+ms/g, 'Nms') // timeouts
+    .replace(/\b\d{4}-\d{2}-\d{2}[T ][\d:.Z+-]+\b/g, '<ts>') // ISO timestamps
+    .replace(/\b[0-9a-f]{8}-[0-9a-f-]{27,}\b/gi, '<uuid>')
+    .replace(/\b[0-9a-f]{7,40}\b/gi, '<hex>')
+    .replace(/:\d+:\d+/g, ':L:C') // line:col
+    .replace(/localhost:\d+|127\.0\.0\.1:\d+/g, '<host>')
+    .replace(/\b\d+\b/g, 'N') // remaining numbers
+    .replace(/(["'`]).*?\1/g, '<str>') // quoted dynamic values
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 400);
+}
+
+function fingerprint(fail: Failure): string {
+  // Error shape + file (not test title): same broken selector across
+  // 5 tests in one spec = one cluster, one task.
+  const basis = `${normalizeError(fail.error)}|${fail.file}`;
+  return crypto.createHash('sha1').update(basis).digest('hex').slice(0, 12);
+}
+
+// ---------- Clustering ----------
+
+function cluster(failures: Failure[]): Map<string, Cluster> {
+  const map = new Map<string, Cluster>();
+  for (const f of failures) {
+    const fp = fingerprint(f);
+    const c = map.get(fp) ?? {
+      fingerprint: fp,
+      errorSample: f.error,
+      files: new Set(),
+      tests: [],
+    };
+    c.files.add(f.file);
+    c.tests.push(f);
+    map.set(fp, c);
+  }
+  return map;
+}
+
+// ---------- Taiga client ----------
+
+class Taiga {
+  private token = '';
+  private projectId = 0;
+  constructor(private base: string) {}
+
+  async login(username: string, password: string, projectSlug: string) {
+    const r = await this.post(
+      '/api/v1/auth',
+      { type: 'normal', username, password },
+      false,
+    );
+    this.token = r.auth_token;
+    const p = await this.get(`/api/v1/projects/by_slug?slug=${projectSlug}`);
+    this.projectId = p.id;
+  }
+
+  async createUserStory(
+    subject: string,
+    description: string,
+    tags: string[],
+  ): Promise<{ id: number; ref: number }> {
+    const r = await this.post('/api/v1/userstories', {
+      project: this.projectId,
+      subject,
+      description,
+      tags,
+    });
+    return { id: r.id, ref: r.ref };
+  }
+
+  async createTask(
+    userStoryId: number,
+    subject: string,
+    description = '',
+  ): Promise<{ id: number; ref: number }> {
+    const r = await this.post('/api/v1/tasks', {
+      project: this.projectId,
+      user_story: userStoryId,
+      subject,
+      description,
+    });
+    return { id: r.id, ref: r.ref };
+  }
+
+  async commentStory(storyId: number, comment: string) {
+    const story = await this.get(`/api/v1/userstories/${storyId}`);
+    await this.patch(`/api/v1/userstories/${storyId}`, {
+      version: story.version,
+      comment,
+    });
+  }
+
+  async commentTask(taskId: number, comment: string) {
+    const task = await this.get(`/api/v1/tasks/${taskId}`);
+    await this.patch(`/api/v1/tasks/${taskId}`, { version: task.version, comment });
+  }
+
+  /** Verify a story still exists (someone may have deleted it in Taiga). */
+  async storyExists(storyId: number): Promise<boolean> {
+    const r = await this.request(
+      'GET',
+      `/api/v1/userstories/${storyId}`,
+      undefined,
+      true,
+      true,
+    );
+    return r.ok;
+  }
+
+  private headers(auth = true): Record<string, string> {
+    const h: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (auth) h['Authorization'] = `Bearer ${this.token}`;
+    return h;
+  }
+
+  /**
+   * Fetch with retry on 429 (Taiga throttling) — waits and retries up to 3 times.
+   * With allowFail, non-ok responses are returned instead of thrown (for existence checks).
+   */
+  private async request(
+    method: string,
+    p: string,
+    body?: unknown,
+    auth = true,
+    allowFail = false,
+  ): Promise<Response> {
+    for (let attempt = 0; ; attempt++) {
+      const r = await fetch(this.base + p, {
+        method,
+        headers: this.headers(auth),
+        body: body === undefined ? undefined : JSON.stringify(body),
+      });
+      if (r.status === 429 && attempt < 3) {
+        const wait =
+          Number(r.headers.get('Retry-After')) * 1000 || 2000 * (attempt + 1);
+        console.log(`Taiga throttled (429), retrying in ${wait}ms...`);
+        await new Promise((res) => setTimeout(res, wait));
+        continue;
+      }
+      if (!r.ok && !allowFail)
+        throw new Error(`${method} ${p} -> ${r.status} ${await r.text()}`);
+      return r;
+    }
+  }
+
+  private async get(p: string) {
+    return (await this.request('GET', p)).json();
+  }
+  private async post(p: string, body: unknown, auth = true) {
+    return (await this.request('POST', p, body, auth)).json();
+  }
+  private async patch(p: string, body: unknown) {
+    return (await this.request('PATCH', p, body)).json();
+  }
+}
+
+// ---------- Main ----------
+
+async function main() {
+  const raw = JSON.parse(fs.readFileSync(RESULTS_PATH, 'utf8'));
+  const failures: Failure[] = [];
+  for (const suite of raw.suites ?? [])
+    walkSuites(suite, suite.file ?? '', failures);
+
+  const hardFailures = failures.filter((f) => !f.flaky);
+  const flakyTests = failures.filter((f) => f.flaky);
+  const clusters = cluster(hardFailures);
+
+  const state: State = fs.existsSync(STATE_PATH)
+    ? JSON.parse(fs.readFileSync(STATE_PATH, 'utf8'))
+    : {};
+
+  const today = new Date().toISOString().slice(0, 10);
+  const newClusters: Cluster[] = [];
+  const knownClusters: Cluster[] = [];
+  const resolved: string[] = [];
+
+  for (const [fp, c] of clusters) {
+    if (state[fp]) {
+      knownClusters.push(c);
+      state[fp].lastSeen = today;
+      state[fp].consecutiveRuns += 1;
+      state[fp].seenInLastNRuns = [1, ...state[fp].seenInLastNRuns].slice(0, 10);
+    } else {
+      newClusters.push(c);
+      state[fp] = {
+        firstSeen: today,
+        lastSeen: today,
+        consecutiveRuns: 1,
+        seenInLastNRuns: [1],
+      };
+    }
+  }
+  for (const fp of Object.keys(state)) {
+    if (!clusters.has(fp)) {
+      state[fp].seenInLastNRuns = [0, ...state[fp].seenInLastNRuns].slice(0, 10);
+      state[fp].consecutiveRuns = 0;
+      if (
+        state[fp].seenInLastNRuns.slice(0, 3).every((x) => x === 0) &&
+        state[fp].taigaRef
+      ) {
+        resolved.push(fp); // green 3 runs in a row -> candidate for closing
+      }
+    }
+  }
+
+  // ----- Taiga -----
+  let taiga: Taiga | null = null;
+  if (!DRY_RUN && newClusters.length + knownClusters.length > 0) {
+    taiga = new Taiga(requiredEnv('TAIGA_URL'));
+    await taiga.login(
+      requiredEnv('TAIGA_USERNAME'),
+      requiredEnv('TAIGA_PASSWORD'),
+      requiredEnv('TAIGA_PROJECT'),
+    );
+  }
+
+  const storyTags = (process.env.TAIGA_TAGS ?? 'daily,needs-triage')
+    .split(',')
+    .map((t: string) => t.trim())
+    .filter((t: string) => t.length > 0);
+
+  if (RELEASE) {
+    // ----- Release mode: ONE user story for the whole release, one task per cluster -----
+    const releaseTag = `release-${RELEASE}`.toLowerCase();
+    const storyKey = '__release_story__';
+    const storyState = (state as any)[storyKey] as StateEntry | undefined;
+
+    let storyId = storyState?.taigaId;
+    let storyRef = storyState?.taigaRef;
+
+    // Someone may have deleted the story in Taiga since the last run — recreate if so.
+    if (taiga && storyId && !(await taiga.storyExists(storyId))) {
+      console.log(
+        `Stored release story ${storyId} no longer exists in Taiga — recreating.`,
+      );
+      storyId = undefined;
+      storyRef = undefined;
+    }
+
+    if (taiga && !storyId) {
+      const subject = `[release ${RELEASE}] Daily failures triage`;
+      const description = [
+        `Triage of daily test failures for release **${RELEASE}**.`,
+        '',
+        `Run date: ${today}`,
+        REPORT_URL ? `[HTML report](${REPORT_URL})` : '',
+        '',
+        'Each task below is one failure cluster (one root cause). Classify each as real bug or test to update.',
+      ].join('\n');
+      const { id, ref } = await taiga.createUserStory(subject, description, [
+        ...storyTags,
+        releaseTag,
+      ]);
+      storyId = id;
+      storyRef = ref;
+      (state as any)[storyKey] = {
+        taigaId: id,
+        taigaRef: ref,
+        firstSeen: today,
+        lastSeen: today,
+        consecutiveRuns: 1,
+        seenInLastNRuns: [1],
+      };
+      console.log(`Created release user story #${ref} [${releaseTag}]`);
+    } else if (!taiga) {
+      console.log(
+        `[dry-run] Would create/reuse release user story: [release ${RELEASE}] Daily failures triage [tags: ${[...storyTags, releaseTag].join(', ')}]`,
+      );
+    }
+
+    if (GROUP_BY === 'file') {
+      // One task per spec file, listing all its failing tests (from new clusters).
+      const byFile = new Map<string, Failure[]>();
+      for (const c of newClusters) {
+        for (const t of c.tests) {
+          byFile.set(t.file, [...(byFile.get(t.file) ?? []), t]);
+        }
+      }
+      const fileTasks: Record<string, number> =
+        (state as any)['__file_tasks__'] ?? {};
+
+      for (const [file, tests] of byFile) {
+        const lines = tests.map(
+          (t) =>
+            `- \`${t.title}\`${t.qaseId ? ` (Qase: ${t.qaseId})` : ''}${t.retries ? ` — ${t.retries} retries` : ''}\n  \`\`\`\n  ${shortError(t.error)}\n  \`\`\``,
+        );
+        if (taiga && storyId) {
+          if (fileTasks[file]) {
+            await taiga.commentTask(
+              fileTasks[file],
+              [`New failures on ${today}:`, ...lines].join('\n'),
+            );
+            console.log(
+              `  ~ appended ${tests.length} test(s) to existing task for ${file}`,
+            );
+          } else {
+            const { id } = await taiga.createTask(
+              storyId,
+              `${path.basename(file)} — ${tests.length} failing test${tests.length > 1 ? 's' : ''}`,
+              [
+                `**Spec file:** \`${file}\``,
+                '',
+                `**Failing tests (${tests.length}):**`,
+                ...lines,
+                '',
+                REPORT_URL ? `[HTML report](${REPORT_URL})` : '',
+              ].join('\n'),
+            );
+            fileTasks[file] = id;
+            console.log(`  + task: ${path.basename(file)} (${tests.length} tests)`);
+          }
+        } else {
+          const qase = tests.map((t) => t.qaseId).filter(Boolean);
+          console.log(
+            `[dry-run]   + task: ${path.basename(file)} — ${tests.length} failing test(s)${qase.length ? ` [Qase: ${qase.join(', ')}]` : ''}`,
+          );
+        }
+      }
+      (state as any)['__file_tasks__'] = fileTasks;
+      // Cluster fingerprints still track new/known/resolved against the release story.
+      for (const c of newClusters) {
+        state[c.fingerprint].taigaId = storyId;
+        state[c.fingerprint].taigaRef = storyRef;
+      }
+    } else {
+      for (const c of newClusters) {
+        const taskSubject = `${shortError(c.errorSample)} — ${[...c.files].map((f: string) => path.basename(f)).join(', ')} (${c.tests.length} test${c.tests.length > 1 ? 's' : ''})`;
+        if (taiga && storyId) {
+          await taiga.createTask(storyId, taskSubject, clusterDescription(c));
+          state[c.fingerprint].taigaId = storyId;
+          state[c.fingerprint].taigaRef = storyRef;
+          console.log(`  + task: ${taskSubject}`);
+        } else {
+          console.log(`[dry-run]   + task: ${taskSubject}`);
+        }
+      }
+    }
+    if (taiga && storyId && knownClusters.length) {
+      await taiga.commentStory(
+        storyId,
+        `Re-run on ${today}: ${knownClusters.length} cluster(s) still failing, ${newClusters.length} new. Report: ${REPORT_URL}`,
+      );
+    }
+  } else {
+    // ----- Daily mode: one user story per cluster, one task per test -----
+    for (const c of newClusters) {
+      const subject = `[daily] ${shortError(c.errorSample)} — ${[...c.files].map((f: string) => path.basename(f)).join(', ')} (${c.tests.length} test${c.tests.length > 1 ? 's' : ''})`;
+      const description = clusterDescription(c);
+      if (taiga) {
+        const { id, ref } = await taiga.createUserStory(
+          subject,
+          description,
+          storyTags,
+        );
+        state[c.fingerprint].taigaId = id;
+        state[c.fingerprint].taigaRef = ref;
+        console.log(`Created Taiga user story #${ref} for cluster ${c.fingerprint}`);
+        for (const t of c.tests) {
+          await taiga.createTask(
+            id,
+            `Review: ${t.title}`,
+            [
+              `File: \`${t.file}\``,
+              t.qaseId ? `Qase: ${t.qaseId}` : '',
+              t.retries ? `Retries: ${t.retries}` : '',
+              '```',
+              t.error,
+              '```',
+            ]
+              .filter(Boolean)
+              .join('\n'),
+          );
+        }
+        console.log(`  + ${c.tests.length} task(s) inside`);
+      } else {
+        console.log(
+          `[dry-run] Would create user story: ${subject} [tags: ${storyTags.join(', ')}]`,
+        );
+        for (const t of c.tests)
+          console.log(`[dry-run]   + task: Review: ${t.title}`);
+      }
+    }
+
+    for (const c of knownClusters) {
+      const entry = state[c.fingerprint];
+      if (taiga && entry.taigaId) {
+        await taiga.commentStory(
+          entry.taigaId,
+          `Still failing on ${today} (${c.tests.length} tests, ${entry.consecutiveRuns} consecutive runs). Report: ${REPORT_URL}`,
+        );
+      }
+    }
+  }
+
+  fs.mkdirSync(path.dirname(STATE_PATH), { recursive: true });
+  fs.writeFileSync(STATE_PATH, JSON.stringify(state, null, 2));
+
+  // ----- Digest (markdown, printed to stdout for Slack/summary step) -----
+  const digest: string[] = [`## Daily triage — ${today}`, ''];
+  digest.push(
+    `**${hardFailures.length} failures** in **${clusters.size} clusters** · ${flakyTests.length} flaky · ${resolved.length} resolved`,
+  );
+  if (REPORT_URL) digest.push(`[Full HTML report](${REPORT_URL})`);
+  digest.push('');
+  if (newClusters.length) {
+    digest.push(`### New clusters (${newClusters.length})`);
+    for (const c of newClusters) {
+      const ref = state[c.fingerprint].taigaRef;
+      digest.push(
+        `- ${ref ? `${taigaLink(ref)} — ` : ''}\`${shortError(c.errorSample)}\` in ${[...c.files].join(', ')} (${c.tests.length} tests)`,
+      );
+    }
+    digest.push('');
+  }
+  if (knownClusters.length) {
+    digest.push(`### known clusters still failing (${knownClusters.length})`);
+    for (const c of knownClusters) {
+      const e = state[c.fingerprint];
+      digest.push(
+        `- ${taigaLink(e.taigaRef)} — ${c.tests.length} tests, failing ${e.consecutiveRuns} runs in a row`,
+      );
+    }
+    digest.push('');
+  }
+  if (resolved.length) {
+    digest.push(`### resolved (green 3 runs) — consider closing`);
+    for (const fp of resolved) digest.push(`- ${taigaLink(state[fp].taigaRef)}`);
+  }
+  const digestText = digest.join('\n');
+  console.log('\n' + digestText);
+  fs.writeFileSync('.triage/digest.md', digestText);
+
+  // ----- Mattermost -----
+  const mmWebhook = process.env.MATTERMOST_WEBHOOK_URL;
+  if (mmWebhook && !DRY_RUN) {
+    const r = await fetch(mmWebhook, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        username: 'Daily Triage',
+        icon_emoji: ':test_tube:',
+        // channel: 'qa-daily',  // optional override; defaults to the webhook's channel
+        text: digestText,
+      }),
+    });
+    if (!r.ok)
+      console.error(`Mattermost post failed: ${r.status} ${await r.text()}`);
+    else console.log('Digest posted to Mattermost');
+  }
+}
+
+function shortError(msg: string): string {
+  return msg.split('\n')[0].slice(0, 90);
+}
+
+function taigaLink(ref?: number): string {
+  if (!ref) return 'Taiga #?';
+  const base = process.env.TAIGA_URL;
+  const project = process.env.TAIGA_PROJECT;
+  return base && project
+    ? `[Taiga #${ref}](${base}/project/${project}/us/${ref})`
+    : `Taiga #${ref}`;
+}
+
+function clusterDescription(c: Cluster): string {
+  const lines = [
+    `**Error signature** \`${c.fingerprint}\``,
+    '',
+    '```',
+    c.errorSample,
+    '```',
+    '',
+    `**Affected tests (${c.tests.length}):**`,
+    ...c.tests.map(
+      (t: Failure) =>
+        `- \`${t.testId}\`${t.retries ? ` (${t.retries} retries)` : ''}`,
+    ),
+    '',
+    REPORT_URL ? `[HTML report](${REPORT_URL})` : '',
+    '',
+    '_Auto-created by daily triage. Classify: real bug vs test to update._',
+  ];
+  return lines.join('\n');
+}
+
+function requiredEnv(name: string): string {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`Missing env var ${name}`);
+    process.exit(1);
+  }
+  return v;
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,33 +1,39 @@
 {
   "compilerOptions": {
     /* Language and Environment */
-    "target": "ESNext", // Modern JS output
-    "lib": ["DOM", "ESNext"], // Include DOM & modern JS APIs
-    "module": "CommonJS", // Playwright typically runs in Node.js
-    "moduleResolution": "Node", // Resolve Node-style imports
-    "types": ["node", "playwright"], // Include typings for Node & Playwright
+    "target": "ES2022", // Stable modern target; Node 18/20 supports all of it
+    "lib": ["DOM", "ES2022"], // DOM kept for page.evaluate() callbacks
+
+    /* Modules */
+    "module": "NodeNext", // Correct CJS/ESM semantics for Node, understands node: imports
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true, // Safe default imports from CommonJS deps
+    "resolveJsonModule": true,
+    "types": ["node"], // "playwright" removed: deprecated stub; real types ship inside @playwright/test
 
     /* JavaScript Support */
-    "allowJs": true, // Allow JS files
-    "checkJs": false, // Skip type checking .js files (set true if you want it)
-    "resolveJsonModule": true, // Allow importing JSON files
+    "allowJs": true,
+    "checkJs": false,
 
     /* Type Checking */
-    "strict": true, // Enable all strict type checks
-    "noEmit": true, // Don’t output JS — Playwright only needs type-checking
-    "skipLibCheck": true, // Skip type checks on dependencies
+    "strict": true,
+    "noEmit": true, // Type-check only; Playwright and tsx do their own transpiling
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true, // Avoids case-sensitivity surprises between macOS and Linux CI
 
-    /* File and Path Management */
-    "rootDir": ".", // Root of your project or tests
-    "baseUrl": ".", // Allows relative imports from project root
+    /* Paths */
+    "baseUrl": ".",
     "paths": {
-      "@tests/*": ["tests/*"], // Example alias for test folder
+      "@tests/*": ["tests/*"],
       "@pages/*": ["pages/*"]
-    },
-
-    /* Source Maps (optional, for debugging) */
-    "sourceMap": true
+    }
   },
-  "include": ["tests/**/*", "playwright.config.ts", "helpers/**/*", "pages/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": [
+    "tests/**/*",
+    "playwright.config.ts",
+    "helpers/**/*",
+    "pages/**/*",
+    "scripts/**/*"
+  ],
+  "exclude": ["node_modules", "dist", "playwright-report", "test-results"]
 }


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/task/1613

## Description

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="5:1-5:223;73-295">Adds an on-demand workflow that turns the daily Playwright report into a pre-grouped Taiga user story, replacing the manual process of digging through the HTML report and creating tasks by hand after big promotions to PRE.</p>

<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3" data-sourcepos="7:1-8:286;297-912">
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="7:1-7:330;297-626"><strong><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">scripts/triage.ts</code></strong> — parses <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">results.json</code> from the daily run, groups failures into clusters by normalized error signature (dynamic values like timeouts, ids, ports and timestamps are stripped, so the same root cause across many tests becomes one item), separates flaky tests, and creates the Taiga items via the REST API.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="8:1-8:286;627-912"><strong><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">.github/workflows/release-triage.yml</code></strong> — manual trigger (Actions → <em>Release triage</em> → Run workflow). Takes a release tag (e.g. <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">26.07</code>), locates the last <strong>scheduled</strong> daily run on <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">main</code> via the GitHub API, and pulls its <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">results.json</code> from <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">s3://kaleidos-qa-reports/run-&lt;id&gt;/</code>.</li>
</ul>

<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" data-sourcepos="10:1-10:28;914-941">What it creates in Taiga</h2>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="12:1-12:210;943-1152">One user story per release — <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">[release &lt;tag&gt;] Daily failures triage</code>, tagged <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">release-&lt;tag&gt;</code> + <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">needs-triage</code> — containing one task per failure. Task granularity is selectable per run via the <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">group_by</code> input:</p>

<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3" data-sourcepos="14:1-15:64;1154-1292">
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="14:1-14:75;1154-1228"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">cluster</code> (default): one task per root cause, listing all affected tests</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="15:1-15:64;1229-1292"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">file</code>: one task per spec file, listing all its failing tests</li>
</ul>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="17:1-17:210;1294-1503">Each task includes the error, retry count, <strong>Qase ID</strong> (extracted from the test title convention <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">(Qase ID: NNNN)</code>), and a link to the S3 HTML report. The digest is posted to Mattermost and to the job summary.</p>

<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" data-sourcepos="19:1-19:17;1505-1521">Re-run safety</h2>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="21:1-21:359;1523-1881">State is kept per release tag in <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">s3://kaleidos-qa-reports/triage/state-release-&lt;tag&gt;.json</code>. Re-running with the same tag reuses the same story and only adds tasks/comments for failures not seen before — no duplicates when triaging multiple times during a freeze week. Failure clusters green for 3 consecutive triaged runs are flagged as candidates to close.</p>

<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" data-sourcepos="23:1-23:40;1883-1922">Config (already created / to create)</h2>

<div class="overflow-x-auto w-full px-2 mb-6" data-sourcepos="25:1-30:60;1924-2188">
Kind | Name | Value
-- | -- | --
Secret | TAIGA_URL | https://api.taiga.io
Secret | TAIGA_USERNAME / TAIGA_PASSWORD | qa-triage bot user
Variable | TAIGA_PROJECT | kaleidos-qa
Variable | TAIGA_PUBLIC_URL | https://tree.taiga.io

</div>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="32:1-32:119;2190-2308">Existing <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">AWS_*</code> and <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">MATTERMOST_WEBHOOK_DAILY_REPORT</code> secrets are reused. New dev dependencies: <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">tsx</code>, <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">@types/node</code>.</p>

<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" data-sourcepos="34:1-34:16;2310-2325">Not affected</h2>

<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3" data-sourcepos="36:1-38:167;2327-2689">
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="36:1-36:121;2327-2447">The daily test execution (<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">playwright_pre_daily.yml</code>) is unchanged — this workflow only <strong>reads</strong> its reports from S3.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="37:1-37:75;2448-2522">Nothing runs automatically: triage happens only when manually triggered.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="38:1-38:167;2523-2689">Robustness: retries on Taiga 429 throttling; recreates the release story if it was deleted in Taiga; <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">DRY_RUN=1</code> env available for testing without writing anything.</li>
</ul>

<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" data-sourcepos="40:1-40:15;2691-2705">How to test</h2>

<ol class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-decimal flex flex-col gap-1 pl-8 mb-3" data-sourcepos="42:1-44:120;2707-3096">
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="42:1-42:144;2707-2850">Uncomment <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">DRY_RUN: "1"</code> in the workflow, trigger with tag <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">test</code> (once with <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">group_by: cluster</code>, once with <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">file</code>), review the job summary.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="43:1-43:126;2851-2976">Re-comment <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">DRY_RUN</code>, trigger with tag <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">test-drive</code>, verify the story/tasks in Taiga, re-trigger to confirm no duplicates.</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="44:1-44:120;2977-3096">Delete the test story and its state file: <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">aws s3 rm s3://kaleidos-qa-reports/triage/state-release-test-drive.json</code>.</li></ol>
