### PR TITLE
feat(ci): integrate qase test reporting into playwright ci pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,8 +37,11 @@ CLIENT_ID="" # Gmail Client ID for email access
 CLIENT_SECRET="" # Gmail Client Secret for email access
 STRIPE_SK="" # Stripe Secret Key for payment processing
 
+
 ######################
-## Qase             ##
+## Qase Reporter    ##
 ######################
 
-QASE_TOKEN="" # Qase API token (https://app.qase.io/user/api/token)
+QASE_API_TOKEN=your_qase_api_token_here
+QASE_MODE=testops
+QASE_PROJECT_CODE=YOUR_PROJECT_CODE

--- a/.github/workflows/playwright_pre_daily.yml
+++ b/.github/workflows/playwright_pre_daily.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Run Playwright tests
         id: run-tests
         env:
+          QASE_API_TOKEN: ${{ secrets.QASE_API_TOKEN }}
+          QASE_MODE: testops
+          QASE_PROJECT_CODE: ${{ secrets.QASE_PROJECT_CODE }}
           BASE_URL: ${{ secrets.BASE_URL }}
           LOGIN_EMAIL: ${{ secrets.LOGIN_EMAIL }}
           SECOND_EMAIL: ${{ secrets.SECOND_EMAIL }}
@@ -42,7 +45,16 @@ jobs:
           GMAIL_NAME: ${{ secrets.GMAIL_NAME }}
           GMAIL_DOMAIN: ${{ secrets.GMAIL_DOMAIN }}
           STRIPE_SK: ${{ secrets.STRIPE_SK }}
-        run: npx playwright test --project=chrome
+        run: npx playwright test --project=chrome 2>&1 | tee test-output.log
+
+      - name: Add Qase run link to summary
+        if: always()
+        run: |
+          QASE_LINK=$(grep -oP 'https://app\.qase\.io/run/[A-Z0-9]+/dashboard/\d+' test-output.log | head -1)
+          if [ -n "$QASE_LINK" ]; then
+            echo "## Qase Report" >> $GITHUB_STEP_SUMMARY
+            echo "🔗 [View run in Qase]($QASE_LINK)" >> $GITHUB_STEP_SUMMARY
+          fi
 
       - name: Generate and Upload Reports
         uses: ./.github/actions/upload-reports

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "fs": "^0.0.1-security",
         "googleapis": "^173.0.0",
         "playwright": "^1.61.1",
-        "playwright-qase-reporter": "^2.5.6",
         "prettier": "^3.9.4",
         "qaseio": "^2.4.3",
         "stripe": "^22.3.0",
@@ -25,6 +24,7 @@
         "@types/node": "^26.1.1",
         "dotenv": "^17.4.2",
         "husky": "^9.1.7",
+        "playwright-qase-reporter": "^2.5.7",
         "tsx": "^4.23.1"
       }
     },
@@ -490,6 +490,7 @@
       "version": "1.61.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
       "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.61.1"
@@ -561,7 +562,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "license": "MIT",
+      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -577,7 +578,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -586,7 +587,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -606,7 +607,7 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
       "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
-      "license": "MIT",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -736,7 +737,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "license": "MIT",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -793,7 +794,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -805,7 +806,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -961,7 +962,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
       "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
-      "license": "BSD-2-Clause",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -1017,7 +1018,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/env-schema/-/env-schema-5.2.1.tgz",
       "integrity": "sha512-gWMNrQ3dVHAZcCx7epiFwgXcyfBh4heD/6+OK3bEbke3uL+KqwYA9nUOwzJyRZh1cJOFcwdPuY1n0GKSFlSWAg==",
-      "license": "MIT",
+      "dev": true,
       "dependencies": {
         "ajv": "^8.0.0",
         "dotenv": "^16.0.0",
@@ -1028,7 +1029,7 @@
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "license": "BSD-2-Clause",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -1131,12 +1132,13 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/fast-uri": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
       "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1146,8 +1148,7 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ],
-      "license": "BSD-3-Clause"
+      ]
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
@@ -1397,7 +1398,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "license": "MIT",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -1538,7 +1539,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/jwa": {
       "version": "2.0.1",
@@ -1561,24 +1562,17 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
-      "license": "MIT"
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/lodash.mergewith": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
       "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/make-error": {
       "version": "1.3.6",
@@ -1760,13 +1754,12 @@
       }
     },
     "node_modules/playwright-qase-reporter": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/playwright-qase-reporter/-/playwright-qase-reporter-2.5.6.tgz",
