### PR TITLE
fix(toolbar): update toolbar locators and methods

### DIFF
--- a/pages/workspace/main-page.js
+++ b/pages/workspace/main-page.js
@@ -10,23 +10,63 @@ exports.MainPage = class MainPage extends BasePage {
 
     //Main Toolbar
     this.pencilBoxButton = page.locator('a[class*="header__main-icon"]');
-    this.moveButton = page.getByRole('button', { name: 'Move (V)' });
-    this.createBoardButton = page.getByTestId('artboard-btn');
-    this.createRectangleButton = page.getByTestId('rect-btn');
-    this.createEllipseButton = page.getByTestId('ellipse-btn');
-    this.createTextButton = page.getByRole('button', { name: 'Text (T)' });
+
+    this.toolBarWindow = page.getByRole('toolbar');
+
+    // Toolbar - Static buttons
+    this.moveButton = this.toolBarWindow.getByRole('button', { name: 'Move (V)' });
+    this.createBoardButton = this.toolBarWindow.getByRole('button', {
+      name: 'Board (B)',
+    });
+    this.createTextButton = this.toolBarWindow.getByRole('button', {
+      name: 'Text (T)',
+    });
     this.uploadImageSelector = page.locator('#image-upload');
-    this.createCurveButton = page.getByTestId('curve-btn');
-    this.createPathButton = page.getByTestId('path-btn');
-    this.MCPButton = page.getByRole('button', { name: 'MCP' });
+
+    // Toolbar - Shape tools
+    this.shapeToolGroup = this.toolBarWindow.getByRole('group', {
+      name: /Options: (Rectangle|Ellipse|Line|Arrow)/,
+    });
+    this.shapeToolButton = this.shapeToolGroup.getByRole('button', {
+      name: /Rectangle|Ellipse|Line|Arrow/,
+    });
+    this.shapeToolMenu = page.getByRole('menu', {
+      name: /Options: (Rectangle|Ellipse|Line|Arrow)/,
+    });
+    this.createRectangleButton = this.shapeToolMenu.getByRole('menuitemradio', {
+      name: /Rectangle/,
+    });
+    this.createEllipseButton = this.shapeToolMenu.getByRole('menuitemradio', {
+      name: /Ellipse/,
+    });
+    this.createLineButton = this.shapeToolMenu.getByRole('menuitemradio', {
+      name: /Line/,
+    });
+    this.createArrowButton = this.shapeToolMenu.getByRole('menuitemradio', {
+      name: /Arrow/,
+    });
+
+    // Toolbar - Path group (Path/Curve)
+    this.pathToolGroup = this.toolBarWindow.getByRole('group', {
+      name: /Options: (Path|Curve)/,
+    });
+    this.pathToolButton = this.pathToolGroup.getByRole('button', {
+      name: /Path|Curve/,
+    });
+    this.pathToolMenu = page.getByRole('menu', { name: /Options: (Path|Curve)/ });
+    this.createPathButton = this.pathToolMenu.getByRole('menuitemradio', {
+      name: /Path/,
+    });
+    this.createCurveButton = this.pathToolMenu.getByRole('menuitemradio', {
+      name: /Curve/,
+    });
+
+    this.MCPButton = this.toolBarWindow.getByRole('button', { name: 'MCP' });
     this.connectHereMCPButton = page.getByRole('menuitem', { name: 'Connect here' });
     this.connectedMCPButton = page.getByText('MCP connected');
     this.colorsPaletteButton = page.locator('button[title^="Color Palette"]');
-    this.toolBarWindow = page.locator('aside[class*="main-toolbar"]').first();
     this.designTab = page.getByRole('tab', { name: 'design' });
-    this.createPathPointer = page
-      .getByTestId('viewport')
-      .locator('[class*="viewport-controls cursor-pen drawing"]');
+    this.createPathPointer = page.locator('#viewport-controls.cursor-pen.drawing');
 
     //Grid editor Toolbar
     this.gridEditorToolBar = page.getByText('Editing grid').locator('..');
@@ -237,24 +277,53 @@ exports.MainPage = class MainPage extends BasePage {
     );
   }
 
