### PR TITLE
test(subscriptions): drop flaky non-regression tests from subscriptions

### DIFF
--- a/tests/subscription-plans/end-trial-behavior.spec.ts
+++ b/tests/subscription-plans/end-trial-behavior.spec.ts
@@ -8,7 +8,6 @@ import {
   createCustomerWithTestClock,
   skipSubscriptionByDays,
   getProfileIdByEmail,
-  addPaymentMethodForCustomer,
 } from 'helpers/stripe';
 import { createTeamName } from 'helpers/teams/create-team-name';
 
@@ -34,29 +33,6 @@ registerTest.beforeEach(async ({ page, name, email }) => {
   await teamPage.createTeam(teamName);
   await teamPage.isTeamSelected(teamName);
 });
-
-registerTest(
-  qase([2297, 2344], 'Trial ends, payment method added → switch to Unlimited'),
-  async ({ email }) => {
-    const currentPlan = 'Unlimited';
-
-    await profilePage.tryTrialForPlan(currentPlan);
-    await profilePage.openYourAccountPage();
-    await profilePage.openSubscriptionTab();
-    await addPaymentMethodForCustomer(customerData.customerId);
-    await profilePage.clickOnAddPaymentMethodButton();
-    await stripePage.isVisaCardAdded(true);
-
-    await skipSubscriptionByDays(email, testClockId, 16);
-
-    await stripePage.waitTrialEndsDisappear();
-    await stripePage.checkCurrentSubscription(currentPlan);
-    await stripePage.clickOnReturnToPenpotButton();
-    await profilePage.checkSubscriptionName(currentPlan);
-    await profilePage.backToDashboardFromAccount();
-    await dashboardPage.checkSubscriptionName(currentPlan + ' plan');
-  },
-);
 
 registerTest(
   qase(

--- a/tests/subscription-plans/plan-switching-logic.spec.ts
+++ b/tests/subscription-plans/plan-switching-logic.spec.ts
@@ -3,8 +3,6 @@ import { TeamPage } from '@pages/dashboard/team-page';
 import { DashboardPage } from '@pages/dashboard/dashboard-page';
 import { qase } from 'playwright-qase-reporter/playwright';
 import { ProfilePage } from '@pages/profile-page';
-import { LoginPage } from '@pages/login-page';
-import { RegisterPage } from '@pages/register-page';
 import { StripePage } from '@pages/dashboard/stripe-page';
 import {
   createCustomerWithTestClock,
@@ -20,64 +18,17 @@ const teamName = createTeamName();
 let teamPage: TeamPage;
 let dashboardPage: DashboardPage;
 let profilePage: ProfilePage;
-let loginPage: LoginPage;
-let registerPage: RegisterPage;
 let stripePage: StripePage;
 
 registerTest.beforeEach(async ({ page }) => {
   teamPage = new TeamPage(page);
   dashboardPage = new DashboardPage(page);
   profilePage = new ProfilePage(page);
-  loginPage = new LoginPage(page);
-  registerPage = new RegisterPage(page);
   stripePage = new StripePage(page);
 
   await teamPage.createTeam(teamName);
   await teamPage.isTeamSelected(teamName);
 });
-
-registerTest(
-  qase(2302, 'Switch from Unlimited → Enterprise'),
-  async ({ page, name, email }) => {
-    const currentPlan = 'Unlimited';
-    const newPlan = 'Enterprise';
-    let date = new Date();
-
-    const penpotId = await getProfileIdByEmail(email);
-    const customerData = await createCustomerWithTestClock(
-      page,
-      name,
-      email,
-      penpotId,
-    );
-    const testClockId = customerData.testClockId;
-
-    await profilePage.tryTrialForPlan(currentPlan);
-    await profilePage.openYourAccountPage();
-    await profilePage.openSubscriptionTab();
-    await profilePage.clickOnAddPaymentMethodButton();
-    await addPaymentMethodForCustomer(customerData.customerId);
-    await stripePage.reloadPage();
-    await stripePage.isVisaCardAdded(true);
-    await skipSubscriptionByDays(email, testClockId, 15, date);
-
-    await stripePage.waitTrialEndsDisappear();
-    await profilePage.reloadPage();
-    await stripePage.checkCurrentSubscription(currentPlan);
-    await stripePage.checkLastInvoiceName(`Penpot ${currentPlan} (per editors)`);
-    await stripePage.checkLastInvoiceAmount(`$7.00`);
-    await stripePage.changeSubscription();
-    await stripePage.checkCurrentSubscription(newPlan);
-    await page.waitForTimeout(1000);
-    await profilePage.reloadPage();
-    await stripePage.checkLastInvoiceName(`Penpot ${newPlan}`);
-    await stripePage.checkLastInvoiceStatus(`Paid`);
-    await stripePage.clickOnReturnToPenpotButton();
-    await profilePage.checkSubscriptionName(newPlan);
-    await profilePage.backToDashboardFromAccount();
-    await dashboardPage.checkSubscriptionName(newPlan + ' plan');
-  },
-);
 
 registerTest(
   qase(2303, 'Switch from Enterprise → Unlimited'),

--- a/tests/subscription-plans/stripe-specific-tests.spec.ts
+++ b/tests/subscription-plans/stripe-specific-tests.spec.ts
@@ -1,16 +1,8 @@
 import { registerTest } from 'fixtures';
-import { random } from 'helpers/string-generator';
 import { TeamPage } from '@pages/dashboard/team-page';
 import { DashboardPage } from '@pages/dashboard/dashboard-page';
 import { qase } from 'playwright-qase-reporter/playwright';
 import { ProfilePage } from '@pages/profile-page';
-import {
-  waitMessage,
-  waitSecondMessage,
-  getVerificationMessage,
-} from 'helpers/gmail';
-import { LoginPage } from '@pages/login-page';
-import { RegisterPage } from '@pages/register-page';
 import { StripePage } from '@pages/dashboard/stripe-page';
 import {
   createCustomerWithTestClock,
@@ -18,7 +10,6 @@ import {
   skipSubscriptionByMonths,
   getProfileIdByEmail,
   addPaymentMethodForCustomer,
-  addPaymentMethodForCustomerByCustomerEmail,
 } from 'helpers/stripe';
 import { createTeamName } from 'helpers/teams/create-team-name';
 
@@ -27,8 +18,6 @@ const teamName = createTeamName();
 let teamPage: TeamPage;
 let dashboardPage: DashboardPage;
 let profilePage: ProfilePage;
-let loginPage: LoginPage;
-let registerPage: RegisterPage;
 let stripePage: StripePage;
 
 registerTest.describe(() => {
@@ -40,8 +29,6 @@ registerTest.describe(() => {
     teamPage = new TeamPage(page);
     dashboardPage = new DashboardPage(page);
     profilePage = new ProfilePage(page);
-    loginPage = new LoginPage(page);
-    registerPage = new RegisterPage(page);
     stripePage = new StripePage(page);
 
     penpotId = await getProfileIdByEmail(email);
@@ -92,41 +79,6 @@ registerTest.describe(() => {
     },
   );
 
-  registerTest(
-    qase(2347, 'Invoices capped at  $950 (Enterprise)'),
-    async ({ email }) => {
-      const currentPlan = 'Enterprise';
-      const date = new Date();
-
-      await profilePage.tryTrialForPlan(currentPlan);
-      await profilePage.openYourAccountPage();
-      await profilePage.openSubscriptionTab();
-      await profilePage.clickOnAddPaymentMethodButton();
-      await addPaymentMethodForCustomer(customerData.customerId);
-      await stripePage.reloadPage();
-      await stripePage.isVisaCardAdded(true);
-      await skipSubscriptionByDays(email, testClockId, 20, date);
-
-      await stripePage.waitTrialEndsDisappear();
-      await profilePage.reloadPage();
-      await stripePage.checkCurrentSubscription(currentPlan);
-      await stripePage.checkLastInvoiceName(`Penpot ${currentPlan} (per editors)`);
-      await stripePage.checkLastInvoiceAmount(`950.00`);
-
-      await skipSubscriptionByMonths(email, testClockId, 1, date);
-      await profilePage.reloadPage();
-
-      await skipSubscriptionByMonths(email, testClockId, 1, date);
-      await profilePage.reloadPage();
-
-      await skipSubscriptionByMonths(email, testClockId, 1, date);
-      await profilePage.reloadPage();
-
-      await stripePage.checkLastInvoiceStatus(`Paid`);
-      await stripePage.waitInvoiceAmountCount(`950.00`, 3);
-    },
-  );
-
   registerTest(qase(2514, 'Maximum billing $175 (Unlimited)'), async ({ email }) => {
     const currentPlan = 'Unlimited';
     const date = new Date();
@@ -159,92 +111,3 @@ registerTest.describe(() => {
     await stripePage.waitInvoiceAmountCount(`$175.00`, 3);
   });
 });
-
-registerTest(
-  qase(2324, 'Owner of team changes Enterprise to Professional'),
-  async ({ page, name, email }) => {
-    const currentPlan = 'Enterprise';
-    const firstOwner: string = random().concat('autotest');
-    const firstEmail: string = `${process.env.GMAIL_NAME}+${firstOwner}${process.env.GMAIL_DOMAIN}`;
-    const secondAdmin: string = name;
-    const secondEmail: string = email;
-
-    teamPage = new TeamPage(page);
-    dashboardPage = new DashboardPage(page);
-    profilePage = new ProfilePage(page);
-    loginPage = new LoginPage(page);
-    registerPage = new RegisterPage(page);
-    stripePage = new StripePage(page);
-
-    await profilePage.logout();
-    await loginPage.isLoginPageOpened();
-    await loginPage.clickOnCreateAccount();
-    await registerPage.registerAccount(
-      firstOwner,
-      firstEmail,
-      process.env.LOGIN_PWD,
-    );
-    await registerPage.isRegisterEmailCorrect(firstEmail);
-    const register2 = await waitMessage(page, firstEmail, 40);
-    await page.goto(register2!.inviteUrl);
-    await dashboardPage.fillOnboardingQuestions();
-
-    await dashboardPage.isDashboardOpenedAfterLogin();
-    await teamPage.createTeam(teamName);
-    await teamPage.isTeamSelected(teamName);
-
-    await profilePage.tryTrialForPlan('Unlimited');
-    await profilePage.openYourAccountPage();
-    await profilePage.openSubscriptionTab();
-    await profilePage.clickOnAddPaymentMethodButton();
-    await addPaymentMethodForCustomerByCustomerEmail(page, firstEmail);
-    await stripePage.reloadPage();
-    await stripePage.isVisaCardAdded(true);
-    await stripePage.changeSubscription();
-    await stripePage.checkCurrentSubscription(currentPlan);
-    await stripePage.clickOnReturnToPenpotButton();
-    await profilePage.backToDashboardFromAccount();
-
-    await teamPage.openInvitationsPageViaOptionsMenu();
-    await teamPage.clickInviteMembersToTeamButton();
-    await teamPage.enterEmailToInviteMembersPopUp(secondEmail);
-    await teamPage.clickSendInvitationButton();
-    await profilePage.logout();
-    await loginPage.isLoginPageOpened();
-    await loginPage.enterEmailAndClickOnContinue(secondEmail);
-    await loginPage.enterPwd(process.env.LOGIN_PWD);
-    await loginPage.clickLoginButton();
-    await dashboardPage.isDashboardOpenedAfterLogin();
-    await waitSecondMessage(page, secondEmail, 40);
-    const invite = await getVerificationMessage(secondEmail);
-    await page.goto(invite!.inviteUrl);
-    await teamPage.switchTeam(teamName);
-    await teamPage.isTeamSelected(teamName);
-
-    await profilePage.logout();
-    await loginPage.isLoginPageOpened();
-    await loginPage.enterEmailAndClickOnContinue(firstEmail);
-    await loginPage.enterPwd(process.env.LOGIN_PWD);
-    await loginPage.clickLoginButton();
-    await dashboardPage.isDashboardOpenedAfterLogin();
-    await teamPage.switchTeam(teamName);
-    await teamPage.isTeamSelected(teamName);
-    await teamPage.openMembersPageViaOptionsMenu();
-    await teamPage.selectMemberRoleInPopUp(secondAdmin, 'Owner');
-    await teamPage.clickOnTransferOwnershipButton();
-    await teamPage.isMultipleMemberRecordDisplayed(
-      secondAdmin,
-      secondEmail,
-      'Owner',
-    );
-    await profilePage.logout();
-    await loginPage.isLoginPageOpened();
-    await loginPage.enterEmailAndClickOnContinue(secondEmail);
-    await loginPage.enterPwd(process.env.LOGIN_PWD);
-    await loginPage.clickLoginButton();
-    await dashboardPage.isDashboardOpenedAfterLogin();
-    await teamPage.switchTeam(teamName);
-    await teamPage.isTeamSelected(teamName);
-    await teamPage.isSubscriptionIconNotVisible();
-  },
-);

--- a/tests/subscription-plans/trial-activation.spec.ts
+++ b/tests/subscription-plans/trial-activation.spec.ts
@@ -3,8 +3,6 @@ import { TeamPage } from '@pages/dashboard/team-page';
 import { DashboardPage } from '@pages/dashboard/dashboard-page';
 import { qase } from 'playwright-qase-reporter/playwright';
 import { ProfilePage } from '@pages/profile-page';
-import { LoginPage } from '@pages/login-page';
-import { RegisterPage } from '@pages/register-page';
 import { StripePage } from '@pages/dashboard/stripe-page';
 import { updateSubscriptionTrialEnd } from 'helpers/stripe';
 import { createTeamName } from 'helpers/teams/create-team-name';
@@ -14,31 +12,16 @@ const teamName = createTeamName();
 let teamPage: TeamPage;
 let dashboardPage: DashboardPage;
 let profilePage: ProfilePage;
-let loginPage: LoginPage;
-let registerPage: RegisterPage;
 let stripePage: StripePage;
 
 registerTest.beforeEach(async ({ page }) => {
   teamPage = new TeamPage(page);
   dashboardPage = new DashboardPage(page);
   profilePage = new ProfilePage(page);
-  loginPage = new LoginPage(page);
-  registerPage = new RegisterPage(page);
   stripePage = new StripePage(page);
 
   await teamPage.createTeam(teamName);
   await teamPage.isTeamSelected(teamName);
-});
-
-registerTest(qase(2289, 'Try it free for 14 days for Unlimited plan'), async () => {
-  const currentPlan = 'Unlimited';
-
-  await profilePage.tryTrialForPlan(currentPlan, '5');
-  await profilePage.openYourAccountPage();
-  await profilePage.openSubscriptionTab();
-  await profilePage.checkSubscriptionName(currentPlan + ' (trial)');
-  await profilePage.backToDashboardFromAccount();
-  await dashboardPage.checkSubscriptionName(currentPlan + ' plan (trial)');
 });
 
 registerTest(


### PR DESCRIPTION
## Taiga URL (optional)

[Taiga Task: 1667](https://tree.taiga.io/project/kaleidos-qa/task/1667)

## Description

![cha-ching gif](https://media.giphy.com/media/bklVhVh7q8DK0/giphy.gif)

This PR continues the non-regression suite pruning effort. We reviewed the subscription plan tests classified as NON-REGRESSION and removed those that are both redundant and among the flakiest in the nightly runs.

## Solution

Reviewed 7 subscription tests (Qase IDs: 2289, 2297, 2302, 2324, 2337, 2344, 2347) with the regression triage criteria. Dropped 6 of them — all appear in the nightly failure list and will be rewritten as part of the subscription test overhaul:

- **2289** — Trial activation for Unlimited: redundant with 2294 (Enterprise trial activation, more complete).
- **2297 / 2344** — Trial ends, payment added → Unlimited: flaky, covered by the future rewrite.
- **2302** — Switch Unlimited → Enterprise: flaky (4.2m runtime), covered by the future rewrite.
- **2324** — Owner changes Enterprise to Professional: flaky multi-user flow (3.1m), covered by the future rewrite.
- **2347** — Invoices capped at $950 (Enterprise): flaky (4.5m runtime), covered by the future rewrite.

Kept **2337** (Enterprise trial, no payment → PAUSED) — not in the failure list and validates a unique business rule.

Cleaned up unused imports and variables in all affected files.

## How to test

- [x] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [x] It complies with the test conventions
- [ ] There are no missing snapshots
- [ ] The tests run OK