-      "integrity": "sha512-rc8bHi0SNF2CHw+QDi9lpEMTykgKaOKuTGpC858+iRF8o58J+hsnuuqjufkHf9voPpm7fU9SFZMHk/Ocw+h57Q==",
-      "license": "Apache-2.0",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/playwright-qase-reporter/-/playwright-qase-reporter-2.5.7.tgz",
+      "integrity": "sha512-K6mlIy8pL/MzpMxIdkqvB40Wjq0kXtiZJAWzaXesLDswyfgmedcCQ/9m9rhoBqNuRFlUQ5rWrFdSEAIeUTRoug==",
+      "dev": true,
       "dependencies": {
-        "chalk": "^4.1.2",
-        "qase-javascript-commons": "~2.7.5",
+        "qase-javascript-commons": "~2.7.6",
         "uuid": "11.1.1"
       },
       "engines": {
@@ -1804,7 +1797,7 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/qase-api-client/-/qase-api-client-1.1.12.tgz",
       "integrity": "sha512-wzN6P0oFfA1Gi7Gr8b13TlPqJeGOkopkPiY8IGLw6EfdqKVf1mNrzr/mI5V2ZikiLta0MVbLi7s3zZLAf+9SxQ==",
-      "license": "Apache-2.0",
+      "dev": true,
       "dependencies": {
         "axios": "^1.16.0",
         "axios-retry": "^4.5.0"
@@ -1817,7 +1810,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz",
       "integrity": "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==",
-      "license": "Apache-2.0",
+      "dev": true,
       "dependencies": {
         "is-retry-allowed": "^2.2.0"
       },
@@ -1829,7 +1822,7 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/qase-api-v2-client/-/qase-api-v2-client-1.0.9.tgz",
       "integrity": "sha512-Xw+jivNicP5t5Uq3HOCMRss0P3t27NGJl7VQHfWcS/YiiFKdRqHmedx8aDfCYed4lObMVYGXOn/c1XImLRKLNQ==",
-      "license": "Apache-2.0",
+      "dev": true,
       "dependencies": {
         "axios": "^1.16.0",
         "axios-retry": "^4.5.0"
@@ -1842,7 +1835,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz",
       "integrity": "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==",
-      "license": "Apache-2.0",
+      "dev": true,
       "dependencies": {
         "is-retry-allowed": "^2.2.0"
       },
@@ -1851,17 +1844,16 @@
       }
     },
     "node_modules/qase-javascript-commons": {
-      "version": "2.7.5",
-      "resolved": "https://registry.npmjs.org/qase-javascript-commons/-/qase-javascript-commons-2.7.5.tgz",
-      "integrity": "sha512-ERVfpMXPKAU+QyQn9DRZ0Yw6FEEPnFDmVurGrCXenkGee6wuU0Rw2IAUO0SJUbxS9AL1Gzc7uHvOOtsqlOxn8A==",
-      "license": "Apache-2.0",
+      "version": "2.7.6",
+      "resolved": "https://registry.npmjs.org/qase-javascript-commons/-/qase-javascript-commons-2.7.6.tgz",
+      "integrity": "sha512-Mo8pbxJlyiqAv+wpTRfJOdOYTMwLgXCv0PQL/d2MZBiR8R5OR7oy1AQ7Cv5qU01oOvR0n+fy9c0NVcmVkSFQ/A==",
+      "dev": true,
       "dependencies": {
         "ajv": "^8.18.0",
         "async-mutex": "~0.5.0",
         "chalk": "^4.1.2",
         "env-schema": "^5.2.1",
-        "form-data": "^4.0.5",
-        "lodash.get": "^4.4.2",
+        "form-data": "^4.0.6",
         "lodash.merge": "^4.6.2",
         "lodash.mergewith": "^4.6.2",
         "mime-types": "^2.1.35",
@@ -1906,7 +1898,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "license": "MIT",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2013,7 +2005,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -2042,7 +2034,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "license": "MIT",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -2096,7 +2088,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "dev": true
     },
     "node_modules/tsx": {
       "version": "4.23.1",
@@ -2167,11 +2159,11 @@
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
       "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
-      "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
       }
@@ -2439,6 +2431,7 @@
       "version": "1.61.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
       "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
       "requires": {
         "playwright": "1.61.1"
       }
@@ -2490,6 +2483,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2500,12 +2494,14 @@
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
     },
     "ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       }
@@ -2519,6 +2515,7 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
       "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "dev": true,
       "requires": {
         "tslib": "^2.4.0"
       }
@@ -2609,6 +2606,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2649,6 +2647,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
@@ -2656,7 +2655,8 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -2753,7 +2753,8 @@
     "dotenv-expand": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
-      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A=="
+      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
+      "dev": true
     },
     "dunder-proto": {
       "version": "1.0.1",
@@ -2791,6 +2792,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/env-schema/-/env-schema-5.2.1.tgz",
       "integrity": "sha512-gWMNrQ3dVHAZcCx7epiFwgXcyfBh4heD/6+OK3bEbke3uL+KqwYA9nUOwzJyRZh1cJOFcwdPuY1n0GKSFlSWAg==",
+      "dev": true,
       "requires": {
         "ajv": "^8.0.0",
         "dotenv": "^16.0.0",
@@ -2800,7 +2802,8 @@
         "dotenv": {
           "version": "16.6.1",
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-          "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="
+          "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+          "dev": true
         }
       }
     },