-  async clickMoveButton() {
-    await this.moveButton.click({ delay: 500 });
-  }
-
-  async clickCreateBoardButton() {
-    await this.createBoardButton.click({ delay: 500 });
+  async openFlyout(triggerButton, menu) {
+    await triggerButton.click();
+    await menu.waitFor({ state: 'visible' });
   }
 
   async clickCreateRectangleButton() {
-    await this.createRectangleButton.click({ delay: 500 });
+    await this.shapeToolButton.click();
   }
 
   async clickCreateEllipseButton() {
-    await this.createEllipseButton.click({ delay: 500 });
+    await this.openFlyout(this.shapeToolButton, this.shapeToolMenu);
+    await this.createEllipseButton.click();
+  }
+
+  async clickCreateLineButton() {
+    await this.openFlyout(this.shapeToolButton, this.shapeToolMenu);
+    await this.createLineButton.click();
+  }
+
+  async clickCreateArrowButton() {
+    await this.openFlyout(this.shapeToolButton, this.shapeToolMenu);
+    await this.createArrowButton.click();
+  }
+
+  async clickCreatePathButton() {
+    await this.viewport.click();
+    await this.pathToolButton.click();
+    await this.viewport.hover();
+    await expect(this.createPathPointer).toBeVisible();
+  }
+
+  async clickCreateCurveButton() {
+    await this.viewport.click();
+    await this.openFlyout(this.pathToolButton, this.pathToolMenu);
+    await this.createCurveButton.click();
+  }
+
+  async clickMoveButton() {
+    await this.moveButton.click();
+  }
+
+  async clickCreateBoardButton() {
+    await this.createBoardButton.click();
   }
 
   async clickCreateTextButton() {
-    await this.createTextButton.click({ delay: 500 });
+    await this.createTextButton.click();
   }
 
   async typeDefaultTextFromKeyboard() {
@@ -290,16 +359,6 @@ exports.MainPage = class MainPage extends BasePage {
     await this.pressUploadImageShortcut();
     const fileChooser = await fileChooserPromise;
     await fileChooser.setFiles(filePath);
-  }
-
-  async clickCreateCurveButton() {
-    await this.createCurveButton.click({ delay: 500 });
-  }
-
-  async clickCreatePathButton() {
-    await this.viewport.click();
-    await this.createPathButton.click({ delay: 500 });
-    await expect(this.createPathPointer).toBeVisible();
   }
 
   async clickViewportOnce() {


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/task/1914
https://tree.taiga.io/project/kaleidos-qa/task/1915
https://tree.taiga.io/project/kaleidos-qa/task/1916
https://tree.taiga.io/project/kaleidos-qa/task/1917

## Description

Fixes broken locators for the toolbar's shape (Rectangle/Ellipse/Line/Arrow) and path (Path/Curve) tool groups. These tools live in a flyout menu that only reveals its options after the group's trigger button is clicked, and several assumptions in the original locators didn't match the actual DOM/ARIA structure.

## Solution

**Removed stale data-testid locators**
createEllipseButton and createCurveButton previously used page.getByTestId('ellipse-btn') / page.getByTestId('curve-btn'). These test IDs no longer exist in the current build. Replaced with role-based locators scoped to the flyout menu.

**Corrected roles for the flyout structure**
Locators now correctly reflect: group (trigger) → menu (flyout container) → menuitemradio (individual options).

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots
- [ ] The tests run OK

## Test Execution Results in local

Executed locally as the snapshots are failing due to size badge color.

<img width="397" height="1186" alt="image" src="https://github.com/user-attachments/assets/f74952c8-09be-43c3-bfdf-21a0f01f4ecc" />

