### PR TITLE
feat(ci): automated failure triage, clustered Taiga stories, app-version tracking, and changelog enrichment

### DIFF
--- a/.github/workflows/playwright_pre_daily.yml
+++ b/.github/workflows/playwright_pre_daily.yml
@@ -55,6 +55,21 @@ jobs:
           testdino_api_key: ${{ secrets.TDPW_API_KEY }}
         if: always()
 
+      - name: Record deployed app version
+        if: always()
+        continue-on-error: true
+        env:
+          BASE_URL: ${{ secrets.BASE_URL }}
+        run: |
+          # Penpot embeds its version directly in the page:
+          #   globalThis.penpotVersion = "2.17.0-...";
+          # (verified against penpot/penpot frontend/resources/templates/index.mustache)
+          VERSION=$(curl -sL "$BASE_URL" | grep -oE 'penpotVersion = "[^"]+"' | head -1 | sed 's/penpotVersion = "//; s/"$//')
+          VERSION=${VERSION:-unknown}
+          echo "Deployed app version: $VERSION"
+          echo "$VERSION" > app-version.txt
+          aws s3 cp app-version.txt "s3://kaleidos-qa-reports/run-${{ github.run_id }}/app-version.txt"
+
       - name: Send Mattermost Notification
         uses: ./.github/actions/send-notification
         with:

--- a/.github/workflows/release-triage.yml
+++ b/.github/workflows/release-triage.yml
@@ -25,6 +25,9 @@ on:
         options:
           - cluster
           - file
+      epic_ref:
+        description: 'Optional: Taiga epic ref (number only, e.g. 118) to link the story under'
+        required: false
 
 permissions:
   contents: read
@@ -88,21 +91,27 @@ jobs:
             --state .triage/state.json \
             --release "${{ inputs.release_tag }}" \
             --group-by "${{ inputs.group_by || 'cluster' }}" \
+            --epic-ref "${{ inputs.epic_ref }}" \
             --report-url "https://kaleidos-qa-reports.s3.eu-west-1.amazonaws.com/run-${{ steps.report.outputs.run_id }}/index.html"
         env:
-          TAIGA_URL: ${{ secrets.TAIGA_URL }}
+          TAIGA_URL: ${{ secrets.TAIGA_URL }} # https://api.taiga.io on Taiga cloud
+          TAIGA_PUBLIC_URL: ${{ vars.TAIGA_PUBLIC_URL }} # https://tree.taiga.io — used for links in the digest
           TAIGA_USERNAME: ${{ secrets.TAIGA_USERNAME }}
           TAIGA_PASSWORD: ${{ secrets.TAIGA_PASSWORD }}
           TAIGA_PROJECT: ${{ vars.TAIGA_PROJECT }}
           TAIGA_TAGS: 'needs-triage' # release-<tag> is added automatically
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_DAILY_REPORT }}
-          DRY_RUN: '1'
+          # DRY_RUN: "1"
 
       - name: Push per-release triage state
         if: always()
         run: |
-          aws s3 cp .triage/state.json \
-            "s3://kaleidos-qa-reports/triage/state-release-${{ inputs.release_tag }}.json"
+          if [ -f .triage/state.json ]; then
+            aws s3 cp .triage/state.json \
+              "s3://kaleidos-qa-reports/triage/state-release-${{ inputs.release_tag }}.json"
+          else
+            echo "No state file to push (dry run leaves no trace)"
+          fi
 
       - name: Digest to job summary
         if: always()

--- a/.github/workflows/release-triage.yml
+++ b/.github/workflows/release-triage.yml
@@ -79,6 +79,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           DAILY_WORKFLOW: playwright_pre_daily.yml # "Daily Penpot Regression Tests on PRE"
 
+      - name: Fetch app version for this run
+        id: appver
+        run: |
+          VERSION=$(aws s3 cp "s3://kaleidos-qa-reports/run-${{ steps.report.outputs.run_id }}/app-version.txt" - 2>/dev/null || echo "")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "App version for this run: ${VERSION:-<not recorded>}"
+
       - name: Pull per-release triage state
         run: |
           mkdir -p .triage
@@ -93,8 +100,11 @@ jobs:
             --release "${{ inputs.release_tag }}" \
             --group-by "${{ inputs.group_by || 'cluster' }}" \
             --epic-ref "${{ inputs.epic_ref }}" \
+            --app-version "${{ steps.appver.outputs.version }}" \
             --report-url "https://kaleidos-qa-reports.s3.eu-west-1.amazonaws.com/run-${{ steps.report.outputs.run_id }}/index.html"
         env:
+          GITHUB_TOKEN: ${{ github.token }} # raises GitHub API rate limit for the app-repo changelog fetch
+          # APP_REPO: penpot/penpot                            # default; override if the app repo moves
           TAIGA_URL: ${{ secrets.TAIGA_URL }} # https://api.taiga.io on Taiga cloud
           TAIGA_PUBLIC_URL: ${{ vars.TAIGA_PUBLIC_URL }} # https://tree.taiga.io — used for links in the digest
           TAIGA_USERNAME: ${{ secrets.TAIGA_USERNAME }}

