### PR TITLE
refactor(tests): Triage view-mode regression tests: keep 693/715, drop 713

### DIFF
--- a/tests/view-mode/view-mode-navigation.spec.ts
+++ b/tests/view-mode/view-mode-navigation.spec.ts
@@ -361,31 +361,6 @@ mainTest(qase([691], 'Change scale'), async () => {
   );
 });
 
-// TODO: The reference does not exist in Qase.
-mainTest(qase([713], 'CO-392 Zoom by pressing + and - keys'), async () => {
-  await mainTest.step('Create board and open view mode', async () => {
-    await mainPage.createDefaultBoardByCoordinates(300, 300);
-    await mainPage.waitForChangeIsSaved();
-    const newPage = await viewModePage.clickViewModeShortcut();
-    viewModePage = new ViewModePage(newPage);
-    await viewModePage.waitForViewerSection(45000);
-  });
-
-  await mainTest.step('Zoom in with the + key and verify', async () => {
-    await viewModePage.clickOnAdd();
-    await expect(viewModePage.viewerLayoutSection).toHaveScreenshot(
-      'view-mode-page-add-button-image.png',
-    );
-  });
-
-  await mainTest.step('Zoom out with the - key and verify', async () => {
-    await viewModePage.clickOnSubtract();
-    await expect(viewModePage.viewerLayoutSection).toHaveScreenshot(
-      'view-mode-page-subtract-button-image.png',
-    );
-  });
-});
-
 mainTest(qase([708], 'Page dropdown'), async () => {
   await mainTest.step(
     'Create board and a second page and open view mode',


### PR DESCRIPTION
## Taiga URL (optional)

[Taiga Ticket: 1670](https://tree.taiga.io/project/kaleidos-qa/task/1670)

## Description

![pruning gif](https://media.giphy.com/media/JebcYN7fj2LfnH7xui/giphy.gif)

This PR continues the regression suite pruning for view-mode tests — triaging PENPOT-693, PENPOT-713, and PENPOT-715.

- **PENPOT-693 (Share prototype - get link)** — Keep as regression: unique end-to-end flow for multi-page share link with public access validation, no equivalent coverage elsewhere.
- **PENPOT-713 (Zoom by pressing +/- keys)** — Drop from regression: keyboard zoom shortcut is a UI variant of scaling behavior already covered by `691` (Change scale), no new business rule; also had no valid Qase reference.
- **PENPOT-715 (Board elements dropdown in Inspect)** — Keep as regression: only test that covers layer selection + Code tab interaction in view-mode inspect, fills a unique coverage gap.

## Solution

Removed the obsolete `713` test from `view-mode-navigation.spec.ts`. Classified `693` and `715` as regression-worthy for future suite updates.

## How to test

- [x] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [x] It complies with the test conventions
- [ ] There are no missing snapshots
- [ ] The tests run OK
