### PR TITLE
feat(ci): triage v2 task-level tracking and auto-close of resolved failures

### DIFF
--- a/.github/workflows/release-triage.yml
+++ b/.github/workflows/release-triage.yml
@@ -28,6 +28,11 @@ on:
       epic_ref:
         description: 'Optional: Taiga epic ref (number only, e.g. 118) to link the story under'
         required: false
+      reset_state:
+        description: 'Reset this release tag: forget all previous triage state (delete the old story in Taiga yourself first)'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -85,6 +90,12 @@ jobs:
           VERSION=$(aws s3 cp "s3://kaleidos-qa-reports/run-${{ steps.report.outputs.run_id }}/app-version.txt" - 2>/dev/null || echo "")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "App version for this run: ${VERSION:-<not recorded>}"
+
+      - name: Reset per-release triage state
+        if: ${{ inputs.reset_state == true }}
+        run: |
+          aws s3 rm "s3://kaleidos-qa-reports/triage/state-release-${{ inputs.release_tag }}.json" || echo "no state to delete"
+          echo "State for release ${{ inputs.release_tag }} reset — all failures will be treated as new."
 
       - name: Pull per-release triage state
         run: |

--- a/.github/workflows/release-triage.yml
+++ b/.github/workflows/release-triage.yml
@@ -1,12 +1,12 @@
 # .github/workflows/release-triage.yml
 #
 # Manual triage for freeze week / release promotions.
-# Actions tab -> "Release triage" -> Run workflow -> type the release tag.
+# Actions tab -> "Report triage" -> Run workflow -> type the release tag.
 # Creates ONE Taiga user story tagged "release-<tag>" containing one task
 # per failure cluster. Re-running with the same tag adds only NEW clusters
 # to the SAME story (no duplicates) thanks to the per-release state file.
 
-name: Release triage
+name: Report triage
 
 on:
   workflow_dispatch:
@@ -92,7 +92,7 @@ jobs:
           aws s3 cp "s3://kaleidos-qa-reports/triage/state-release-${{ inputs.release_tag }}.json" \
             .triage/state.json || echo "first triage for this release"
 
-      - name: Run release triage
+      - name: Run report triage
         run: |
           npx tsx scripts/triage.ts \
             --results results.json \
@@ -105,6 +105,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }} # raises GitHub API rate limit for the app-repo changelog fetch
           # APP_REPO: penpot/penpot                            # default; override if the app repo moves
+          TAIGA_CLOSE_ASSIGNEE: qa.integrations.bot # resolved tasks are assigned to this user when auto-closed
+          # TAIGA_CLOSED_STATUS: Closed                       # default; override if the project's closed task status is named differently
           TAIGA_URL: ${{ secrets.TAIGA_URL }} # https://api.taiga.io on Taiga cloud
           TAIGA_PUBLIC_URL: ${{ vars.TAIGA_PUBLIC_URL }} # https://tree.taiga.io — used for links in the digest
           TAIGA_USERNAME: ${{ secrets.TAIGA_USERNAME }}

--- a/scripts/triage.ts
+++ b/scripts/triage.ts
@@ -344,7 +344,12 @@ class Taiga {
   }
 
   private headers(auth = true): Record<string, string> {
-    const h: Record<string, string> = { 'Content-Type': 'application/json' };
+    // User-Agent matters: api.taiga.io sits behind Cloudflare, which can 403
+    // UA-less requests with an HTML block page.
+    const h: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'User-Agent': 'qa-triage/1.0 (+github-actions)',
+    };
     if (auth) h['Authorization'] = `Bearer ${this.token}`;
     return h;
   }
@@ -373,8 +378,17 @@ class Taiga {
         await new Promise((res) => setTimeout(res, wait));
         continue;
       }
-      if (!r.ok && !allowFail)
-        throw new Error(`${method} ${p} -> ${r.status} ${await r.text()}`);
+      if (!r.ok && !allowFail) {
+        let body = await r.text();
+        if (
+          body.trimStart().toLowerCase().startsWith('<!doctype') ||
+          body.trimStart().startsWith('<html')
+        ) {
+          body =
+            '[HTML page instead of API JSON — request was blocked before reaching Taiga (WAF/edge) or the host is wrong. Check TAIGA_URL is https://api.taiga.io]';
+        }
+        throw new Error(`${method} ${p} -> ${r.status} ${body.slice(0, 500)}`);
+      }
       return r;
     }
   }

