### PR TITLE
refactor(tests): triage tokens regression tests

### DIFF
--- a/tests/tokens/export.spec.ts
+++ b/tests/tokens/export.spec.ts
@@ -29,28 +29,6 @@ mainTest.beforeEach(async ({ page }) => {
   await tokensPage.toolsComp.clickOnTokenToolsButton();
 });
 
-mainTest(
-  qase([2266], 'Export tokens multi-file folder (no token, set or theme)'),
-  async () => {
-    await mainTest.step(
-      'Open export multi-file modal and verify empty message',
-      async () => {
-        await tokensPage.toolsComp.clickOnExportButton();
-        await tokensPage.toolsComp.clickOnMultipleFilesButton();
-        await tokensPage.toolsComp.checkEmptyExportTabMessage();
-      },
-    );
-
-    await mainTest.step(
-      'Close modal and verify export window is closed',
-      async () => {
-        await mainPage.closeModalWindow();
-        await tokensPage.toolsComp.isExportWindowClosed();
-      },
-    );
-  },
-);
-
 mainTest(qase([2265], 'Export tokens multi-file folder'), async ({ page }) => {
   const baseComp: BaseComponent = new BaseComponent(page);
 

--- a/tests/tokens/token-types/font-size-token.spec.ts
+++ b/tests/tokens/token-types/font-size-token.spec.ts
@@ -66,15 +66,6 @@ mainTest.describe(() => {
     await tokensPage.tokensComp.isTokenVisibleWithName(fontSizeToken.name);
   });
 
-  mainTest(qase([2358], 'Create a font size token'), async () => {
-    await mainTest.step(
-      `Verify "${fontSizeToken.name}" token is visible`,
-      async () => {
-        await tokensPage.tokensComp.isTokenVisibleWithName(fontSizeToken.name);
-      },
-    );
-  });
-
   mainTest(qase([2359], 'Apply a font size token'), async () => {
     await mainTest.step(
       `Apply "${fontSizeToken.name}" token and verify it is applied`,


### PR DESCRIPTION
## Taiga URL (optional)

[Taiga Ticket: 1668](https://tree.taiga.io/project/kaleidos-qa/task/1668)

## Description

![tokens gif](https://media.giphy.com/media/8Rgat2FUwHFGprw3K6/giphy.gif)

Continues regression suite pruning for design tokens tests.

**Moved to regression:**
- **PENPOT-2218** — Unique axis-specific dimension token application to text (X/Y independent).
- **PENPOT-2240** — Only test covering token import error handling (parse + naming errors).
- **PENPOT-2359** — Core font size token application with visual verification.
- **PENPOT-2607** — Invalid reference validation in typography tokens, unique business rule.

**Deleted:**
- **PENPOT-2266** — Empty export modal state, redundant with 2265 which covers full export flow.
- **PENPOT-2358** — Token visibility check after setup, no incremental signal beyond beforeEach.

## Solution

Removed 2266 from `export.spec.ts` and 2358 from `font-size-token.spec.ts`. Classified 2218, 2240, 2359, and 2607 as regression-worthy.

## How to test

- [x] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [x] It complies with the test conventions
- [ ] There are no missing snapshots
- [ ] The tests run OK