--- a/.github/workflows/release-triage.yml
+++ b/.github/workflows/release-triage.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: 'Release tag (e.g. 26.07) — story will be tagged release-<tag>'
+        description: 'Release tag (e.g. 2.17) — story will be tagged release-<tag>'
         required: true
       report_run_id:
         description: 'Override: specific run id to triage (default: last scheduled daily run on main)'
@@ -36,6 +36,7 @@ permissions:
 jobs:
   triage:
     runs-on: ubuntu-latest
+    environment: PRE # grants access to MATTERMOST_WEBHOOK_DAILY_REPORT (environment secret)
     steps:
       - uses: actions/checkout@v4
 
@@ -100,7 +101,7 @@ jobs:
           TAIGA_PASSWORD: ${{ secrets.TAIGA_PASSWORD }}
           TAIGA_PROJECT: ${{ vars.TAIGA_PROJECT }}
           TAIGA_TAGS: 'needs-triage' # release-<tag> is added automatically
-          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_DAILY_REPORT }}
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_DAILY_REPORT }} # PRE environment secret -> Autotests Reports channel
           # DRY_RUN: "1"
 
       - name: Push per-release triage state

--- a/scripts/triage.ts
+++ b/scripts/triage.ts
@@ -331,8 +331,11 @@ async function main() {
     if (state[fp]) {
       knownClusters.push(c);
       state[fp].lastSeen = today;
-      state[fp].consecutiveRuns += 1;
-      state[fp].seenInLastNRuns = [1, ...state[fp].seenInLastNRuns].slice(0, 10);
+      state[fp].consecutiveRuns = (state[fp].consecutiveRuns ?? 0) + 1;
+      state[fp].seenInLastNRuns = [1, ...(state[fp].seenInLastNRuns ?? [])].slice(
+        0,
+        10,
+      );
     } else {
       newClusters.push(c);
       state[fp] = {
@@ -344,8 +347,12 @@ async function main() {
     }
   }
   for (const fp of Object.keys(state)) {
+    if (fp.startsWith('__')) continue; // internal bookkeeping (release story, file->task map), not a cluster
     if (!clusters.has(fp)) {
-      state[fp].seenInLastNRuns = [0, ...state[fp].seenInLastNRuns].slice(0, 10);
+      state[fp].seenInLastNRuns = [0, ...(state[fp].seenInLastNRuns ?? [])].slice(
+        0,
+        10,
+      );
       state[fp].consecutiveRuns = 0;
       if (
         state[fp].seenInLastNRuns.slice(0, 3).every((x) => x === 0) &&

--- a/scripts/triage.ts
+++ b/scripts/triage.ts
@@ -37,6 +37,7 @@ const REPORT_URL = arg('report-url', '');
 const RELEASE = arg('release', ''); // e.g. "2.17" -> single story tagged release-2.17 with one task per cluster
 const GROUP_BY = arg('group-by', 'cluster'); // release-mode tasks: 'cluster' (one per root cause) or 'file' (one per spec file)
 const EPIC_REF = arg('epic-ref', ''); // optional: Taiga epic ref (#number) to link created stories under
+const APP_VERSION = arg('app-version', ''); // optional: deployed app version this report ran against
 const DRY_RUN = process.env.DRY_RUN === '1';
 
 // ---------- Types ----------
@@ -370,6 +371,24 @@ async function main() {
     : {};
 
   const today = new Date().toISOString().slice(0, 10);
+
+  // ----- App version tracking -----
+  const prevVersion = (state as any)['__app_version__'] as
+    { version: string; date: string } | undefined;
+  const versionChanged = !!(
+    APP_VERSION &&
+    prevVersion?.version &&
+    prevVersion.version !== APP_VERSION
+  );
+  if (APP_VERSION && !DRY_RUN) {
+    (state as any)['__app_version__'] = { version: APP_VERSION, date: today };
+  }
+  const versionLine = APP_VERSION
+    ? `App version: **${APP_VERSION}**${versionChanged ? ` — changed from ${prevVersion!.version} (recorded ${prevVersion!.date})` : prevVersion ? ' (unchanged since last triage)' : ''}`
+    : '';
+  const changelog = versionChanged
+    ? await fetchChangelog(prevVersion!.version, APP_VERSION)
+    : null;
   const newClusters: Cluster[] = [];
   const knownClusters: Cluster[] = [];
   const resolved: string[] = [];
@@ -453,6 +472,13 @@ async function main() {
         REPORT_URL ? `[HTML report](${REPORT_URL})` : '',
         '',
         'Each task below is one failure cluster (one root cause). Classify each as real bug or test to update.',
+        ...(changelog
+          ? [
+              '',
+              `**App changes since last triage (${changelog.total} commits, [compare](${changelog.compareUrl})):**`,
+              ...changelog.lines,
+            ]
+          : []),
       ].join('\n');
       const { id, ref } = await taiga.createUserStory(subject, description, [
         ...storyTags,
@@ -552,6 +578,16 @@ async function main() {
         `Re-run on ${today}: ${knownClusters.length} cluster(s) still failing, ${newClusters.length} new. Report: ${REPORT_URL}`,
       );
     }
+    if (taiga && storyId && changelog && !!storyState?.taigaId) {
+      // story pre-existed and the app changed since -> post the changelog as a comment
+      await taiga.commentStory(
+        storyId,
+        [
+          `App changed: \`${prevVersion!.version}\` -> \`${APP_VERSION}\` (${changelog.total} commits, [compare](${changelog.compareUrl}))`,
+          ...changelog.lines,
+        ].join('\n'),
+      );
+    }
   } else {
     // ----- Daily mode: one user story per cluster, one task per test -----
     for (const c of newClusters) {
@@ -619,6 +655,12 @@ async function main() {
   digest.push(
     `**${hardFailures.length} failures** in **${clusters.size} clusters** · ${flakyTests.length} flaky · ${resolved.length} resolved`,
   );
+  if (versionLine) digest.push(versionLine);
+  if (changelog) {
+    digest.push(
+      `App changes since last triage: **${changelog.total} commits** — [compare](${changelog.compareUrl})`,
+    );
+  }
   if (REPORT_URL) digest.push(`[Full HTML report](${REPORT_URL})`);
   digest.push('');
   if (newClusters.length) {
@@ -655,7 +697,7 @@ async function main() {
     ? ((state as any)['__release_story__'] as StateEntry | undefined)?.taigaRef
     : undefined;
   const mm: string[] = [];
-  const verdict = `**:mag: Triage${RELEASE ? ` release ${RELEASE}` : ''}** — ${newClusters.length} new · ${knownClusters.length} known · ${resolved.length} resolved${releaseStoryRef ? ` · ${taigaLink(releaseStoryRef)}` : ''}`;
+  const verdict = `**:mag: Triage${RELEASE ? ` release ${RELEASE}` : ''}** — ${newClusters.length} new · ${knownClusters.length} known · ${resolved.length} resolved${releaseStoryRef ? ` · ${taigaLink(releaseStoryRef)}` : ''}${APP_VERSION ? `\napp \`${APP_VERSION}\`${versionChanged ? ` :warning: changed from \`${prevVersion!.version}\`${changelog ? ` ([${changelog.total} commits](${changelog.compareUrl}))` : ''}` : ''}` : ''}`;
   mm.push(verdict);
   if (newClusters.length) {
     mm.push('', '**New:**');
@@ -731,6 +773,66 @@ function conciseError(msg: string): string {
     );
   else if (exp) parts.push(`expected ${exp[1].trim().slice(0, 40)}`);
   return parts.length ? `${first} — ${parts.join(' — ')}` : first;
+}
+
+// ---------- App changelog (public repo compare) ----------
+
+/** Extract the commit hash from a git-describe style version: 2.17.0-RC3-18-g85dbf14344 -> 85dbf14344 */
+function commitFromVersion(v?: string): string | undefined {
+  return v?.match(/-g([0-9a-f]{7,40})$/i)?.[1];
+}
+
+interface Changelog {
+  compareUrl: string;
+  total: number;
+  lines: string[];
+}
+
+/**
+ * List commits between two deployed versions via the app repo's public compare API.
+ * Never throws — changelog is enrichment, not a dependency.
+ */
+async function fetchChangelog(
+  prevVersion: string,
+  currVersion: string,
+): Promise<Changelog | null> {
+  const repo = process.env.APP_REPO || 'penpot/penpot';
+  const oldSha = commitFromVersion(prevVersion);
+  const newSha = commitFromVersion(currVersion);
+  if (!oldSha || !newSha) return null;
+  try {
+    const headers: Record<string, string> = {
+      'Accept': 'application/vnd.github+json',
+      'User-Agent': 'qa-triage',
+    };
+    if (process.env.GITHUB_TOKEN)
+      headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+    const r = await fetch(
+      `https://api.github.com/repos/${repo}/compare/${oldSha}...${newSha}`,
+      { headers },
+    );
+    if (!r.ok) {
+      console.log(`Changelog fetch skipped: compare API -> ${r.status}`);
+      return null;
+    }
+    const data = await r.json();
+    const commits: Array<{ sha: string; commit: { message: string } }> =
+      data.commits ?? [];
+    const lines = commits
+      .map(
+        (c) =>
+          `- \`${c.sha.slice(0, 10)}\` ${c.commit.message.split('\n')[0].slice(0, 100)}`,
+      )
+      .slice(-30); // most recent 30
+    return {
+      compareUrl: `https://github.com/${repo}/compare/${oldSha}...${newSha}`,
+      total: data.total_commits ?? commits.length,
+      lines,
+    };
+  } catch (e) {
+    console.log(`Changelog fetch skipped: ${e instanceof Error ? e.message : e}`);
+    return null;
+  }
 }
 
 function taigaLink(ref?: number): string {

--- a/scripts/triage.ts
+++ b/scripts/triage.ts
@@ -700,7 +700,11 @@ function conciseError(msg: string): string {
 
 function taigaLink(ref?: number): string {
   if (!ref) return 'Taiga #?';
-  const base = process.env.TAIGA_URL;
+  // Links must use the web UI host (tree.taiga.io on cloud), not the API host.
+  // Also: TAIGA_URL is a GitHub *secret*, so any link built from it gets masked
+  // to *** in job summaries — TAIGA_PUBLIC_URL is a plain variable and doesn't.
+  // `||` not `??`: GitHub Actions passes unset vars as empty strings.
+  const base = process.env.TAIGA_PUBLIC_URL || process.env.TAIGA_URL;
   const project = process.env.TAIGA_PROJECT;
   return base && project
     ? `[Taiga #${ref}](${base}/project/${project}/us/${ref})`

--- a/scripts/triage.ts
+++ b/scripts/triage.ts
@@ -34,7 +34,7 @@ function arg(name: string, fallback?: string): string {
 const RESULTS_PATH = arg('results', 'playwright-report/results.json');
 const STATE_PATH = arg('state', '.triage/state.json');
 const REPORT_URL = arg('report-url', '');
-const RELEASE = arg('release', ''); // e.g. "26.07" -> single story tagged release-26.07 with one task per cluster
+const RELEASE = arg('release', ''); // e.g. "2.17" -> single story tagged release-2.17 with one task per cluster
 const GROUP_BY = arg('group-by', 'cluster'); // release-mode tasks: 'cluster' (one per root cause) or 'file' (one per spec file)
 const EPIC_REF = arg('epic-ref', ''); // optional: Taiga epic ref (#number) to link created stories under
 const DRY_RUN = process.env.DRY_RUN === '1';
@@ -614,7 +614,7 @@ async function main() {
     fs.writeFileSync(STATE_PATH, JSON.stringify(state, null, 2));
   }
 
-  // ----- Digest (markdown, printed to stdout for Slack/summary step) -----
+  // ----- Digest (markdown: stdout, job summary, and .triage/digest.md) -----
   const digest: string[] = [`## Daily triage — ${today}`, ''];
   digest.push(
     `**${hardFailures.length} failures** in **${clusters.size} clusters** · ${flakyTests.length} flaky · ${resolved.length} resolved`,
@@ -650,7 +650,37 @@ async function main() {
   fs.mkdirSync('.triage', { recursive: true });
   fs.writeFileSync('.triage/digest.md', digestText);
 
-  // ----- Mattermost -----
+  // ----- Mattermost (compressed: verdict + new clusters + resolved; details live in Taiga) -----
+  const releaseStoryRef = RELEASE
+    ? ((state as any)['__release_story__'] as StateEntry | undefined)?.taigaRef
+    : undefined;
+  const mm: string[] = [];
+  const verdict = `**:mag: Triage${RELEASE ? ` release ${RELEASE}` : ''}** — ${newClusters.length} new · ${knownClusters.length} known · ${resolved.length} resolved${releaseStoryRef ? ` · ${taigaLink(releaseStoryRef)}` : ''}`;
+  mm.push(verdict);
+  if (newClusters.length) {
+    mm.push('', '**New:**');
+    for (const c of newClusters) {
+      mm.push(
+        `- \`${conciseError(c.errorSample)}\` — ${c.tests.length} test${c.tests.length > 1 ? 's' : ''}${qaseList(c)}`,
+      );
+    }
+  }
+  if (resolved.length) {
+    mm.push(
+      '',
+      `**Resolved (close?):** ${resolved.map((fp) => taigaLink(state[fp].taigaRef)).join(', ')}`,
+    );
+  }
+  mm.push(
+    '',
+    `${hardFailures.length} failures · ${flakyTests.length} flaky${REPORT_URL ? ` · [HTML report](${REPORT_URL})` : ''}`,
+  );
+  const nothingChanged =
+    newClusters.length === 0 && resolved.length === 0 && knownClusters.length > 0;
+  const mmText = nothingChanged
+    ? `**:mag: Triage${RELEASE ? ` release ${RELEASE}` : ''}** — re-run: nothing new, ${knownClusters.length} known cluster${knownClusters.length > 1 ? 's' : ''} still failing.${releaseStoryRef ? ` ${taigaLink(releaseStoryRef)}` : ''}`
+    : mm.join('\n');
+
   const mmWebhook = process.env.MATTERMOST_WEBHOOK_URL;
   if (mmWebhook && !DRY_RUN) {
     const r = await fetch(mmWebhook, {
@@ -659,13 +689,18 @@ async function main() {
       body: JSON.stringify({
         username: 'Daily Triage',
         icon_emoji: ':test_tube:',
-        // channel: 'qa-daily',  // optional override; defaults to the webhook's channel
-        text: digestText,
+        text: mmText,
       }),
     });
     if (!r.ok)
       console.error(`Mattermost post failed: ${r.status} ${await r.text()}`);
     else console.log('Digest posted to Mattermost');
+  } else if (DRY_RUN) {
+    console.log(
+      '\n----- MATTERMOST PREVIEW -----\n' +
+        mmText +
+        '\n------------------------------',
+    );
   }
 }
 

--- a/scripts/triage.ts
+++ b/scripts/triage.ts
@@ -99,7 +99,7 @@ function walkSuites(suite: any, file: string, out: Failure[]) {
         file: f,
         title: spec.title,
         qaseId: extractQaseId(spec.title, test.annotations ?? []),
-        error: message.split('\n').slice(0, 6).join('\n'),
+        error: message.split('\n').slice(0, 14).join('\n'),
         snippet: frame,
         retries: results.length - 1,
         flaky: isFlaky && !isFailure,
@@ -435,7 +435,7 @@ async function main() {
       for (const [file, tests] of byFile) {
         const lines = tests.map(
           (t) =>
-            `- \`${t.title}\`${t.qaseId ? ` (Qase: ${t.qaseId})` : ''}${t.retries ? ` — ${t.retries} retries` : ''}\n  \`\`\`\n  ${shortError(t.error)}\n  \`\`\``,
+            `- \`${t.title}\`${t.qaseId ? ` (Qase: ${t.qaseId})` : ''}${t.retries ? ` — ${t.retries} retries` : ''}\n  \`\`\`\n  ${conciseError(t.error)}\n  \`\`\``,
         );
         if (taiga && storyId) {
           if (fileTasks[file]) {
@@ -477,7 +477,7 @@ async function main() {
       }
     } else {
       for (const c of newClusters) {
-        const taskSubject = `${shortError(c.errorSample)} — ${[...c.files].map((f: string) => path.basename(f)).join(', ')} (${c.tests.length} test${c.tests.length > 1 ? 's' : ''})`;
+        const taskSubject = `${conciseError(c.errorSample)} — ${[...c.files].map((f: string) => path.basename(f)).join(', ')} (${c.tests.length} test${c.tests.length > 1 ? 's' : ''})`;
         if (taiga && storyId) {
           await taiga.createTask(storyId, taskSubject, clusterDescription(c));
           state[c.fingerprint].taigaId = storyId;
@@ -497,7 +497,7 @@ async function main() {
   } else {
     // ----- Daily mode: one user story per cluster, one task per test -----
     for (const c of newClusters) {
-      const subject = `[daily] ${shortError(c.errorSample)} — ${[...c.files].map((f: string) => path.basename(f)).join(', ')} (${c.tests.length} test${c.tests.length > 1 ? 's' : ''})`;
+      const subject = `[daily] ${conciseError(c.errorSample)} — ${[...c.files].map((f: string) => path.basename(f)).join(', ')} (${c.tests.length} test${c.tests.length > 1 ? 's' : ''})`;
       const description = clusterDescription(c);
       if (taiga) {
         const { id, ref } = await taiga.createUserStory(
@@ -545,8 +545,14 @@ async function main() {
     }
   }
 
-  fs.mkdirSync(path.dirname(STATE_PATH), { recursive: true });
-  fs.writeFileSync(STATE_PATH, JSON.stringify(state, null, 2));
+  if (DRY_RUN) {
+    console.log(
+      '[dry-run] state NOT saved — dry runs leave no trace, so a later real run still sees these failures as new',
+    );
+  } else {
+    fs.mkdirSync(path.dirname(STATE_PATH), { recursive: true });
+    fs.writeFileSync(STATE_PATH, JSON.stringify(state, null, 2));
+  }
 
   // ----- Digest (markdown, printed to stdout for Slack/summary step) -----
   const digest: string[] = [`## Daily triage — ${today}`, ''];
@@ -560,7 +566,7 @@ async function main() {
     for (const c of newClusters) {
       const ref = state[c.fingerprint].taigaRef;
       digest.push(
-        `- ${ref ? `${taigaLink(ref)} — ` : ''}\`${shortError(c.errorSample)}\` in ${[...c.files].join(', ')} (${c.tests.length} tests)`,
+        `- ${ref ? `${taigaLink(ref)} — ` : ''}\`${conciseError(c.errorSample)}\` in ${[...c.files].join(', ')} (${c.tests.length} test${c.tests.length > 1 ? 's' : ''})`,
       );
     }
     digest.push('');
@@ -570,7 +576,7 @@ async function main() {
     for (const c of knownClusters) {
       const e = state[c.fingerprint];
       digest.push(
-        `- ${taigaLink(e.taigaRef)} — ${c.tests.length} tests, failing ${e.consecutiveRuns} runs in a row`,
+        `- ${taigaLink(e.taigaRef)} — \`${conciseError(c.errorSample)}\` in ${[...c.files].join(', ')} (${c.tests.length} test${c.tests.length > 1 ? 's' : ''}, failing ${e.consecutiveRuns} runs in a row)`,
       );
     }
     digest.push('');
@@ -581,6 +587,7 @@ async function main() {
   }
   const digestText = digest.join('\n');
   console.log('\n' + digestText);
+  fs.mkdirSync('.triage', { recursive: true });
   fs.writeFileSync('.triage/digest.md', digestText);
 
   // ----- Mattermost -----
@@ -604,6 +611,26 @@ async function main() {
 
 function shortError(msg: string): string {
   return msg.split('\n')[0].slice(0, 90);
+}
+
+/**
+ * Playwright's first error line is generic ("expect(locator).toBeVisible() failed");
+ * the concrete facts (which element, expected vs received) are on later lines.
+ * Build a one-line summary that includes them.
+ */
+function conciseError(msg: string): string {
+  const first = msg.split('\n')[0].slice(0, 90);
+  const parts: string[] = [];
+  const loc = msg.match(/(?:Locator:|waiting for)\s+(.+)/);
+  if (loc) parts.push(`@ ${loc[1].trim().slice(0, 70)}`);
+  const exp = msg.match(/Expected(?: string| pattern)?:\s+(.+)/);
+  const rec = msg.match(/Received(?: string)?:\s+(.+)/);
+  if (exp && rec)
+    parts.push(
+      `expected ${exp[1].trim().slice(0, 40)}, got ${rec[1].trim().slice(0, 40)}`,
+    );
+  else if (exp) parts.push(`expected ${exp[1].trim().slice(0, 40)}`);
+  return parts.length ? `${first} — ${parts.join(' — ')}` : first;
 }
 
 function taigaLink(ref?: number): string {

--- a/scripts/triage.ts
+++ b/scripts/triage.ts
@@ -36,6 +36,7 @@ const STATE_PATH = arg('state', '.triage/state.json');
 const REPORT_URL = arg('report-url', '');
 const RELEASE = arg('release', ''); // e.g. "26.07" -> single story tagged release-26.07 with one task per cluster
 const GROUP_BY = arg('group-by', 'cluster'); // release-mode tasks: 'cluster' (one per root cause) or 'file' (one per spec file)
+const EPIC_REF = arg('epic-ref', ''); // optional: Taiga epic ref (#number) to link created stories under
 const DRY_RUN = process.env.DRY_RUN === '1';
 
 // ---------- Types ----------
@@ -266,6 +267,28 @@ class Taiga {
     });
   }
 
+  async epicIdByRef(ref: string): Promise<number> {
+    const e = await this.get(
+      `/api/v1/epics/by_ref?ref=${encodeURIComponent(ref)}&project=${this.projectId}`,
+    );
+    return e.id;
+  }
+
+  async linkStoryToEpic(epicId: number, storyId: number) {
+    // 400 here usually means "already linked" (re-runs) — tolerated.
+    const r = await this.request(
+      'POST',
+      `/api/v1/epics/${epicId}/related_userstories`,
+      { epic: epicId, user_story: storyId },
+      true,
+      true,
+    );
+    if (!r.ok && r.status !== 400)
+      throw new Error(
+        `Linking story to epic failed -> ${r.status} ${await r.text()}`,
+      );
+  }
+
   async commentTask(taskId: number, comment: string) {
     const task = await this.get(`/api/v1/tasks/${taskId}`);
     await this.patch(`/api/v1/tasks/${taskId}`, { version: task.version, comment });
@@ -446,9 +469,13 @@ async function main() {
         seenInLastNRuns: [1],
       };
       console.log(`Created release user story #${ref} [${releaseTag}]`);
+      if (EPIC_REF) {
+        await taiga.linkStoryToEpic(await taiga.epicIdByRef(EPIC_REF), id);
+        console.log(`Linked story #${ref} under epic #${EPIC_REF}`);
+      }
     } else if (!taiga) {
       console.log(
-        `[dry-run] Would create/reuse release user story: [release ${RELEASE}] Daily failures triage [tags: ${[...storyTags, releaseTag].join(', ')}]`,
+        `[dry-run] Would create/reuse release user story: [release ${RELEASE}] Daily failures triage [tags: ${[...storyTags, releaseTag].join(', ')}]${EPIC_REF ? ` under epic #${EPIC_REF}` : ''}`,
       );
     }
 
@@ -539,6 +566,8 @@ async function main() {
         state[c.fingerprint].taigaId = id;
         state[c.fingerprint].taigaRef = ref;
         console.log(`Created Taiga user story #${ref} for cluster ${c.fingerprint}`);
+        if (EPIC_REF)
+          await taiga.linkStoryToEpic(await taiga.epicIdByRef(EPIC_REF), id);
         for (const t of c.tests) {
           await taiga.createTask(
             id,
@@ -679,22 +708,28 @@ function taigaLink(ref?: number): string {
 }
 
 function clusterDescription(c: Cluster): string {
+  const qaseIds = c.tests.map((t: Failure) => t.qaseId).filter(Boolean);
   const lines = [
-    `**Error signature** \`${c.fingerprint}\``,
+    `**Error:** \`${conciseError(c.errorSample)}\``,
     '',
-    '```',
-    c.errorSample,
-    '```',
+    `**Spec files affected (${c.files.size}):**`,
+    ...[...c.files].map((f: string) => `- \`${f}\``),
+    '',
+    `**Qase IDs affected:** ${qaseIds.length ? qaseIds.map((q) => `\`${q}\``).join(', ') : '_none linked_'}`,
     '',
     `**Affected tests (${c.tests.length}):**`,
     ...c.tests.map(
       (t: Failure) =>
-        `- \`${t.testId}\`${t.retries ? ` (${t.retries} retries)` : ''}`,
+        `- \`${t.title}\`${t.qaseId ? ` (Qase: ${t.qaseId})` : ''} — \`${t.file}\`${t.retries ? ` (${t.retries} retries)` : ''}`,
     ),
     '',
-    REPORT_URL ? `[HTML report](${REPORT_URL})` : '',
+    '**Full error:**',
+    '```',
+    c.errorSample,
+    '```',
     '',
-    '_Auto-created by daily triage. Classify: real bug vs test to update._',
+    REPORT_URL ? `[HTML report](${REPORT_URL})` : '',
+    `_Cluster \`${c.fingerprint}\` — auto-created by daily triage. Classify: real bug vs test to update._`,
   ];
   return lines.join('\n');
 }

--- a/scripts/triage.ts
+++ b/scripts/triage.ts
@@ -162,11 +162,35 @@ function normalizeError(msg: string): string {
     .slice(0, 400);
 }
 
+/** Visual-comparison failures are debugged per spec file; their messages carry little identity. */
+function isSnapshotError(msg: string): boolean {
+  return /toHaveScreenshot|toMatchSnapshot|Screenshot comparison failed|snapshot/i.test(
+    msg,
+  );
+}
+
 function fingerprint(fail: Failure): string {
-  // Error shape + file (not test title): same broken selector across
-  // 5 tests in one spec = one cluster, one task.
-  const basis = `${normalizeError(fail.error)}|${fail.file}`;
+  // Hybrid clustering:
+  // - snapshot/visual errors: per spec file (generic message, and visual diffs are
+  //   debugged file by file against the spec's snapshots folder)
+  // - functional errors: cross-file, keyed by error shape + locator. The locator's
+  //   quoted text ('Select' vs 'Cancel subscription') IS the identity, so it is kept
+  //   verbatim — only dynamic fragments (hex ids, numbers) inside it are neutralized.
+  const basis = isSnapshotError(fail.error)
+    ? `${normalizeError(fail.error)}|${fail.file}`
+    : `${normalizeError(fail.error)}|${locatorKey(fail.error)}`;
   return crypto.createHash('sha1').update(basis).digest('hex').slice(0, 12);
+}
+
+/** Locator with dynamic fragments neutralized but quoted text preserved. */
+function locatorKey(msg: string): string {
+  const m = msg.match(/(?:Locator:|waiting for)\s+(.+)/);
+  if (!m) return '';
+  return m[1]
+    .trim()
+    .replace(/\b[0-9a-f]{6,40}\b/gi, '<hex>')
+    .replace(/\b\d+\b/g, 'N')
+    .slice(0, 200);
 }
 
 // ---------- Clustering ----------

--- a/scripts/triage.ts
+++ b/scripts/triage.ts
@@ -573,7 +573,7 @@ async function main() {
     for (const c of newClusters) {
       const ref = state[c.fingerprint].taigaRef;
       digest.push(
-        `- ${ref ? `${taigaLink(ref)} — ` : ''}\`${conciseError(c.errorSample)}\` in ${[...c.files].join(', ')} (${c.tests.length} test${c.tests.length > 1 ? 's' : ''})`,
+        `- ${ref ? `${taigaLink(ref)} — ` : ''}\`${conciseError(c.errorSample)}\` in ${[...c.files].join(', ')} (${c.tests.length} test${c.tests.length > 1 ? 's' : ''})${qaseList(c)}`,
       );
     }
     digest.push('');
@@ -583,7 +583,7 @@ async function main() {
     for (const c of knownClusters) {
       const e = state[c.fingerprint];
       digest.push(
-        `- ${taigaLink(e.taigaRef)} — \`${conciseError(c.errorSample)}\` in ${[...c.files].join(', ')} (${c.tests.length} test${c.tests.length > 1 ? 's' : ''}, failing ${e.consecutiveRuns} runs in a row)`,
+        `- ${taigaLink(e.taigaRef)} — \`${conciseError(c.errorSample)}\` in ${[...c.files].join(', ')} (${c.tests.length} test${c.tests.length > 1 ? 's' : ''}, failing ${e.consecutiveRuns} runs in a row)${qaseList(c)}`,
       );
     }
     digest.push('');
@@ -618,6 +618,11 @@ async function main() {
 
 function shortError(msg: string): string {
   return msg.split('\n')[0].slice(0, 90);
+}
+
+function qaseList(c: Cluster): string {
+  const ids = c.tests.map((t) => t.qaseId).filter(Boolean);
+  return ids.length ? ` [Qase: ${ids.join(', ')}]` : '';
 }
 
 /**


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/task/1613

## Description

After large promotions to PRE — especially during feature-freeze weeks — the daily Playwright report fills with failures, and QA had to manually read the HTML report, group failures by root cause, decide "real bug vs. test to update", and create Taiga tasks by hand. Because the app is developed in a separate repository, we don't know what changed until it lands on PRE, which makes the review slower and blinder than it needs to be.

## Solution

An on-demand triage pipeline in this repo:

- scripts/triage.ts — parses the daily run's results.json, clusters failures by root cause, tracks state across runs, records the deployed app version, fetches the app changelog from the public Penpot repo, and creates/updates the Taiga items via the REST API.
- .github/workflows/release-triage.yml — manual workflow (Actions → Release triage). Inputs: release tag (e.g. 2.17), optional task granularity (cluster/file), optional Taiga epic ref, optional run-id override.
- playwright_pre_daily.yml — one added step ("Record deployed app version"): reads globalThis.penpotVersion from the PRE page and stores it as run-<id>/app-version.txt next to the report in S3. continue-on-error, so it can never affect the daily run.

The daily test execution itself is unchanged beyond that one additive step; triage only reads the reports the daily run already publishes.

## How it works

1. Locating the report. The workflow queries the GitHub API for the last scheduled completed run of playwright_pre_daily.yml on main and downloads that run's results.json and app-version.txt. A specific run id can be passed to triage an older report.

2. Clustering. Each failure's error is normalized (timeouts, dynamic ids, timestamps, ports stripped) and fingerprinted. Clustering is hybrid, matching how we debug:

- Functional errors (timeouts, visibility, text assertions) are keyed by error shape + failing locator and merge across spec files — the same broken getByText('Select') failing from three specs is one cluster and one task. Dynamic fragments inside locators (hex ids) are neutralized so #checkout-9f3a2b and #checkout-77aa01 merge, while the quoted text that identifies the element is preserved. 
- Snapshot/visual errors stay grouped per spec file, because visual diffs are debugged file by file against the spec's snapshot folder, and a global visual change must not collapse into one unusable mega-task.

On real data this turned 12 failures into 7 root-cause tasks. Flaky tests (failed → passed on retry) are counted but never generate tasks.

3. Taiga output. One user story per release — [release 2.17] Daily failures triage, tagged release-2.17 + needs-triage, optionally linked under a given epic — with one task per cluster (or per spec file in file mode). Each task contains: the meaningful one-line error (type + locator + expected/received), the spec files affected, the Qase IDs of every affected test (extracted from the (Qase ID: NNNN) title convention), the per-test breakdown with retries, the full raw error, and the report link.

4. State & re-run safety. A per-release state file remembers fingerprints, run history, Taiga refs, and the app version at last triage. Re-running with the same tag reuses the same story, adds only new failures, comments what is still failing, and flags clusters green for 3 consecutive triaged runs as candidates to close. Taiga API calls retry on 429 throttling, and a deleted release story is recreated instead of crashing.

5. App version + changelog. The daily run records the deployed Penpot version (git-describe format, e.g. 2.17.0-RC3-18-g85dbf14344). Triage compares it with the version at the previous triage; when it changed, the digest and Mattermost show a ⚠️ "changed from X" line, and because the version embeds the exact commit, the script calls the public penpot/penpot compare API and attaches the list of commits that landed between the two deployments to the release story (section on creation, comment on later promotions). This directly answers "what changed on PRE?" without any dependency on the development team. The changelog is enrichment only — any API failure is logged and skipped, never breaking the run.

6. Notifications. A compressed digest is posted to the Autotests Reports Mattermost channel (via the existing environment secret — the job declares environment: PRE to access it): verdict line with counts and the story link, app version/changelog line, the new clusters with concise errors and Qase IDs, resolved candidates, and a one-line footer. Re-runs with nothing new post a single line instead. The full verbose digest goes to the workflow job summary.

<img width="1045" height="237" alt="image" src="https://github.com/user-attachments/assets/a076a366-0e33-4dce-9fe2-7d9e95b17eed" />