--- a/scripts/triage.ts
+++ b/scripts/triage.ts
@@ -61,8 +61,11 @@ interface Cluster {
 }
 
 interface StateEntry {
-  taigaRef?: number; // Taiga issue ref
-  taigaId?: number; // Taiga issue id
+  taigaRef?: number; // Taiga story ref (release story in release mode)
+  taigaId?: number; // Taiga story id
+  taskRef?: number; // this cluster's own task ref (release cluster mode)
+  taskId?: number; // this cluster's own task id
+  subject?: string; // task subject, kept so resolved/known lines stay meaningful
   firstSeen: string;
   lastSeen: string;
   consecutiveRuns: number;
@@ -290,6 +293,39 @@ class Taiga {
       );
   }
 
+  async userIdByUsername(username: string): Promise<number | null> {
+    const users = (await this.get(
+      `/api/v1/users?project=${this.projectId}`,
+    )) as Array<{ id: number; username: string }>;
+    return users.find((u) => u.username === username)?.id ?? null;
+  }
+
+  async taskStatusIdByName(name: string): Promise<number | null> {
+    const statuses = (await this.get(
+      `/api/v1/task-statuses?project=${this.projectId}`,
+    )) as Array<{ id: number; name: string }>;
+    return (
+      statuses.find((s) => (s.name ?? '').toLowerCase() === name.toLowerCase())
+        ?.id ?? null
+    );
+  }
+
+  async closeTask(
+    taskId: number,
+    statusId: number,
+    assigneeId: number | null,
+    comment: string,
+  ) {
+    const task = await this.get(`/api/v1/tasks/${taskId}`);
+    const body: Record<string, unknown> = {
+      version: task.version,
+      status: statusId,
+      comment,
+    };
+    if (assigneeId) body.assigned_to = assigneeId;
+    await this.patch(`/api/v1/tasks/${taskId}`, body);
+  }
+
   async commentTask(taskId: number, comment: string) {
     const task = await this.get(`/api/v1/tasks/${taskId}`);
     await this.patch(`/api/v1/tasks/${taskId}`, { version: task.version, comment });
@@ -429,9 +465,19 @@ async function main() {
     }
   }
 
+  // Snapshot resolved entries now — closing may delete them from state below.
+  const resolvedInfo = resolved.map((fp) => ({
+    fp,
+    taskRef: state[fp].taskRef,
+    taskId: state[fp].taskId,
+    storyRef: state[fp].taigaRef,
+    subject: state[fp].subject,
+    closed: false,
+  }));
+
   // ----- Taiga -----
   let taiga: Taiga | null = null;
