### PR TITLE
fix(test): update a locator to fix the test (Qase ID:833)

### DIFF
--- a/pages/workspace/panels-features/pages-panel-page.ts
+++ b/pages/workspace/panels-features/pages-panel-page.ts
@@ -40,9 +40,7 @@ export class PagesPanelPage extends MainPage {
     this.selectedPage = page.locator(
       'ul[class*="page-list"] li[class*="sitemap__selected"] div[class*="element-list-body"]',
     );
-    this.pageNameInput = page.locator(
-      'ul[class*="page-list"] div[class*="element-list-body"] input',
-    );
+    this.pageNameInput = this.pagesBlock.getByRole('textbox');
     this.renamePageMenuItem = page
       .getByRole('listitem')
       .filter({ hasText: 'Rename' });

--- a/tests/panels-features/panels-features-pages.spec.ts
+++ b/tests/panels-features/panels-features-pages.spec.ts
@@ -58,7 +58,6 @@ mainTest(qase([833], 'Rename page'), async () => {
   await mainTest.step('Add a second page', async () => {
     await pagesPanelPage.clickAddPageButton();
     await mainPage.waitForChangeIsSaved();
-    await mainPage.clickMoveButton();
   });
 
   await mainTest.step('Rename first page', async () => {


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

_If relevant, include the Taiga URL_
https://tree.taiga.io/project/kaleidos-qa/task/1968

## Description

This PR resolves the test with Qase ID 833, failing due to a bad locator for a CSS change.

## Solution

* Change the locator
* Remove unnecessary weird test action (clicking in the move icon from the toolbar)

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots
- [ ] The tests run OK

## Screenshots 📸 (optional)

<img width="910" height="217" alt="image" src="https://github.com/user-attachments/assets/3da21a18-8f09-4e0c-b138-81ff4730599f" />

## Anything Else? (optional)

The flakiness is not because of changes in this PR:

<img width="893" height="719" alt="image" src="https://github.com/user-attachments/assets/d3ab511c-03d5-4dc0-8514-4e4ef5877753" />
