### PR TITLE
feat(ci): point MM notification action to specific version

### DIFF
--- a/.github/actions/send-notification/action.yml
+++ b/.github/actions/send-notification/action.yml
@@ -56,7 +56,7 @@ runs:
 
     - name: Send Mattermost notification
       if: always()
-      uses: mattermost/action-mattermost-notify@master
+      uses: mattermost/action-mattermost-notify@v2.0.0
       with:
         MATTERMOST_WEBHOOK_URL: ${{ inputs.mattermost-webhook-url }}
         TEXT: ${{ steps.message.outputs.message }}

--- a/.github/actions/send-notification/action.yml
+++ b/.github/actions/send-notification/action.yml
@@ -56,7 +56,7 @@ runs:
 
     - name: Send Mattermost notification
       if: always()
-      uses: mattermost/action-mattermost-notify@v2.0.0
+      uses: mattermost/action-mattermost-notify@2.0.0
       with:
         MATTERMOST_WEBHOOK_URL: ${{ inputs.mattermost-webhook-url }}
         TEXT: ${{ steps.message.outputs.message }}


### PR DESCRIPTION
# Done Definition Checks

## Description

The "Send Mattermost Notification" step in CI workflows was failing with:

Error: unable to verify the first certificate; if the root CA is installed locally, try running Node.js with --use-system-ca
Root Cause

Pinned the action to @2.0.0 — the last stable version before the Node 24 upgrade — in .github/actions/send-notification/action.yml.

<img width="996" height="604" alt="image" src="https://github.com/user-attachments/assets/f5946f71-3bb9-47ed-b6e5-3966b7b4be4d" />