@@ -2875,12 +2878,14 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "fast-uri": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg=="
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "dev": true
     },
     "fetch-blob": {
       "version": "3.2.0",
@@ -3035,7 +3040,8 @@
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.1.0",
@@ -3115,7 +3121,8 @@
     "json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
     },
     "jwa": {
       "version": "2.0.1",
@@ -3136,20 +3143,17 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
-    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "lodash.mergewith": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "dev": true
     },
     "make-error": {
       "version": "1.3.6",
@@ -3254,12 +3258,12 @@
       "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="
     },
     "playwright-qase-reporter": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/playwright-qase-reporter/-/playwright-qase-reporter-2.5.6.tgz",
-      "integrity": "sha512-rc8bHi0SNF2CHw+QDi9lpEMTykgKaOKuTGpC858+iRF8o58J+hsnuuqjufkHf9voPpm7fU9SFZMHk/Ocw+h57Q==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/playwright-qase-reporter/-/playwright-qase-reporter-2.5.7.tgz",
+      "integrity": "sha512-K6mlIy8pL/MzpMxIdkqvB40Wjq0kXtiZJAWzaXesLDswyfgmedcCQ/9m9rhoBqNuRFlUQ5rWrFdSEAIeUTRoug==",
+      "dev": true,
       "requires": {
-        "chalk": "^4.1.2",
-        "qase-javascript-commons": "~2.7.5",
+        "qase-javascript-commons": "~2.7.6",
         "uuid": "11.1.1"
       }
     },
@@ -3277,6 +3281,7 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/qase-api-client/-/qase-api-client-1.1.12.tgz",
       "integrity": "sha512-wzN6P0oFfA1Gi7Gr8b13TlPqJeGOkopkPiY8IGLw6EfdqKVf1mNrzr/mI5V2ZikiLta0MVbLi7s3zZLAf+9SxQ==",
+      "dev": true,
       "requires": {
         "axios": "^1.16.0",
         "axios-retry": "^4.5.0"
@@ -3286,6 +3291,7 @@
           "version": "4.5.0",
           "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz",
           "integrity": "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==",
+          "dev": true,
           "requires": {
             "is-retry-allowed": "^2.2.0"
           }
@@ -3296,6 +3302,7 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/qase-api-v2-client/-/qase-api-v2-client-1.0.9.tgz",
       "integrity": "sha512-Xw+jivNicP5t5Uq3HOCMRss0P3t27NGJl7VQHfWcS/YiiFKdRqHmedx8aDfCYed4lObMVYGXOn/c1XImLRKLNQ==",
+      "dev": true,
       "requires": {
         "axios": "^1.16.0",
         "axios-retry": "^4.5.0"
@@ -3305,6 +3312,7 @@
           "version": "4.5.0",
           "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz",
           "integrity": "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==",
+          "dev": true,
           "requires": {
             "is-retry-allowed": "^2.2.0"
           }
@@ -3312,16 +3320,16 @@
       }
     },
     "qase-javascript-commons": {
-      "version": "2.7.5",
-      "resolved": "https://registry.npmjs.org/qase-javascript-commons/-/qase-javascript-commons-2.7.5.tgz",
-      "integrity": "sha512-ERVfpMXPKAU+QyQn9DRZ0Yw6FEEPnFDmVurGrCXenkGee6wuU0Rw2IAUO0SJUbxS9AL1Gzc7uHvOOtsqlOxn8A==",
+      "version": "2.7.6",
+      "resolved": "https://registry.npmjs.org/qase-javascript-commons/-/qase-javascript-commons-2.7.6.tgz",
+      "integrity": "sha512-Mo8pbxJlyiqAv+wpTRfJOdOYTMwLgXCv0PQL/d2MZBiR8R5OR7oy1AQ7Cv5qU01oOvR0n+fy9c0NVcmVkSFQ/A==",
+      "dev": true,
       "requires": {
         "ajv": "^8.18.0",
         "async-mutex": "~0.5.0",
         "chalk": "^4.1.2",
         "env-schema": "^5.2.1",
-        "form-data": "^4.0.5",
-        "lodash.get": "^4.4.2",
+        "form-data": "^4.0.6",
         "lodash.merge": "^4.6.2",
         "lodash.mergewith": "^4.6.2",
         "mime-types": "^2.1.35",
@@ -3351,7 +3359,8 @@
     "require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
     },
     "safe-buffer": {
       "version": "5.2.1",
@@ -3411,6 +3420,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }
@@ -3425,6 +3435,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
       }
