### PR TITLE
test(plugins): remove trivial modal-close steps from non-regression suite

### DIFF
--- a/tests/plugins/plugins.spec.js
+++ b/tests/plugins/plugins.spec.js
@@ -20,51 +20,39 @@ mainTest.beforeEach(async ({ page }) => {
   await pluginsPage.isMainPageLoaded();
 });
 
-mainTest(
-  qase([1837, 1838, 1839, 1842, 1844], 'Install, open and delete a plugin'),
-  async () => {
-    await mainTest.step(
-      '1837, Install a plugin by URL (via plugin icon in toolbar)',
-      async () => {
-        await pluginsPage.clickPluginsButton();
-        await pluginsPage.isPluginManagerModalVisible();
-        await pluginsPage.setPluginLoremIpsumUrl();
-        await pluginsPage.clickOnInstallPluginButton();
-        await pluginsPage.clickOnAllowPluginButton();
-        await pluginsPage.isInstalledPluginsCount(1);
-        await pluginsPage.isOpenPluginButtonVisible();
-      },
-    );
+mainTest(qase([1837, 1839, 1844], 'Install, open and delete a plugin'), async () => {
+  await mainTest.step(
+    '1837, Install a plugin by URL (via plugin icon in toolbar)',
+    async () => {
+      await pluginsPage.clickPluginsButton();
+      await pluginsPage.isPluginManagerModalVisible();
+      await pluginsPage.setPluginLoremIpsumUrl();
+      await pluginsPage.clickOnInstallPluginButton();
+      await pluginsPage.clickOnAllowPluginButton();
+      await pluginsPage.isInstalledPluginsCount(1);
+      await pluginsPage.isOpenPluginButtonVisible();
+    },
+  );
 
-    await mainTest.step('1838, Close the "Plugins Manager" modal', async () => {
-      await pluginsPage.clickOnESC();
-    });
+  await mainTest.step(
+    '1844, Open a plugin (via Main menu 3 dots > Plugins > plugin name)',
+    async () => {
+      await pluginsPage.clickMainMenuButton();
+      await pluginsPage.clickPluginsMainMenuItem();
+      await pluginsPage.clickLoremIpsumButton();
+      await pluginsPage.isLoremIpsumPluginVisible();
+    },
+  );
 
-    await mainTest.step(
-      '1844, Open a plugin (via Main menu 3 dots > Plugins > plugin name)',
-      async () => {
-        await pluginsPage.clickMainMenuButton();
-        await pluginsPage.clickPluginsMainMenuItem();
-        await pluginsPage.clickLoremIpsumButton();
-        await pluginsPage.isLoremIpsumPluginVisible();
-      },
-    );
-
-    await mainTest.step(
-      '1839, Delete a plugin from the "Plugins Manager" modal (via delete icon button)',
-      async () => {
-        await pluginsPage.clickMainMenuButton();
-        await pluginsPage.clickPluginsMainMenuItem();
-        await pluginsPage.clickPluginsManagerButton();
-        await pluginsPage.clickOnDeletePluginButton();
-        await pluginsPage.isInstalledPluginsCount(0);
-        await pluginsPage.isNoPluginMessageVisible();
-      },
-    );
-
-    await mainTest.step('1842, Close the plugin modal (via "X" icon)', async () => {
-      await pluginsPage.clickClosePluginPanelButton();
-      await pluginsPage.isPluginManagerModalNotVisible();
-    });
-  },
-);
+  await mainTest.step(
+    '1839, Delete a plugin from the "Plugins Manager" modal (via delete icon button)',
+    async () => {
+      await pluginsPage.clickMainMenuButton();
+      await pluginsPage.clickPluginsMainMenuItem();
+      await pluginsPage.clickPluginsManagerButton();
+      await pluginsPage.clickOnDeletePluginButton();
+      await pluginsPage.isInstalledPluginsCount(0);
+      await pluginsPage.isNoPluginMessageVisible();
+    },
+  );
+});


### PR DESCRIPTION
## Taiga URL (optional)

[Taiga Task: 1666](https://tree.taiga.io/project/kaleidos-qa/task/1666)

## Description

![delete plugin gif](https://media.giphy.com/media/FO2ALAo2bwU1Vq45bJ/giphy.gif)

This PR continues the non-regression suite pruning. We reviewed the plugin tests classified as NON-REGRESSION and removed trivial modal-close steps that add no regression value.

## Solution

Reviewed 3 plugin Qase IDs (1837, 1838, 1842) bundled in a single combined test (`tests/plugins/plugins.spec.js`). All 5 steps shared one `qase([1837, 1838, 1839, 1842, 1844], ...)` call.

Dropped 2 steps:
- **1838** — "Close the Plugins Manager modal (ESC)": trivial UI interaction, not a business rule.
- **1842** — "Close the plugin modal (X icon)": same axis as 1838, redundant modal-close variant.

Kept 3 steps covering the core plugin lifecycle:
- **1837** — Install plugin by URL (core install flow)
- **1844** — Open plugin via main menu (core open flow)
- **1839** — Delete plugin from manager (core delete flow)

Updated `qase()` to `[1837, 1839, 1844]` and removed the two deleted steps.

## How to test

- [x] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [x] It complies with the test conventions
- [ ] There are no missing snapshots
- [ ] The tests run OK