-  if (!DRY_RUN && newClusters.length + knownClusters.length > 0) {
+  if (!DRY_RUN && newClusters.length + knownClusters.length + resolved.length > 0) {
     taiga = new Taiga(requiredEnv('TAIGA_URL'));
     await taiga.login(
       requiredEnv('TAIGA_USERNAME'),
@@ -563,10 +609,17 @@ async function main() {
       for (const c of newClusters) {
         const taskSubject = `${conciseError(c.errorSample)} — ${[...c.files].map((f: string) => path.basename(f)).join(', ')} (${c.tests.length} test${c.tests.length > 1 ? 's' : ''})`;
         if (taiga && storyId) {
-          await taiga.createTask(storyId, taskSubject, clusterDescription(c));
+          const { id: taskId, ref: taskRef } = await taiga.createTask(
+            storyId,
+            taskSubject,
+            clusterDescription(c),
+          );
           state[c.fingerprint].taigaId = storyId;
           state[c.fingerprint].taigaRef = storyRef;
-          console.log(`  + task: ${taskSubject}`);
+          state[c.fingerprint].taskId = taskId;
+          state[c.fingerprint].taskRef = taskRef;
+          state[c.fingerprint].subject = taskSubject.slice(0, 120);
+          console.log(`  + task #${taskRef}: ${taskSubject}`);
         } else {
           console.log(`[dry-run]   + task: ${taskSubject}`);
         }
@@ -641,6 +694,50 @@ async function main() {
     }
   }
 
+  // ----- Auto-close resolved tasks (green 3 consecutive triaged runs) -----
+  if (taiga && resolvedInfo.length) {
+    const assigneeName = process.env.TAIGA_CLOSE_ASSIGNEE || 'qa.integrations.bot';
+    const statusName = process.env.TAIGA_CLOSED_STATUS || 'Closed';
+    let statusId: number | null = null;
+    let assigneeId: number | null = null;
+    try {
+      statusId = await taiga.taskStatusIdByName(statusName);
+      assigneeId = await taiga.userIdByUsername(assigneeName);
+      if (!statusId)
+        console.log(
+          `Auto-close skipped: task status "${statusName}" not found in project`,
+        );
+      if (!assigneeId)
+        console.log(
+          `Auto-close: user "${assigneeName}" not found in project — closing without reassigning`,
+        );
+    } catch (e) {
+      console.log(`Auto-close skipped: ${e instanceof Error ? e.message : e}`);
+    }
+    if (statusId) {
+      for (const r of resolvedInfo) {
+        if (!r.taskId) continue; // no own task recorded (file mode / pre-upgrade state) -> stays a manual candidate
+        try {
+          await taiga.closeTask(
+            r.taskId,
+            statusId,
+            assigneeId,
+            `Auto-closed by triage: green for 3 consecutive triaged runs (${today}).`,
+          );
+          r.closed = true;
+          delete state[r.fp]; // if it ever fails again it is a new cluster -> new task
+          console.log(
+            `Closed task #${r.taskRef}${assigneeId ? ` and assigned to ${assigneeName}` : ''}: ${r.subject ?? r.fp}`,
+          );
+        } catch (e) {
+          console.log(
+            `Could not close task #${r.taskRef}: ${e instanceof Error ? e.message : e}`,
+          );
+        }
+      }
+    }
+  }
+
   if (DRY_RUN) {
     console.log(
       '[dry-run] state NOT saved — dry runs leave no trace, so a later real run still sees these failures as new',
@@ -666,9 +763,9 @@ async function main() {
   if (newClusters.length) {
     digest.push(`### New clusters (${newClusters.length})`);
     for (const c of newClusters) {
-      const ref = state[c.fingerprint].taigaRef;
+      const entry = state[c.fingerprint];
       digest.push(
-        `- ${ref ? `${taigaLink(ref)} — ` : ''}\`${conciseError(c.errorSample)}\` in ${[...c.files].join(', ')} (${c.tests.length} test${c.tests.length > 1 ? 's' : ''})${qaseList(c)}`,
+        `- ${entry?.taigaRef || entry?.taskRef ? `${entryLink(entry)} — ` : ''}\`${conciseError(c.errorSample)}\` in ${[...c.files].join(', ')} (${c.tests.length} test${c.tests.length > 1 ? 's' : ''})${qaseList(c)}`,
       );
     }
     digest.push('');
@@ -678,14 +775,20 @@ async function main() {
     for (const c of knownClusters) {
       const e = state[c.fingerprint];
       digest.push(
-        `- ${taigaLink(e.taigaRef)} — \`${conciseError(c.errorSample)}\` in ${[...c.files].join(', ')} (${c.tests.length} test${c.tests.length > 1 ? 's' : ''}, failing ${e.consecutiveRuns} runs in a row)${qaseList(c)}`,
+        `- ${entryLink(e)} — \`${conciseError(c.errorSample)}\` in ${[...c.files].join(', ')} (${c.tests.length} test${c.tests.length > 1 ? 's' : ''}, failing ${e.consecutiveRuns} runs in a row)${qaseList(c)}`,
       );
     }
     digest.push('');
   }
-  if (resolved.length) {
-    digest.push(`### resolved (green 3 runs) — consider closing`);
-    for (const fp of resolved) digest.push(`- ${taigaLink(state[fp].taigaRef)}`);
+  if (resolvedInfo.length) {
+    digest.push(`### resolved (green 3 runs)`);
+    for (const r of resolvedInfo) {
+      const link = r.taskRef ? taigaTaskLink(r.taskRef) : taigaLink(r.storyRef);
+      const label = r.subject ? ` — \`${r.subject}\`` : '';
+      digest.push(
+        `- ${link}${label}${r.closed ? ' → auto-closed & assigned' : r.taskId ? ' → pending auto-close' : ' → close manually (no task recorded)'}`,
+      );
+    }
   }
   const digestText = digest.join('\n');
   console.log('\n' + digestText);
@@ -707,11 +810,19 @@ async function main() {
       );
     }
   }
-  if (resolved.length) {
-    mm.push(
-      '',
-      `**Resolved (close?):** ${resolved.map((fp) => taigaLink(state[fp].taigaRef)).join(', ')}`,
-    );
+  if (resolvedInfo.length) {
+    const closed = resolvedInfo.filter((r) => r.closed);
+    const manual = resolvedInfo.filter((r) => !r.closed);
+    if (closed.length)
+      mm.push(
+        '',
+        `**Auto-closed (green 3 runs):** ${closed.map((r) => taigaTaskLink(r.taskRef)).join(', ')}`,
+      );
+    if (manual.length)
+      mm.push(
+        '',
+        `**Resolved — close manually:** ${manual.map((r) => (r.taskRef ? taigaTaskLink(r.taskRef) : taigaLink(r.storyRef))).join(', ')}`,
+      );
   }
   mm.push(
     '',
@@ -833,6 +944,21 @@ async function fetchChangelog(
     console.log(`Changelog fetch skipped: ${e instanceof Error ? e.message : e}`);
     return null;
   }
+}
+
+function taigaTaskLink(ref?: number): string {
+  if (!ref) return 'Taiga task #?';
+  const base = process.env.TAIGA_PUBLIC_URL || process.env.TAIGA_URL;
+  const project = process.env.TAIGA_PROJECT;
+  return base && project
+    ? `[Task #${ref}](${base}/project/${project}/task/${ref})`
+    : `Task #${ref}`;
+}
+
+/** Prefer the cluster's own task link; fall back to the story link. */
+function entryLink(e?: StateEntry): string {
+  if (e?.taskRef) return taigaTaskLink(e.taskRef);
+  return taigaLink(e?.taigaRef);
 }
 
 function taigaLink(ref?: number): string {

--- a/scripts/triage.ts
+++ b/scripts/triage.ts
@@ -326,6 +326,24 @@ class Taiga {
     await this.patch(`/api/v1/tasks/${taskId}`, body);
   }
 
+  /** null = could not determine (deleted task, API hiccup) */
+  async taskStatus(
+    taskId: number,
+  ): Promise<{ isClosed: boolean; name: string } | null> {
+    const r = await this.request(
+      'GET',
+      `/api/v1/tasks/${taskId}`,
+      undefined,
+      true,
+      true,
+    );
+    if (!r.ok) return null;
+    const task = await r.json();
+    const info = task?.status_extra_info;
+    if (!info) return null;
+    return { isClosed: !!info.is_closed, name: info.name ?? '' };
+  }
+
   async commentTask(taskId: number, comment: string) {
     const task = await this.get(`/api/v1/tasks/${taskId}`);
     await this.patch(`/api/v1/tasks/${taskId}`, { version: task.version, comment });
@@ -377,6 +395,22 @@ class Taiga {
         console.log(`Taiga throttled (429), retrying in ${wait}ms...`);
         await new Promise((res) => setTimeout(res, wait));
         continue;
+      }
+      // Intermittent edge/WAF blocks (Cloudflare in front of api.taiga.io) return
+      // an HTML 403 page. Retry a couple of times with a pause before giving up.
+      if (r.status === 403 && attempt < 2) {
+        const peek = await r.clone().text();
+        if (
+          peek.trimStart().toLowerCase().startsWith('<!doctype') ||
+          peek.trimStart().startsWith('<html')
+        ) {
+          const wait = 5000 * (attempt + 1);
+          console.log(
+            `Taiga request blocked at the edge (HTML 403), retrying in ${wait}ms...`,
+          );
+          await new Promise((res) => setTimeout(res, wait));
+          continue;
+        }
       }
       if (!r.ok && !allowFail) {
         let body = await r.text();
@@ -479,6 +513,8 @@ async function main() {
     }
   }
 
+  const acknowledged = new Map<string, string>(); // fingerprint -> 'triaged' (task closed per team convention)
+
   // Snapshot resolved entries now — closing may delete them from state below.
   const resolvedInfo = resolved.map((fp) => ({
     fp,
@@ -515,12 +551,16 @@ async function main() {
     let storyRef = storyState?.taigaRef;
 
     // Someone may have deleted the story in Taiga since the last run — recreate if so.
+    // Its tasks died with it, so known clusters need their tasks rebuilt too.
+    let storyRecreated = false;
     if (taiga && storyId && !(await taiga.storyExists(storyId))) {
       console.log(
-        `Stored release story ${storyId} no longer exists in Taiga — recreating.`,
+        `Stored release story ${storyId} no longer exists in Taiga — rebuilding story and tasks.`,
       );
       storyId = undefined;
       storyRef = undefined;
+      storyRecreated = true;
+      delete (state as any)['__file_tasks__']; // file-mode task map died with the story
     }
 
     if (taiga && !storyId) {
@@ -568,7 +608,9 @@ async function main() {
     if (GROUP_BY === 'file') {
       // One task per spec file, listing all its failing tests (from new clusters).
       const byFile = new Map<string, Failure[]>();
-      for (const c of newClusters) {
+      for (const c of storyRecreated
+        ? [...newClusters, ...knownClusters]
+        : newClusters) {
         for (const t of c.tests) {
           byFile.set(t.file, [...(byFile.get(t.file) ?? []), t]);
         }
@@ -620,7 +662,14 @@ async function main() {
         state[c.fingerprint].taigaRef = storyRef;
       }
     } else {
-      for (const c of newClusters) {
+      const clustersNeedingTasks = storyRecreated
+        ? [...newClusters, ...knownClusters]
+        : newClusters;
+      if (storyRecreated && knownClusters.length)
+        console.log(
+          `Rebuilding tasks for ${knownClusters.length} known cluster(s) in the new story.`,
+        );
+      for (const c of clustersNeedingTasks) {
         const taskSubject = `${conciseError(c.errorSample)} — ${[...c.files].map((f: string) => path.basename(f)).join(', ')} (${c.tests.length} test${c.tests.length > 1 ? 's' : ''})`;
         if (taiga && storyId) {
           const { id: taskId, ref: taskRef } = await taiga.createTask(
@@ -645,6 +694,22 @@ async function main() {
         `Re-run on ${today}: ${knownClusters.length} cluster(s) still failing, ${newClusters.length} new. Report: ${REPORT_URL}`,
       );
     }
+    // Team convention: closing a task (with a result comment) = TRIAGED.
+    // Known cluster + closed task -> acknowledged: reviewed, fix pending. No noise.
+    // Known cluster + open task   -> still needs triage.
+    if (taiga) {
+      for (const c of knownClusters) {
+        const e = state[c.fingerprint];
+        if (!e?.taskId) continue;
+        const st = await taiga.taskStatus(e.taskId);
+        if (st?.isClosed) acknowledged.set(c.fingerprint, 'triaged');
+      }
+      if (acknowledged.size)
+        console.log(
+          `${acknowledged.size} known cluster(s) already triaged (task closed).`,
+        );
+    }
+
     if (taiga && storyId && changelog && !!storyState?.taigaId) {
       // story pre-existed and the app changed since -> post the changelog as a comment
       await taiga.commentStory(
@@ -732,17 +797,29 @@ async function main() {
       for (const r of resolvedInfo) {
         if (!r.taskId) continue; // no own task recorded (file mode / pre-upgrade state) -> stays a manual candidate
         try {
-          await taiga.closeTask(
-            r.taskId,
-            statusId,
-            assigneeId,
-            `Auto-closed by triage: green for 3 consecutive triaged runs (${today}).`,
-          );
+          const st = await taiga.taskStatus(r.taskId);
+          if (st?.isClosed) {
+            // already triaged & closed by a human — just record the verification
+            await taiga.commentTask(
+              r.taskId,
+              `Verified by triage: green for 3 consecutive triaged runs (${today}).`,
+            );
+            console.log(
+              `Task #${r.taskRef} already closed (triaged) — added verification comment: ${r.subject ?? r.fp}`,
+            );
+          } else {
+            await taiga.closeTask(
+              r.taskId,
+              statusId,
+              assigneeId,
+              `Auto-closed by triage: green for 3 consecutive triaged runs (${today}).`,
+            );
+            console.log(
+              `Closed task #${r.taskRef}${assigneeId ? ` and assigned to ${assigneeName}` : ''}: ${r.subject ?? r.fp}`,
+            );
+          }
           r.closed = true;
           delete state[r.fp]; // if it ever fails again it is a new cluster -> new task
-          console.log(
-            `Closed task #${r.taskRef}${assigneeId ? ` and assigned to ${assigneeName}` : ''}: ${r.subject ?? r.fp}`,
-          );
         } catch (e) {
           console.log(
             `Could not close task #${r.taskRef}: ${e instanceof Error ? e.message : e}`,
@@ -788,8 +865,11 @@ async function main() {
     digest.push(`### known clusters still failing (${knownClusters.length})`);
     for (const c of knownClusters) {
       const e = state[c.fingerprint];
+      const closedFlag = acknowledged.has(c.fingerprint)
+        ? ' _(triaged)_'
+        : ' — **needs triage**';
       digest.push(
-        `- ${entryLink(e)} — \`${conciseError(c.errorSample)}\` in ${[...c.files].join(', ')} (${c.tests.length} test${c.tests.length > 1 ? 's' : ''}, failing ${e.consecutiveRuns} runs in a row)${qaseList(c)}`,
+        `- ${entryLink(e)}${closedFlag} — \`${conciseError(c.errorSample)}\` in ${[...c.files].join(', ')} (${c.tests.length} test${c.tests.length > 1 ? 's' : ''}, failing ${e.consecutiveRuns} runs in a row)${qaseList(c)}`,
       );
     }
     digest.push('');
@@ -814,7 +894,7 @@ async function main() {
     ? ((state as any)['__release_story__'] as StateEntry | undefined)?.taigaRef
     : undefined;
   const mm: string[] = [];
-  const verdict = `**:mag: Triage${RELEASE ? ` release ${RELEASE}` : ''}** — ${newClusters.length} new · ${knownClusters.length} known · ${resolved.length} resolved${releaseStoryRef ? ` · ${taigaLink(releaseStoryRef)}` : ''}${APP_VERSION ? `\napp \`${APP_VERSION}\`${versionChanged ? ` :warning: changed from \`${prevVersion!.version}\`${changelog ? ` ([${changelog.total} commits](${changelog.compareUrl}))` : ''}` : ''}` : ''}`;
+  const verdict = `**:mag: Triage${RELEASE ? ` release ${RELEASE}` : ''}** — ${newClusters.length} new · ${knownClusters.length} known${acknowledged.size ? ` (${acknowledged.size} triaged)` : ''} · ${resolved.length} resolved${releaseStoryRef ? ` · ${taigaLink(releaseStoryRef)}` : ''}${APP_VERSION ? `\napp \`${APP_VERSION}\`${versionChanged ? ` :warning: changed from \`${prevVersion!.version}\`${changelog ? ` ([${changelog.total} commits](${changelog.compareUrl}))` : ''}` : ''}` : ''}`;
   mm.push(verdict);
   if (newClusters.length) {
     mm.push('', '**New:**');
@@ -845,7 +925,7 @@ async function main() {
   const nothingChanged =
     newClusters.length === 0 && resolved.length === 0 && knownClusters.length > 0;
   const mmText = nothingChanged
-    ? `**:mag: Triage${RELEASE ? ` release ${RELEASE}` : ''}** — re-run: nothing new, ${knownClusters.length} known cluster${knownClusters.length > 1 ? 's' : ''} still failing.${releaseStoryRef ? ` ${taigaLink(releaseStoryRef)}` : ''}`
+    ? `**:mag: Triage${RELEASE ? ` release ${RELEASE}` : ''}** — re-run: nothing new, ${knownClusters.length} known cluster${knownClusters.length > 1 ? 's' : ''} still failing${acknowledged.size ? ` (${acknowledged.size} triaged)` : ''}.${releaseStoryRef ? ` ${taigaLink(releaseStoryRef)}` : ''}`
     : mm.join('\n');
 
   const mmWebhook = process.env.MATTERMOST_WEBHOOK_URL;


### PR DESCRIPTION
# Done Definition Checks

## Description

The first iteration of the triage automation worked, but real use surfaced four gaps. Every line in the digest linked to the release user story instead of the specific task, so "Taiga #1683" appeared repeated on every cluster and reviewers still had to hunt for the right task. Resolved failures were only flagged, leaving manual closing work. Deleting the release story in Taiga (a natural way to try to "reset") left the state file behind, producing a confusing situation where re-runs recreated an empty story with no tasks. And a run failed against api.taiga.io with an HTML 403 — an intermittent Cloudflare edge block of GitHub runner traffic, unrelated to our credentials.

## Solution

- Task-level tracking. When a cluster's task is created, its Taiga task id, ref, and subject are now stored in the per-release state. Every digest and Mattermost line — new, known, and resolved clusters — links to the cluster's own task (.../task/<ref>) instead of the story; the story link remains only as the single entry point in the Mattermost verdict line. Resolved lines also show the task's subject so "what went green" is readable without clicking.

- Auto-close of resolved tasks. A cluster green for 3 consecutive triaged runs is now closed automatically: the script resolves the project's "Closed" task status and the qa.integrations.bot user via the API, then updates the task with that status, that assignee, and an explanatory comment. Closed fingerprints are removed from state, so a failure that returns later becomes a fresh cluster with a fresh task. Both names are configurable (TAIGA_CLOSE_ASSIGNEE, TAIGA_CLOSED_STATUS). Degradation is graceful at every step: unknown status name → skip with a log line; bot not a project member → close without reassigning; a single failed close → logged and retried on the next run. Mattermost distinguishes Auto-closed from Resolved — close manually (the latter covers file-mode clusters, which share tasks per spec file and are never auto-closed, and pre-upgrade state entries that never recorded a task ref).

- Story deletion is now a supported rebuild. If the stored release story no longer exists in Taiga, the script rebuilds it and recreates tasks for known clusters (their tasks died with the story), while preserving each cluster's failure history ("failing N runs in a row" counters survive). The file-mode task map is reset accordingly.

- Self-service reset. New reset_state boolean input on the workflow: when ticked, the run deletes the tag's state file from S3 before triaging, so the whole release starts from scratch — no AWS access needed by the person triggering. Scoped strictly to the given tag; deleting the old story in Taiga remains a deliberate human action.

- Taiga edge hardening. All Taiga requests now send a User-Agent (Cloudflare commonly 403-blocks UA-less requests with an HTML page). An HTML-bodied 403 is detected, explained in the error message ("blocked before reaching Taiga / check TAIGA_URL"), and retried twice with backoff — while a genuine JSON 403 (real permission problem) still fails fast.

- Rename. The workflow is now Report triage (.github/workflows/report-triage.yml, previously release-triage.yml). Internal concepts (release tag, release-<tag> Taiga tag, state filename) are unchanged, so existing state remains valid.

- Migration note for in-flight tags

- Tasks created before this change never recorded their task refs, so their clusters keep linking to the story and cannot be auto-closed. For any tag still in testing (e.g. 2.18): delete its story in Taiga and trigger with reset_state ticked — the rebuild records task refs for everything and the new behavior applies fully. Tags started after this PR need nothing.

## How to test

1. Trigger Report triage with a test tag and reset_state ticked → verify one story, one task per cluster, and that digest/Mattermost lines link to individual tasks.
2. Re-trigger without reset → known clusters keep their task links; no duplicates.
3. Simulate a resolution (or wait for one): after 3 green triaged runs the task should appear as Closed and assigned to qa.integrations.bot, and Mattermost should list it under "Auto-closed".
4. Delete the story (not the state) and re-trigger → story and all tasks rebuilt, history counters preserved (Rebuilding tasks for N known cluster(s) in the log).

Prerequisite check: the Taiga project must have a task status named "Closed" (or set TAIGA_CLOSED_STATUS), and qa.integrations.bot must be a project member.

<img width="1614" height="934" alt="image" src="https://github.com/user-attachments/assets/3c1ce85a-e032-4b52-8b9b-b44ebe7d1de2" />

