### PR TITLE
test(design-panel,plugins): fix flaky stroke cap and plugin tests (501, [1837, 1839, 1844])

### DIFF
--- a/pages/workspace/design-panel-page.js
+++ b/pages/workspace/design-panel-page.js
@@ -302,9 +302,10 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
     );
     this.strokeAlignmentField = page.getByTestId('stroke.alignment');
     this.strokeTypeField = page.getByTestId('stroke.style');
-    this.strokeCapDropdowns = page
-      .locator('div[class*="stroke-caps-options"]')
-      .getByRole('combobox');
+    this.strokeCapStartDropdown =
+      this.strokeSectionContainer.getByTestId('stroke.cap-start');
+    this.strokeCapEndDropdown =
+      this.strokeSectionContainer.getByTestId('stroke.cap-end');
     this.strokeCapSwitchButton = this.strokeSectionContainer.getByRole('button', {
       name: 'Switch',
     });
@@ -1697,10 +1698,10 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
   async changeCap(capName, firstSecond = 'first') {
     const dropdown =
       firstSecond === 'first'
-        ? await this.strokeCapDropdowns.first()
-        : await this.strokeCapDropdowns.last();
+        ? this.strokeCapStartDropdown
+        : this.strokeCapEndDropdown;
     await dropdown.click();
-    await dropdown.getByRole('option', { name: capName }).click();
+    await this.strokeSectionContainer.getByRole('option', { name: capName }).click();
   }
 
   async clickSwitchCapButton() {

--- a/tests/plugins/plugins.spec.ts
+++ b/tests/plugins/plugins.spec.ts
@@ -32,6 +32,8 @@ mainTest(qase([1837, 1839, 1844], 'Install, open and delete a plugin'), async ()
       await pluginsPage.clickOnAllowPluginButton();
       await pluginsPage.isInstalledPluginsCount(1);
       await pluginsPage.isOpenPluginButtonVisible();
+      await pluginsPage.clickClosePluginPanelButton();
+      await pluginsPage.isPluginManagerModalNotVisible();
     },
   );
 


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

[Taiga Ticket: 1852](https://tree.taiga.io/project/kaleidos-qa/us/1852)

## Description

This PR resolves flaky failures in two test specs caused by UI changes in Penpot.

**Stroke cap test (Qase 501):** The stroke cap dropdowns were using a generic CSS-based locator (`div[class*="stroke-caps-options"]`) that no longer matches the updated DOM. Updated `DesignPanelPage` to use specific `data-testid` attributes (`stroke.cap-start` and `stroke.cap-end`) for more stable and accessible locators.

**Plugins test (Qase 1837, 1839, 1844):** After installing a plugin, the plugin manager modal remained open and interfered with subsequent assertions. Added explicit steps to close the plugin panel and verify the modal is dismissed.

## Solution

- `design-panel-page.js`: Replaced `strokeCapDropdowns` generic combobox locator with explicit `strokeCapStartDropdown` and `strokeCapEndDropdown` locators using `getByTestId`. Updated `changeCap()` to use the new locators and click options within the stroke section container.
- `plugins.spec.ts`: Added `clickClosePluginPanelButton()` and `isPluginManagerModalNotVisible()` calls after plugin installation to ensure clean state.

## How to test

- [x] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [x] It complies with the test conventions
- [ ] There are no missing snapshots
- [ ] The tests run OK

## Screenshots 📸 (optional)

<img width="1007" height="217" alt="image" src="https://github.com/user-attachments/assets/ab0cd9ba-649a-40d8-8cb5-4db26ae9cb44" />
<img width="1684" height="1040" alt="image" src="https://github.com/user-attachments/assets/287b9c1a-b7a8-4323-9631-021d63ceb556" />

