### PR TITLE
refactor(login-signup): remove redundant forgot-password and non-essential survey tests

### DIFF
--- a/tests/login-signup/forgot-password.spec.ts
+++ b/tests/login-signup/forgot-password.spec.ts
@@ -4,7 +4,6 @@ import {
   getVerificationMessage,
   waitSecondMessage,
 } from 'helpers/gmail';
-import { random } from 'helpers/string-generator';
 import { DashboardPage } from '@pages/dashboard/dashboard-page';
 import { ForgotPasswordPage } from '@pages/forgot-password-page';
 import { LoginPage } from '@pages/login-page';
@@ -28,16 +27,6 @@ test.describe('Forgot password form validations', () => {
   test(qase([50], 'Forgot password flow with invalid email'), async () => {
     await test.step('Verify invalid email prevents password recovery', async () => {
       await forgotPasswordPage.enterEmail('xxx');
-      await forgotPasswordPage.isRecoverPasswordButtonDisabled();
-    });
-  });
-
-  test(qase([51], 'Forgot password flow with non existed email'), async () => {
-    const email = `${process.env.GMAIL_NAME}autotest+${random()}${process.env.GMAIL_DOMAIN}`;
-
-    await test.step('Verify non-existent email prevents password recovery', async () => {
-      await forgotPasswordPage.enterEmail(email);
-      await forgotPasswordPage.clickRecoverPasswordButton();
       await forgotPasswordPage.isRecoverPasswordButtonDisabled();
     });
   });

--- a/tests/login-signup/survey-questions.spec.ts
+++ b/tests/login-signup/survey-questions.spec.ts
@@ -81,21 +81,4 @@ test.describe(() => {
       });
     },
   );
-
-  test(
-    qase([1801], 'Close and reopen penpot page while questions survey is opened'),
-    async ({ context, page }) => {
-      await test.step('Verify survey is visible and close current page', async () => {
-        await dashboardPage.isOnboardingFirstQuestionsVisible();
-        await page.close();
-      });
-
-      await test.step('Reopen page and verify survey is still visible', async () => {
-        const newPage = await context.newPage();
-        await newPage.goto(invite.inviteUrl);
-        const dashboardPage2 = new DashboardPage(newPage);
-        await dashboardPage2.isOnboardingFirstQuestionsVisible();
-      });
-    },
-  );
 });


### PR DESCRIPTION
## Taiga URL (optional)

[Taiga Ticket: 1663](https://tree.taiga.io/project/kaleidos-qa/task/1663)

## Description

This PR resolves redundancy and non-essential coverage in the login-signup test suite.

### Triage summary

| Qase ID | Keep/Drop | Regression | Reason |
|---------|-----------|------------|--------|
| 33 | Keep | Yes | Signup: empty password → validation |
| 36 | Keep | Yes | Demo account, unique flow |
| 41 | Keep | Yes | Login: empty password → behavior |
| 50 | Keep | Yes | Forgot password: invalid email → validation |
| 52 | Keep | Yes | Old password after change → security |
| 54 | Keep | Yes | Signup: duplicate email → error |
| 2245 | Keep | Yes | Onboarding: team without invitation |
| 51 | Drop | No | Redundant with 50 (same functional axis) |
| 1801 | Drop | No | Survey onboarding: close/reopen, non-essential |

Only 51 and 1801 are removed.

## Solution

Removed tests 51 and 1801, and cleaned up the unused `random` import left behind in `forgot-password.spec.ts`.

## How to test

- [x] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [x] It complies with the test conventions
- [ ] There are no missing snapshots
- [ ] The tests run OK