@@ -3452,7 +3463,8 @@
     "tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true
     },
     "tsx": {
       "version": "4.23.1",
@@ -3497,7 +3509,8 @@
     "uuid": {
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "dev": true
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@types/node": "^26.1.1",
     "dotenv": "^17.4.2",
     "husky": "^9.1.7",
+    "playwright-qase-reporter": "^2.5.7",
     "tsx": "^4.23.1"
   },
   "dependencies": {
@@ -40,7 +41,6 @@
     "fs": "^0.0.1-security",
     "googleapis": "^173.0.0",
     "playwright": "^1.61.1",
-    "playwright-qase-reporter": "^2.5.6",
     "prettier": "^3.9.4",
     "qaseio": "^2.4.3",
     "stripe": "^22.3.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,8 +16,8 @@ export default defineConfig({
     timeout: 15000,
     toMatchSnapshot: {
       maxDiffPixelRatio: 0.001,
+      maxDiffPixels: 30,
     },
-    maxDiffPixels: 30,
   },
   /* Run tests in files in parallel */
   fullyParallel: true,
@@ -39,7 +39,29 @@ export default defineConfig({
         [
           'playwright-qase-reporter',
           {
-            logging: true,
+            mode: process.env.QASE_MODE ?? 'off',
+            environment: 'PRE',
+            testops: {
+              api: {
+                token: process.env.QASE_API_TOKEN,
+              },
+              project: process.env.QASE_PROJECT_CODE,
+              run: {
+                title: `[Automated] PRE Chrome Daily - ${new Date().toISOString().split('T')[0]}`,
+                description: 'PRE_chrome_daily',
+                complete: true,
+                tags: ['automated'],
+              },
+              uploadAttachments: true,
+              showPublicReportLink: true,
+            },
+            framework: {
+              browser: {
+                addAsParameter: true,
+                parameterName: 'Browser',
+              },
+              markAsFlaky: true,
+            },
           },
         ],
       ]


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/task/1622

## Description

This PR adds Qase TestOps integration to the daily Playwright regression suite, enabling automatic test result reporting and centralized test management.

<img width="480" height="360" alt="giphy" src="https://github.com/user-attachments/assets/023c29ec-4dd2-4c01-909a-72257e1840b4" />

## Solution

- Added Qase reporter configuration with environment-aware mode toggling
- Reporter is active only in CI (process.env.CI), stays off locally
- Reports include environment (PRE), run title with date, tags (automated), and attachment uploads .github/workflows/playwright_pre_daily.yml
- Added QASE_API_TOKEN, QASE_MODE, and QASE_PROJECT_CODE env vars
- Added step to extract the Qase run link and display it in the GitHub Actions workflow summary

**Setup Required**
GitHub Actions secrets added:

- QASE_API_TOKEN: generated in Qase under Apps > Playwright > Access Tokens (it is currently added for my user but stored in out vault)
- QASE_PROJECT_CODE: the short project code from the Qase project URL

**How it works**

- On scheduled runs (main branch), results are automatically reported to Qase
- Each run creates a test run in Qase with environment, tags, and date in the title
- Failed tests include screenshots and trace file attachments
- A shareable Qase run link is added to the GitHub Actions workflow summary
- Local runs are unaffected (reporter stays off)

<img width="1702" height="724" alt="image" src="https://github.com/user-attachments/assets/c7fe12c0-eb14-4397-957b-73864a5073ea" />
