### PR TITLE
fix(tests): report related tasks 1935, 1957 and 1959

### DIFF
--- a/helpers/user-flows.js
+++ b/helpers/user-flows.js
@@ -72,7 +72,7 @@ async function setupUserWithRole(
   await teamPage.clickInviteMembersToTeamButton();
 
   if (assertInviteHeader) {
-    await teamPage.isInviteMembersPopUpHeaderDisplayed('Invite members to the team');
+    await teamPage.isInviteMembersPopUpHeaderVisible();
   }
 
   await teamPage.enterEmailToInviteMembersPopUp(userEmail);

--- a/pages/dashboard/team-page.js
+++ b/pages/dashboard/team-page.js
@@ -51,15 +51,13 @@ exports.TeamPage = class TeamPage extends BasePage {
     //Invitations
     this.invitationsMenuItem = page.getByRole('menuitem', { name: 'Invitations' });
     this.inviteMembersToTeamButton = page.getByTestId('invite-member');
-    this.inviteMembersPopUpHeader = page.locator(
-      'div[class*="modal-team-container"] div[class*="title"]',
-    );
+    this.inviteMembersPopUpHeader = page.getByRole('heading', {
+      name: 'Invite members to the team',
+    });
     this.inviteMembersTeamHeroButton = page.getByRole('button', {
       name: 'Invite members',
     });
-    this.inviteMembersToTeamRoleSelectorButton = page.locator(
-      'div[class*="custom-select"]',
-    );
+    this.inviteMembersToTeamRoleSelector = page.getByRole('combobox');
     this.adminRoleSelector = page.locator('li').filter({ hasText: 'Admin' });
     this.editorRoleSelector = page.locator('li').filter({ hasText: 'Editor' });
     this.viewerRoleSelector = page.locator('li').filter({ hasText: 'Viewer' });
@@ -217,7 +215,7 @@ exports.TeamPage = class TeamPage extends BasePage {
   }
 
   async isTeamDeleted(teamName) {
-    await expect(this.page.getByText('Your Penpot')).toBeVisible({ timeout: 8000 });
+    await expect(this.page.getByText('My Files')).toBeVisible({ timeout: 8000 });
     await this.openTeamsListIfClosed();
     for (const el of await this.teamCurrentNameDiv.elementHandles()) {
       const text = (await el.innerText()).valueOf();
@@ -249,8 +247,8 @@ exports.TeamPage = class TeamPage extends BasePage {
     await expect(this.inviteMembersToTeamButton).not.toBeVisible();
   }
 
-  async isInviteMembersPopUpHeaderDisplayed(title) {
-    await expect(this.inviteMembersPopUpHeader).toHaveText(title);
+  async isInviteMembersPopUpHeaderVisible() {
+    await expect(this.inviteMembersPopUpHeader).toBeVisible();
   }
 
   async clickInviteMembersTeamHeroButton() {
@@ -333,7 +331,7 @@ exports.TeamPage = class TeamPage extends BasePage {
   }
 
   async selectInvitationRoleInPopUp(role) {
-    await this.inviteMembersToTeamRoleSelectorButton.click();
+    await this.inviteMembersToTeamRoleSelector.click();
     switch (role) {
       case 'Admin':
         await this.adminRoleSelector.click();
@@ -463,7 +461,7 @@ exports.TeamPage = class TeamPage extends BasePage {
       ? await this.selectMember(name)
       : await this.clickOnLeaveTeamButton();
     await expect(this.teamCurrentBtn).not.toHaveText(teamName);
-    await expect(this.teamCurrentBtn).toHaveText('Your Penpot');
+    await expect(this.teamCurrentBtn).toHaveText('My Files');
   }
 
   /**

--- a/tests/action-menu/copy-link.spec.ts
+++ b/tests/action-menu/copy-link.spec.ts
@@ -67,9 +67,7 @@ mainTest.describe(() => {
           async () => {
             await teamPage.openInvitationsPageViaOptionsMenu();
             await teamPage.clickInviteMembersToTeamButton();
-            await teamPage.isInviteMembersPopUpHeaderDisplayed(
-              'Invite members to the team',
-            );
+            await teamPage.isInviteMembersPopUpHeaderVisible();
             await teamPage.enterEmailToInviteMembersPopUp(firstEmail);
             await teamPage.selectInvitationRoleInPopUp('Editor');
             await teamPage.clickSendInvitationButton();

--- a/tests/composition/composition-comments.spec.ts
+++ b/tests/composition/composition-comments.spec.ts
@@ -301,9 +301,7 @@ mainTest.describe(() => {
 
         await teamPage.openInvitationsPageViaOptionsMenu();
         await teamPage.clickInviteMembersToTeamButton();
-        await teamPage.isInviteMembersPopUpHeaderDisplayed(
-          'Invite members to the team',
-        );
+        await teamPage.isInviteMembersPopUpHeaderVisible();
         await teamPage.enterEmailToInviteMembersPopUp(firstEmail);
         await teamPage.selectInvitationRoleInPopUp('Viewer');
         await teamPage.clickSendInvitationButton();
@@ -392,9 +390,7 @@ mainTest.describe(() => {
     await mainTest.step('Invite editor to team', async () => {
       await teamPage.openInvitationsPageViaOptionsMenu();
       await teamPage.clickInviteMembersToTeamButton();
-      await teamPage.isInviteMembersPopUpHeaderDisplayed(
-        'Invite members to the team',
-      );
+      await teamPage.isInviteMembersPopUpHeaderVisible();
       await teamPage.enterEmailToInviteMembersPopUp(firstEmail);
       await teamPage.selectInvitationRoleInPopUp('Editor');
       await teamPage.clickSendInvitationButton();
@@ -463,9 +459,7 @@ mainTest.describe(() => {
 
       await teamPage.openInvitationsPageViaOptionsMenu();
       await teamPage.clickInviteMembersToTeamButton();
-      await teamPage.isInviteMembersPopUpHeaderDisplayed(
-        'Invite members to the team',
-      );
+      await teamPage.isInviteMembersPopUpHeaderVisible();
       await teamPage.enterEmailToInviteMembersPopUp(firstEmail);
       await teamPage.selectInvitationRoleInPopUp('Editor');
       await teamPage.clickSendInvitationButton();
@@ -564,9 +558,7 @@ mainTest.describe(() => {
 
         await teamPage.openInvitationsPageViaOptionsMenu();
         await teamPage.clickInviteMembersToTeamButton();
-        await teamPage.isInviteMembersPopUpHeaderDisplayed(
-          'Invite members to the team',
-        );
+        await teamPage.isInviteMembersPopUpHeaderVisible();
         await teamPage.enterEmailToInviteMembersPopUp(firstEmail);
         await teamPage.selectInvitationRoleInPopUp('Editor');
         await teamPage.clickSendInvitationButton();

--- a/tests/dashboard/teams/teams-bad-url.spec.ts
+++ b/tests/dashboard/teams/teams-bad-url.spec.ts
@@ -144,9 +144,7 @@ mainTest(
         await teamPage.openInvitationsPageViaOptionsMenu();
         await teamPage.clickInviteMembersToTeamButton();
 
-        await teamPage.isInviteMembersPopUpHeaderDisplayed(
-          'Invite members to the team',
-        );
+        await teamPage.isInviteMembersPopUpHeaderVisible();
 
         await teamPage.enterEmailToInviteMembersPopUp(firstEmail);
         await teamPage.selectInvitationRoleInPopUp('Admin');

--- a/tests/dashboard/teams/teams-invitations.spec.ts
+++ b/tests/dashboard/teams/teams-invitations.spec.ts
@@ -37,7 +37,7 @@ mainTest(qase(1164, 'Open the form via Invitations tab'), async () => {
   await teamPage.isTeamSelected(team);
   await teamPage.openInvitationsPageViaOptionsMenu();
   await teamPage.clickInviteMembersToTeamButton();
-  await teamPage.isInviteMembersPopUpHeaderDisplayed('Invite members to the team');
+  await teamPage.isInviteMembersPopUpHeaderVisible();
   await teamPage.deleteTeam(team);
 });
 
@@ -47,7 +47,7 @@ registerTest(
     await teamPage.createTeam(team);
     await teamPage.isTeamSelected(team);
     await teamPage.clickInviteMembersTeamHeroButton();
-    await teamPage.isInviteMembersPopUpHeaderDisplayed('Invite members to the team');
+    await teamPage.isInviteMembersPopUpHeaderVisible();
     await teamPage.deleteTeam(team);
   },
 );
@@ -59,7 +59,7 @@ mainTest(qase(1166, 'Invite via owner (single invitation, editor)'), async () =>
   await teamPage.isTeamSelected(team);
   await teamPage.openInvitationsPageViaOptionsMenu();
   await teamPage.clickInviteMembersToTeamButton();
-  await teamPage.isInviteMembersPopUpHeaderDisplayed('Invite members to the team');
+  await teamPage.isInviteMembersPopUpHeaderVisible();
   await teamPage.enterEmailToInviteMembersPopUp(email);
   await teamPage.clickSendInvitationButton();
   await teamPage.isSuccessMessageDisplayed('Invitation sent successfully');
@@ -78,7 +78,7 @@ mainTest(qase(1167, 'Invite via owner (single invitation, admin)'), async () => 
   await teamPage.isTeamSelected(team);
   await teamPage.openInvitationsPageViaOptionsMenu();
   await teamPage.clickInviteMembersToTeamButton();
-  await teamPage.isInviteMembersPopUpHeaderDisplayed('Invite members to the team');
+  await teamPage.isInviteMembersPopUpHeaderVisible();
 
   await teamPage.selectInvitationRoleInPopUp('Admin');
   await teamPage.enterEmailToInviteMembersPopUp(email);
@@ -99,7 +99,7 @@ mainTest(qase(1175, 'Fail to send invitation to existing team member'), async ()
   await teamPage.openInvitationsPageViaOptionsMenu();
   await teamPage.clickInviteMembersToTeamButton();
 
-  await teamPage.isInviteMembersPopUpHeaderDisplayed('Invite members to the team');
+  await teamPage.isInviteMembersPopUpHeaderVisible();
 
   await teamPage.enterEmailToInviteMembersPopUp(process.env.LOGIN_EMAIL);
   await teamPage.isSendInvitationBtnDisabled();
@@ -183,9 +183,7 @@ mainTest.describe(
         await teamPage.isTeamSelected(team);
         await teamPage.openInvitationsPageViaOptionsMenu();
         await teamPage.clickInviteMembersToTeamButton();
-        await teamPage.isInviteMembersPopUpHeaderDisplayed(
-          'Invite members to the team',
-        );
+        await teamPage.isInviteMembersPopUpHeaderVisible();
         await teamPage.enterEmailToInviteMembersPopUp(
           `${firstEmail}, ${secondEmail}`,
         );
@@ -259,7 +257,7 @@ mainTest(qase(1176, 'Resend multiple invitations via owner'), async () => {
   await teamPage.isTeamSelected(team);
   await teamPage.openInvitationsPageViaOptionsMenu();
   await teamPage.clickInviteMembersToTeamButton();
-  await teamPage.isInviteMembersPopUpHeaderDisplayed('Invite members to the team');
+  await teamPage.isInviteMembersPopUpHeaderVisible();
   await teamPage.enterEmailToInviteMembersPopUp([email1, email2, email3]);
   await teamPage.clickSendInvitationButton();
   await teamPage.isSuccessMessageDisplayed('Invitation sent successfully');
@@ -282,7 +280,7 @@ mainTest(qase(1178, 'Delete multiple invitations via owner'), async () => {
   await teamPage.isTeamSelected(team);
   await teamPage.openInvitationsPageViaOptionsMenu();
   await teamPage.clickInviteMembersToTeamButton();
-  await teamPage.isInviteMembersPopUpHeaderDisplayed('Invite members to the team');
+  await teamPage.isInviteMembersPopUpHeaderVisible();
   await teamPage.enterEmailToInviteMembersPopUp([email1, email2, email3]);
   await teamPage.clickSendInvitationButton();
   await teamPage.isSuccessMessageDisplayed('Invitation sent successfully');
@@ -303,7 +301,7 @@ mainTest(qase(1181, 'Change role in invitation via owner'), async () => {
   await teamPage.isTeamSelected(team);
   await teamPage.openInvitationsPageViaOptionsMenu();
   await teamPage.clickInviteMembersToTeamButton();
-  await teamPage.isInviteMembersPopUpHeaderDisplayed('Invite members to the team');
+  await teamPage.isInviteMembersPopUpHeaderVisible();
   await teamPage.enterEmailToInviteMembersPopUp(email);
   await teamPage.clickSendInvitationButton();
   await teamPage.isSuccessMessageDisplayed('Invitation sent successfully');

--- a/tests/dashboard/teams/teams-leave-team.spec.ts
+++ b/tests/dashboard/teams/teams-leave-team.spec.ts
@@ -47,7 +47,7 @@ async function setupInvitedUser(
   // Send invite
   await teamPage.openInvitationsPageViaOptionsMenu();
   await teamPage.clickInviteMembersToTeamButton();
-  await teamPage.isInviteMembersPopUpHeaderDisplayed('Invite members to the team');
+  await teamPage.isInviteMembersPopUpHeaderVisible();
   await teamPage.enterEmailToInviteMembersPopUp(userEmail);
 
   if (role !== 'Editor') {

--- a/tests/dashboard/teams/teams-members.spec.ts
+++ b/tests/dashboard/teams/teams-members.spec.ts
@@ -186,7 +186,7 @@ mainTest(qase([1196], 'Team. Members - leave team (as owner)'), async ({ page })
     await teamPage.isTeamSelected(team);
     await teamPage.openInvitationsPageViaOptionsMenu();
     await teamPage.clickInviteMembersToTeamButton();
-    await teamPage.isInviteMembersPopUpHeaderDisplayed('Invite members to the team');
+    await teamPage.isInviteMembersPopUpHeaderVisible();
     await teamPage.enterEmailToInviteMembersPopUp(firstEmail);
     await teamPage.selectInvitationRoleInPopUp('Admin');
     await teamPage.clickSendInvitationButton();

--- a/tests/dashboard/teams/teams-permissions.spec.ts
+++ b/tests/dashboard/teams/teams-permissions.spec.ts
@@ -73,9 +73,7 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
 
       await teamPage.openInvitationsPageViaOptionsMenu();
       await teamPage.clickInviteMembersToTeamButton();
-      await teamPage.isInviteMembersPopUpHeaderDisplayed(
-        'Invite members to the team',
-      );
+      await teamPage.isInviteMembersPopUpHeaderVisible();
       await teamPage.enterEmailToInviteMembersPopUp(secondEmail);
       await teamPage.selectInvitationRoleInPopUp('Admin');
       await teamPage.clickSendInvitationButton();
@@ -105,9 +103,7 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       await teamPage.isTeamSelected(team);
       await teamPage.openInvitationsPageViaOptionsMenu();
       await teamPage.clickInviteMembersToTeamButton();
-      await teamPage.isInviteMembersPopUpHeaderDisplayed(
-        'Invite members to the team',
-      );
+      await teamPage.isInviteMembersPopUpHeaderVisible();
       await teamPage.enterEmailToInviteMembersPopUp(secondEmail);
       await teamPage.clickSendInvitationButton();
       await teamPage.isSuccessMessageDisplayed('Invitation sent successfully');
@@ -172,9 +168,7 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       await teamPage.isTeamSelected(team);
       await teamPage.openInvitationsPageViaOptionsMenu();
       await teamPage.clickInviteMembersToTeamButton();
-      await teamPage.isInviteMembersPopUpHeaderDisplayed(
-        'Invite members to the team',
-      );
+      await teamPage.isInviteMembersPopUpHeaderVisible();
       await teamPage.enterEmailToInviteMembersPopUp(`${firstEmail}, ${secondEmail}`);
       await teamPage.selectInvitationRoleInPopUp('Admin');
       await teamPage.clickSendInvitationButton();
@@ -258,17 +252,13 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       await teamPage.isTeamSelected(team);
       await teamPage.openInvitationsPageViaOptionsMenu();
       await teamPage.clickInviteMembersToTeamButton();
-      await teamPage.isInviteMembersPopUpHeaderDisplayed(
-        'Invite members to the team',
-      );
+      await teamPage.isInviteMembersPopUpHeaderVisible();
       await teamPage.enterEmailToInviteMembersPopUp(`${firstEmail}`);
       await teamPage.selectInvitationRoleInPopUp('Admin');
       await teamPage.clickSendInvitationButton();
       await teamPage.isSuccessMessageDisplayed('Invitation sent successfully');
       await teamPage.clickInviteMembersToTeamButton();
-      await teamPage.isInviteMembersPopUpHeaderDisplayed(
-        'Invite members to the team',
-      );
+      await teamPage.isInviteMembersPopUpHeaderVisible();
       await teamPage.enterEmailToInviteMembersPopUp(`${secondEmail}`);
       await teamPage.selectInvitationRoleInPopUp('Editor');
       await teamPage.clickSendInvitationButton();
@@ -329,9 +319,7 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       await teamPage.isTeamSelected(team);
       await teamPage.openInvitationsPageViaOptionsMenu();
       await teamPage.clickInviteMembersToTeamButton();
-      await teamPage.isInviteMembersPopUpHeaderDisplayed(
-        'Invite members to the team',
-      );
+      await teamPage.isInviteMembersPopUpHeaderVisible();
       await teamPage.enterEmailToInviteMembersPopUp(`${firstEmail}`);
       await teamPage.selectInvitationRoleInPopUp('Admin');
       await teamPage.clickSendInvitationButton();
@@ -372,17 +360,13 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       await teamPage.isTeamSelected(team);
       await teamPage.openInvitationsPageViaOptionsMenu();
       await teamPage.clickInviteMembersToTeamButton();
-      await teamPage.isInviteMembersPopUpHeaderDisplayed(
-        'Invite members to the team',
-      );
+      await teamPage.isInviteMembersPopUpHeaderVisible();
       await teamPage.enterEmailToInviteMembersPopUp(`${firstEmail}`);
       await teamPage.selectInvitationRoleInPopUp('Admin');
       await teamPage.clickSendInvitationButton();
       await teamPage.isSuccessMessageDisplayed('Invitation sent successfully');
       await teamPage.clickInviteMembersToTeamButton();
-      await teamPage.isInviteMembersPopUpHeaderDisplayed(
-        'Invite members to the team',
-      );
+      await teamPage.isInviteMembersPopUpHeaderVisible();
       await teamPage.enterEmailToInviteMembersPopUp(`${secondEmail}`);
       await teamPage.selectInvitationRoleInPopUp('Editor');
       await teamPage.clickSendInvitationButton();
@@ -423,9 +407,7 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       await teamPage.isTeamSelected(team);
       await teamPage.openInvitationsPageViaOptionsMenu();
       await teamPage.clickInviteMembersToTeamButton();
-      await teamPage.isInviteMembersPopUpHeaderDisplayed(
-        'Invite members to the team',
-      );
+      await teamPage.isInviteMembersPopUpHeaderVisible();
       await teamPage.enterEmailToInviteMembersPopUp(firstEmail);
       await teamPage.selectInvitationRoleInPopUp('Admin');
       await teamPage.clickSendInvitationButton();
@@ -477,9 +459,7 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       await teamPage.isTeamSelected(team);
       await teamPage.openInvitationsPageViaOptionsMenu();
       await teamPage.clickInviteMembersToTeamButton();
-      await teamPage.isInviteMembersPopUpHeaderDisplayed(
-        'Invite members to the team',
-      );
+      await teamPage.isInviteMembersPopUpHeaderVisible();
       await teamPage.enterEmailToInviteMembersPopUp(`${firstEmail}, ${secondEmail}`);
       await teamPage.selectInvitationRoleInPopUp('Admin');
       await teamPage.clickSendInvitationButton();
@@ -542,17 +522,13 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       await teamPage.isTeamSelected(team);
       await teamPage.openInvitationsPageViaOptionsMenu();
       await teamPage.clickInviteMembersToTeamButton();
-      await teamPage.isInviteMembersPopUpHeaderDisplayed(
-        'Invite members to the team',
-      );
+      await teamPage.isInviteMembersPopUpHeaderVisible();
       await teamPage.enterEmailToInviteMembersPopUp(`${firstEmail}`);
       await teamPage.selectInvitationRoleInPopUp('Admin');
       await teamPage.clickSendInvitationButton();
       await teamPage.isSuccessMessageDisplayed('Invitation sent successfully');
       await teamPage.clickInviteMembersToTeamButton();
-      await teamPage.isInviteMembersPopUpHeaderDisplayed(
-        'Invite members to the team',
-      );
+      await teamPage.isInviteMembersPopUpHeaderVisible();
       await teamPage.enterEmailToInviteMembersPopUp(`${secondEmail}`);
       await teamPage.selectInvitationRoleInPopUp('Editor');
       await teamPage.clickSendInvitationButton();
@@ -615,17 +591,13 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       await teamPage.isTeamSelected(team);
       await teamPage.openInvitationsPageViaOptionsMenu();
       await teamPage.clickInviteMembersToTeamButton();
-      await teamPage.isInviteMembersPopUpHeaderDisplayed(
-        'Invite members to the team',
-      );
+      await teamPage.isInviteMembersPopUpHeaderVisible();
       await teamPage.enterEmailToInviteMembersPopUp(`${firstEmail}`);
       await teamPage.selectInvitationRoleInPopUp('Admin');
       await teamPage.clickSendInvitationButton();
       await teamPage.isSuccessMessageDisplayed('Invitation sent successfully');
       await teamPage.clickInviteMembersToTeamButton();
-      await teamPage.isInviteMembersPopUpHeaderDisplayed(
-        'Invite members to the team',
-      );
+      await teamPage.isInviteMembersPopUpHeaderVisible();
       await teamPage.enterEmailToInviteMembersPopUp(`${secondEmail}`);
       await teamPage.selectInvitationRoleInPopUp('Editor');
       await teamPage.clickSendInvitationButton();

--- a/tests/dashboard/teams/teams-rename.spec.ts
+++ b/tests/dashboard/teams/teams-rename.spec.ts
@@ -55,9 +55,7 @@ mainTest.describe('Rename a team', () => {
         await teamPage.isTeamSelected(team);
         await teamPage.openInvitationsPageViaOptionsMenu();
         await teamPage.clickInviteMembersToTeamButton();
-        await teamPage.isInviteMembersPopUpHeaderDisplayed(
-          'Invite members to the team',
-        );
+        await teamPage.isInviteMembersPopUpHeaderVisible();
         await teamPage.enterEmailToInviteMembersPopUp(firstEmail);
         await teamPage.clickSendInvitationButton();
         await teamPage.isSuccessMessageDisplayed('Invitation sent successfully');

--- a/tests/view-mode/view-mode-share.spec.ts
+++ b/tests/view-mode/view-mode-share.spec.ts
@@ -254,9 +254,7 @@ mainTest.describe(() => {
       await mainTest.step('Invite a second admin to the team', async () => {
         await teamPage.openInvitationsPageViaOptionsMenu();
         await teamPage.clickInviteMembersToTeamButton();
-        await teamPage.isInviteMembersPopUpHeaderDisplayed(
-          'Invite members to the team',
-        );
+        await teamPage.isInviteMembersPopUpHeaderVisible();
         await teamPage.enterEmailToInviteMembersPopUp(firstEmail);
         await teamPage.selectInvitationRoleInPopUp('Admin');
         await teamPage.clickSendInvitationButton();


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

[1935](https://tree.taiga.io/project/kaleidos-qa/task/1935)
[1957](https://tree.taiga.io/project/kaleidos-qa/task/1957)
[1959](https://tree.taiga.io/project/kaleidos-qa/task/1959)

## Description

This PR fix tests changing:
- locator('div[class*="modal-team-container"] div[class*="title"]',);  to getByRole('heading', { name: 'Invite members to the team',});
- locator('div[class*="custom-select"]',); to getByRole('combobox');
- "Your Penpot" to "My Files".

Also there is a refactor in isInviteMembersPopUpHeaderDisplayed function making it more usable.

There are some failures note related to this tasks.

## How to test

- [ ] Check the code
- [ ] It complies with the test conventions
- [ ] The tests run OK

## Screenshots 📸 
<img width="1980" height="146" alt="view-mode" src="https://github.com/user-attachments/assets/67d71356-80e8-4add-be9f-3d7fc9e77282" />
<img width="1770" height="1868" alt="teams-permission" src="https://github.com/user-attachments/assets/12551178-7cba-41ee-bc32-466b82fcef68" />
<img width="1980" height="1576" alt="comments" src="https://github.com/user-attachments/assets/c50450cd-6080-442e-9a2c-27fb35ef5de0" />
<img width="1970" height="1240" alt="bad-url" src="https://github.com/user-attachments/assets/4f50a21b-163d-48eb-88ad-21c21919d313" />
<img width="1978" height="546" alt="leave-team" src="https://github.com/user-attachments/assets/c3993d76-3356-4957-9a69-cdd9f0b84210" />
<img width="1974" height="804" alt="team-members" src="https://github.com/user-attachments/assets/ebed1eb5-2e32-4a4e-be62-50e7e48f70de" />
<img width="1980" height="548" alt="rename" src="https://github.com/user-attachments/assets/0887b1d7-7f51-4698-ab38-589cf956103c" />
