### PR TITLE
refactor(triage): refactor triage workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -33,26 +33,38 @@ During **freeze week / release promotion**, once there's a scheduled daily PRE r
 3. **Loads previous triage state** for this release tag from S3 (if any exists) — this is how it knows which failures it's already seen.
 4. **Runs `scripts/triage.ts`**, which:
    - Parses the Playwright results and separates real failures from flaky tests (failed then passed on retry — flaky ones are counted in the digest but not filed).
-   - **Clusters failures by root cause**, not by test: it normalizes each error message (strips timestamps, ids, line numbers, etc.) so the same underlying bug filed from different tests/runs hashes to the same cluster. Screenshot/visual-diff failures are clustered per spec file instead, since their messages carry little identity.
+   - **Clusters failures by root cause**, not by test: it normalizes each error message (strips timestamps, ids, line numbers, etc.) so the same underlying bug filed from different tests/runs hashes to the same cluster. Screenshot/visual-diff failures are clustered **strictly per spec file** instead — the error text (snapshot name, diff stats) is never part of that fingerprint, so every `toHaveScreenshot` failure in one file collapses into a single cluster/task no matter how many different diffs it covers.
    - Creates the release story in Taiga if it doesn't exist yet (subject `[release <tag>] Daily failures triage`, tagged `needs-triage` + `release-<tag>`, optionally linked under `epic_ref`).
    - Adds **one task per new cluster** (or per file, if `group_by: file`) — see "What's in a task" below.
    - For clusters already known and still failing, comments on the story instead of creating a new task, so it doesn't spam duplicates.
-   - **Auto-closes tasks for clusters whose error is no longer seen in the next triaged run** — closed status, assigned to `qa.integrations.bot`, with a comment explaining why. If someone already closed the task manually (see "Triage convention" below), it just adds a verification comment instead.
-5. **Saves the updated state** back to S3 so the next run knows what's open, closed, and how many consecutive runs each cluster has failed/passed.
-6. **Posts a digest** (new clusters / still-failing clusters / resolved clusters, plus flaky count and app version) to the job summary and to Mattermost.
+   - **Auto-closes tasks for clusters whose error is no longer seen in the next triaged run** — closed status, assigned to `qa.integrations.bot`, with a comment explaining why. If someone already closed the task manually (see "Triage convention" below), it just adds a verification comment instead. This tracks every task it creates (in both `group_by: cluster` and `group_by: file` mode) so nothing is silently un-closeable — see "Ad-hoc closing" below for sweeping a backlog or fixing a stray task by hand.
+5. **Saves the updated state** back to S3 so the next run knows what's open, closed, and how many consecutive runs each cluster has failed/passed. State is saved even if the run throws partway through (a Taiga hiccup, a network blip), so a failed run doesn't strand already-created tasks out of state and cause duplicates on the next run.
+6. **Posts a digest** (new clusters / still-failing clusters / resolved clusters, plus flaky count, run id, and app version) to the job summary and to Mattermost.
 
 **Re-running is safe.** Run it again with the same tag and it only adds _new_ clusters and closes _resolved_ ones — nothing gets duplicated.
+
+### Ad-hoc closing
+
+Two flags let you close resolved tasks without running (and filing) a full triage:
+
+- `--close-only` — runs the normal parse → cluster → detect-resolved pipeline but skips creating any new story/task; it only sweeps and closes tasks whose error is no longer present in the given `results.json`. Writes `.triage/digest.md` as usual (a trimmed version: what got closed, nothing about "new"/"known" since nothing was filed). Useful for clearing a backlog of resolved tasks on demand.
+- `--close-ref <taskRef> [--close-ref <taskRef> ...]` — force-closes specific Taiga tasks by their visible ref number (`#1234`), bypassing `results.json`/state entirely. Escape hatch for one-off closes or tasks that predate this tracking (e.g. old `group_by: file` tasks created before per-file tracking existed). Purely a manual CLI action: it does **not** write `.triage/digest.md` or post to Mattermost, so don't wire it into a step that `cat`s the digest afterward expecting fresh output.
+
+### Debugging a run
+
+Every run logs a one-line summary of its inputs (results path, state path, mode, run id, app version, flags) at the top of the job log. The run id of the `results.json` being triaged (the daily regression run, not the triage workflow's own run) is also stamped into the digest, Taiga story/task descriptions, and the Mattermost post, so it's always traceable back to its source without decoding the report URL.
 
 ### What's in a task
 
 Each task represents one failure cluster and includes:
 
 - A one-line subject: the concise error + affected spec file(s) + test count, e.g. `expect(locator).toBeVisible() failed @ Cancel subscription — checkout.spec.ts (3 tests)`
-- The full list of failing tests in that cluster, with Qase ID (if tagged) and retry count
-- The raw error for each test
-- A link to the full HTML report for the triaged run
+- Spec files affected, and a **Qase IDs affected** summary line aggregating every Qase ID across the cluster's tests — including tests tagged with more than one ID (`qase([1234, 1235], ...)`), which are listed in full rather than truncated to the first
+- The full list of failing tests in that cluster, each with its own Qase ID(s) (if tagged) and retry count
+- The raw error for the cluster
+- The run id and a link to the full HTML report for the triaged run
 
-In `group_by: file` mode, tasks are per spec file instead, listing every failing test in that file.
+In `group_by: file` mode, tasks are per spec file instead, listing every failing test in that file (Qase IDs appear inline per test rather than as a separate summary line).
 
 ### Triage convention
 

--- a/.github/workflows/release-triage.yml
+++ b/.github/workflows/release-triage.yml
@@ -112,6 +112,7 @@ jobs:
             --group-by "${{ inputs.group_by || 'cluster' }}" \
             --epic-ref "${{ inputs.epic_ref }}" \
             --app-version "${{ steps.appver.outputs.version }}" \
+            --run-id "${{ steps.report.outputs.run_id }}" \
             --report-url "https://kaleidos-qa-reports.s3.eu-west-1.amazonaws.com/run-${{ steps.report.outputs.run_id }}/index.html"
         env:
           GITHUB_TOKEN: ${{ github.token }} # raises GitHub API rate limit for the app-repo changelog fetch

--- a/scripts/triage.ts
+++ b/scripts/triage.ts
@@ -31,6 +31,16 @@ function arg(name: string, fallback?: string): string {
   process.exit(1);
 }
 
+/** Collects every occurrence of a repeatable flag, e.g. --close-ref 1 --close-ref 2. */
+function argAll(name: string): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < process.argv.length; i++) {
+    if (process.argv[i] === `--${name}` && process.argv[i + 1])
+      out.push(process.argv[i + 1]);
+  }
+  return out;
+}
+
 const RESULTS_PATH = arg('results', 'playwright-report/results.json');
 const STATE_PATH = arg('state', '.triage/state.json');
 const REPORT_URL = arg('report-url', '');
@@ -38,7 +48,25 @@ const RELEASE = arg('release', ''); // e.g. "2.17" -> single story tagged releas
 const GROUP_BY = arg('group-by', 'cluster'); // release-mode tasks: 'cluster' (one per root cause) or 'file' (one per spec file)
 const EPIC_REF = arg('epic-ref', ''); // optional: Taiga epic ref (#number) to link created stories under
 const APP_VERSION = arg('app-version', ''); // optional: deployed app version this report ran against
+// Debug: which run's results.json this triage was executed over. Falls back to parsing it out of
+// REPORT_URL (every report URL this repo builds embeds it as /run-<id>/) so old callers that only
+// pass --report-url still get it for free.
+const RUN_ID = arg('run-id', '') || REPORT_URL.match(/run-(\d+)/)?.[1] || '';
 const DRY_RUN = process.env.DRY_RUN === '1';
+
+// --close-ref: bypass the whole parse/cluster/create pipeline and force-close specific Taiga task
+// ids directly. Escape hatch for tasks orphaned before per-file/per-test tracking existed, or any
+// one-off manual close.
+const CLOSE_REFS = argAll('close-ref');
+const CLOSE_COMMENT = arg(
+  'close-comment',
+  'Manually closed via triage --close-ref: error no longer occurring.',
+);
+
+// --close-only: run the resolved-detection + auto-close steps only — no new stories/tasks are
+// created, no "new clusters" Mattermost post. Lets a backlog of resolved tasks be swept and closed
+// on demand without needing to run (and file) a full triage.
+const CLOSE_ONLY = process.argv.includes('--close-only');
 
 // ---------- Types ----------
 
@@ -65,6 +93,8 @@ interface StateEntry {
   taigaId?: number; // Taiga story id
   taskRef?: number; // this cluster's own task ref (release cluster mode)
   taskId?: number; // this cluster's own task id
+  taskIds?: number[]; // daily mode: one task per test inside the cluster's story — every one of them, so auto-close can close them all
+  taskRefs?: number[]; // same order as taskIds, for building digest/Mattermost links
   subject?: string; // task subject, kept so resolved/known lines stay meaningful
   firstSeen: string;
   lastSeen: string;
@@ -123,11 +153,14 @@ function extractQaseId(
   annotations: Array<{ type?: string; description?: string }>,
 ): string | undefined {
   const ann = annotations.find((a) => /qase/i.test(a?.type ?? ''));
-  if (ann?.description) return String(ann.description);
+  if (ann?.description) return String(ann.description).replace(/\s+/g, '');
+  // qase([1234, 1235], 'title') renders as "... (Qase ID: 1234,1235)" — capture
+  // the whole comma-separated list, not just the first id ([\w-]+ used to stop at
+  // the comma and silently drop every id after the first).
   const m =
-    title.match(/\(\s*Qase(?:\s*ID)?\s*[:=]?\s*([\w-]+)\s*\)/i) ??
+    title.match(/\(\s*Qase(?:\s*ID)?\s*[:=]?\s*([\w,\s-]+?)\s*\)/i) ??
     title.match(/^([A-Z][A-Z0-9]+-\d+)\s*[:.]/);
-  return m?.[1];
+  return m?.[1]?.replace(/\s+/g, '');
 }
 
 function stripAnsi(s: string): string {
@@ -176,13 +209,15 @@ function isSnapshotError(msg: string): boolean {
 
 function fingerprint(fail: Failure): string {
   // Hybrid clustering:
-  // - snapshot/visual errors: per spec file (generic message, and visual diffs are
-  //   debugged file by file against the spec's snapshots folder)
+  // - snapshot/visual errors: per spec file, full stop. The error message carries
+  //   the snapshot name and diff stats, which vary per screenshot — including any
+  //   of it in the basis would split one file's diffs into many clusters/tasks, so
+  //   the error text is deliberately NOT part of the basis here.
   // - functional errors: cross-file, keyed by error shape + locator. The locator's
   //   quoted text ('Select' vs 'Cancel subscription') IS the identity, so it is kept
   //   verbatim — only dynamic fragments (hex ids, numbers) inside it are neutralized.
   const basis = isSnapshotError(fail.error)
-    ? `${normalizeError(fail.error)}|${fail.file}`
+    ? `snapshot|${fail.file}`
     : `${normalizeError(fail.error)}|${locatorKey(fail.error)}`;
   return crypto.createHash('sha1').update(basis).digest('hex').slice(0, 12);
 }
@@ -276,6 +311,14 @@ class Taiga {
       `/api/v1/epics/by_ref?ref=${encodeURIComponent(ref)}&project=${this.projectId}`,
     );
     return e.id;
+  }
+
+  /** --close-ref takes the human-visible task ref (#1234); the rest of the API wants the internal id. */
+  async taskIdByRef(ref: number): Promise<number> {
+    const t = await this.get(
+      `/api/v1/tasks/by_ref?ref=${ref}&project=${this.projectId}`,
+    );
+    return t.id;
   }
 
   async linkStoryToEpic(epicId: number, storyId: number) {
@@ -441,6 +484,52 @@ class Taiga {
 // ---------- Main ----------
 
 async function main() {
+  // --close-ref: force-close specific task refs directly, bypassing results.json/state/clustering
+  // entirely. Escape hatch for tasks this script has no other way to find (orphaned before the
+  // per-file/per-test tracking below existed, or any other one-off manual close).
+  if (CLOSE_REFS.length) {
+    console.log(
+      `[close-ref] Closing ${CLOSE_REFS.length} task(s) directly: ${CLOSE_REFS.join(', ')}`,
+    );
+    if (DRY_RUN) {
+      console.log('[dry-run] Would close the above and exit — no Taiga calls made.');
+      return;
+    }
+    const taiga = new Taiga(requiredEnv('TAIGA_URL'));
+    await taiga.login(
+      requiredEnv('TAIGA_USERNAME'),
+      requiredEnv('TAIGA_PASSWORD'),
+      requiredEnv('TAIGA_PROJECT'),
+    );
+    const assigneeName = process.env.TAIGA_CLOSE_ASSIGNEE || 'qa.integrations.bot';
+    const statusName = process.env.TAIGA_CLOSED_STATUS || 'Closed';
+    const statusId = await taiga.taskStatusIdByName(statusName);
+    const assigneeId = await taiga.userIdByUsername(assigneeName);
+    if (!statusId) {
+      console.error(`Task status "${statusName}" not found in project — aborting.`);
+      process.exit(1);
+    }
+    for (const refStr of CLOSE_REFS) {
+      const ref = Number(refStr);
+      try {
+        const taskId = await taiga.taskIdByRef(ref);
+        await taiga.closeTask(taskId, statusId, assigneeId, CLOSE_COMMENT);
+        console.log(
+          `Closed task #${ref}${assigneeId ? ` and assigned to ${assigneeName}` : ''}.`,
+        );
+      } catch (e) {
+        console.error(
+          `Could not close task #${ref}: ${e instanceof Error ? e.message : e}`,
+        );
+      }
+    }
+    return;
+  }
+
+  console.log(
+    `[triage] results=${RESULTS_PATH} state=${STATE_PATH}${RELEASE ? ` release=${RELEASE} group-by=${GROUP_BY}` : ' mode=daily'}${RUN_ID ? ` run-id=${RUN_ID}` : ''}${APP_VERSION ? ` app-version=${APP_VERSION}` : ''}${CLOSE_ONLY ? ' close-only=1' : ''}${DRY_RUN ? ' dry-run=1' : ''}`,
+  );
+
   const raw = JSON.parse(fs.readFileSync(RESULTS_PATH, 'utf8'));
   const failures: Failure[] = [];
   for (const suite of raw.suites ?? [])
@@ -497,7 +586,7 @@ async function main() {
     }
   }
   for (const fp of Object.keys(state)) {
-    if (fp.startsWith('__')) continue; // internal bookkeeping (release story, file->task map), not a cluster
+    if (fp.startsWith('__') || fp.startsWith('file::')) continue; // internal bookkeeping / per-file tracking (below), not a cluster
     if (!clusters.has(fp)) {
       state[fp].seenInLastNRuns = [0, ...(state[fp].seenInLastNRuns ?? [])].slice(
         0,
@@ -513,333 +602,463 @@ async function main() {
     }
   }
 
+  // ----- Release + group-by=file: track each spec file's own task, independently of cluster
+  // fingerprints. Non-snapshot clusters can span multiple files, and a file's failures can bounce
+  // between fingerprints run to run, so "is this file still failing?" has to be asked directly —
+  // otherwise (the bug this replaces) file tasks were never linked back into state at all, and
+  // auto-close could never find them.
+  const fileStateKey = (file: string) => `file::${file}`;
+  if (RELEASE && GROUP_BY === 'file') {
+    const failingFiles = new Set<string>();
+    for (const c of clusters.values())
+      for (const t of c.tests) failingFiles.add(t.file);
+
+    for (const file of failingFiles) {
+      const key = fileStateKey(file);
+      if (state[key]) {
+        state[key].lastSeen = today;
+        state[key].consecutiveRuns = (state[key].consecutiveRuns ?? 0) + 1;
+        state[key].seenInLastNRuns = [
+          1,
+          ...(state[key].seenInLastNRuns ?? []),
+        ].slice(0, 10);
+      } else {
+        state[key] = {
+          firstSeen: today,
+          lastSeen: today,
+          consecutiveRuns: 1,
+          seenInLastNRuns: [1],
+        };
+      }
+    }
+    for (const key of Object.keys(state)) {
+      if (!key.startsWith('file::')) continue;
+      const file = key.slice('file::'.length);
+      if (!failingFiles.has(file)) {
+        state[key].seenInLastNRuns = [
+          0,
+          ...(state[key].seenInLastNRuns ?? []),
+        ].slice(0, 10);
+        state[key].consecutiveRuns = 0;
+        if (
+          state[key].seenInLastNRuns.slice(0, 1).every((x) => x === 0) &&
+          state[key].taskId
+        ) {
+          resolved.push(key); // file has no failing tests in this run -> candidate for closing
+        }
+      }
+    }
+  }
+
   const acknowledged = new Map<string, string>(); // fingerprint -> 'triaged' (task closed per team convention)
 
   // Snapshot resolved entries now — closing may delete them from state below.
-  const resolvedInfo = resolved.map((fp) => ({
-    fp,
-    taskRef: state[fp].taskRef,
-    taskId: state[fp].taskId,
-    storyRef: state[fp].taigaRef,
-    subject: state[fp].subject,
-    closed: false,
-  }));
-
-  // ----- Taiga -----
-  let taiga: Taiga | null = null;
-  if (!DRY_RUN && newClusters.length + knownClusters.length + resolved.length > 0) {
-    taiga = new Taiga(requiredEnv('TAIGA_URL'));
-    await taiga.login(
-      requiredEnv('TAIGA_USERNAME'),
-      requiredEnv('TAIGA_PASSWORD'),
-      requiredEnv('TAIGA_PROJECT'),
+  const resolvedInfo = resolved.map((fp) => {
+    // Every task tracked against this entry: the single taskId (release/cluster mode, file mode)
+    // plus taskIds[] (daily mode's one-task-per-test/bundle). Deduplicated, order preserved.
+    const ids = [state[fp].taskId, ...(state[fp].taskIds ?? [])].filter(
+      (v): v is number => v != null,
     );
-  }
+    const refs = [state[fp].taskRef, ...(state[fp].taskRefs ?? [])].filter(
+      (v): v is number => v != null,
+    );
+    return {
+      fp,
+      taskIds: [...new Set(ids)],
+      taskRefs: [...new Set(refs)],
+      taskRef: state[fp].taskRef, // kept for the single-task-per-entry call sites (digest/mm links)
+      taskId: state[fp].taskId,
+      storyRef: state[fp].taigaRef,
+      subject: state[fp].subject,
+      closed: false,
+    };
+  });
 
-  const storyTags = (process.env.TAIGA_TAGS ?? 'daily,needs-triage')
-    .split(',')
-    .map((t: string) => t.trim())
-    .filter((t: string) => t.length > 0);
-
-  if (RELEASE) {
-    // ----- Release mode: ONE user story for the whole release, one task per cluster -----
-    const releaseTag = `release-${RELEASE}`.toLowerCase();
-    const storyKey = '__release_story__';
-    const storyState = (state as any)[storyKey] as StateEntry | undefined;
-
-    let storyId = storyState?.taigaId;
-    let storyRef = storyState?.taigaRef;
-
-    // Someone may have deleted the story in Taiga since the last run — recreate if so.
-    // Its tasks died with it, so known clusters need their tasks rebuilt too.
-    let storyRecreated = false;
-    if (taiga && storyId && !(await taiga.storyExists(storyId))) {
-      console.log(
-        `Stored release story ${storyId} no longer exists in Taiga — rebuilding story and tasks.`,
-      );
-      storyId = undefined;
-      storyRef = undefined;
-      storyRecreated = true;
-      delete (state as any)['__file_tasks__']; // file-mode task map died with the story
-    }
-
-    if (taiga && !storyId) {
-      const subject = `[release ${RELEASE}] Daily failures triage`;
-      const description = [
-        `Triage of daily test failures for release **${RELEASE}**.`,
-        '',
-        `Run date: ${today}`,
-        REPORT_URL ? `[HTML report](${REPORT_URL})` : '',
-        '',
-        'Each task below is one failure cluster (one root cause). Classify each as real bug or test to update.',
-        ...(changelog
-          ? [
-              '',
-              `**App changes since last triage (${changelog.total} commits, [compare](${changelog.compareUrl})):**`,
-              ...changelog.lines,
-            ]
-          : []),
-      ].join('\n');
-      const { id, ref } = await taiga.createUserStory(subject, description, [
-        ...storyTags,
-        releaseTag,
-      ]);
-      storyId = id;
-      storyRef = ref;
-      (state as any)[storyKey] = {
-        taigaId: id,
-        taigaRef: ref,
-        firstSeen: today,
-        lastSeen: today,
-        consecutiveRuns: 1,
-        seenInLastNRuns: [1],
-      };
-      console.log(`Created release user story #${ref} [${releaseTag}]`);
-      if (EPIC_REF) {
-        await taiga.linkStoryToEpic(await taiga.epicIdByRef(EPIC_REF), id);
-        console.log(`Linked story #${ref} under epic #${EPIC_REF}`);
-      }
-    } else if (!taiga) {
-      console.log(
-        `[dry-run] Would create/reuse release user story: [release ${RELEASE}] Daily failures triage [tags: ${[...storyTags, releaseTag].join(', ')}]${EPIC_REF ? ` under epic #${EPIC_REF}` : ''}`,
+  // Everything from here through auto-close mutates Taiga. Wrapped in try/finally so a mid-run
+  // throw (a Taiga 500, a network blip) still saves whatever was already created/closed instead of
+  // discarding it — otherwise the next run recreates those entities as duplicates.
+  let taiga: Taiga | null = null;
+  try {
+    // ----- Taiga -----
+    if (
+      !DRY_RUN &&
+      newClusters.length + knownClusters.length + resolved.length > 0
+    ) {
+      taiga = new Taiga(requiredEnv('TAIGA_URL'));
+      await taiga.login(
+        requiredEnv('TAIGA_USERNAME'),
+        requiredEnv('TAIGA_PASSWORD'),
+        requiredEnv('TAIGA_PROJECT'),
       );
     }
 
-    if (GROUP_BY === 'file') {
-      // One task per spec file, listing all its failing tests (from new clusters).
-      const byFile = new Map<string, Failure[]>();
-      for (const c of storyRecreated
-        ? [...newClusters, ...knownClusters]
-        : newClusters) {
-        for (const t of c.tests) {
-          byFile.set(t.file, [...(byFile.get(t.file) ?? []), t]);
-        }
-      }
-      const fileTasks: Record<string, number> =
-        (state as any)['__file_tasks__'] ?? {};
+    const storyTags = (process.env.TAIGA_TAGS ?? 'daily,needs-triage')
+      .split(',')
+      .map((t: string) => t.trim())
+      .filter((t: string) => t.length > 0);
 
-      for (const [file, tests] of byFile) {
-        const lines = tests.map(
-          (t) =>
-            `- \`${t.title}\`${t.qaseId ? ` (Qase: ${t.qaseId})` : ''}${t.retries ? ` — ${t.retries} retries` : ''}\n  \`\`\`\n  ${conciseError(t.error)}\n  \`\`\``,
-        );
-        if (taiga && storyId) {
-          if (fileTasks[file]) {
-            await taiga.commentTask(
-              fileTasks[file],
-              [`New failures on ${today}:`, ...lines].join('\n'),
-            );
-            console.log(
-              `  ~ appended ${tests.length} test(s) to existing task for ${file}`,
-            );
-          } else {
-            const { id } = await taiga.createTask(
-              storyId,
-              `${path.basename(file)} — ${tests.length} failing test${tests.length > 1 ? 's' : ''}`,
-              [
-                `**Spec file:** \`${file}\``,
-                '',
-                `**Failing tests (${tests.length}):**`,
-                ...lines,
-                '',
-                REPORT_URL ? `[HTML report](${REPORT_URL})` : '',
-              ].join('\n'),
-            );
-            fileTasks[file] = id;
-            console.log(`  + task: ${path.basename(file)} (${tests.length} tests)`);
-          }
-        } else {
-          const qase = tests.map((t) => t.qaseId).filter(Boolean);
-          console.log(
-            `[dry-run]   + task: ${path.basename(file)} — ${tests.length} failing test(s)${qase.length ? ` [Qase: ${qase.join(', ')}]` : ''}`,
-          );
-        }
-      }
-      (state as any)['__file_tasks__'] = fileTasks;
-      // Cluster fingerprints still track new/known/resolved against the release story.
-      for (const c of newClusters) {
-        state[c.fingerprint].taigaId = storyId;
-        state[c.fingerprint].taigaRef = storyRef;
-      }
-    } else {
-      const clustersNeedingTasks = storyRecreated
-        ? [...newClusters, ...knownClusters]
-        : newClusters;
-      if (storyRecreated && knownClusters.length)
+    // --close-only: sweep and close resolved tasks (below), but file nothing new — new/known
+    // clusters stay untouched in state so a later normal run still files them.
+    if (CLOSE_ONLY) {
+      console.log(
+        `[close-only] Skipping story/task creation — ${newClusters.length} new, ${knownClusters.length} known cluster(s) left untouched.`,
+      );
+    } else if (RELEASE) {
+      // ----- Release mode: ONE user story for the whole release, one task per cluster -----
+      const releaseTag = `release-${RELEASE}`.toLowerCase();
+      const storyKey = '__release_story__';
+      const storyState = (state as any)[storyKey] as StateEntry | undefined;
+
+      let storyId = storyState?.taigaId;
+      let storyRef = storyState?.taigaRef;
+
+      // Someone may have deleted the story in Taiga since the last run — recreate if so.
+      // Its tasks died with it, so known clusters need their tasks rebuilt too.
+      let storyRecreated = false;
+      if (taiga && storyId && !(await taiga.storyExists(storyId))) {
         console.log(
-          `Rebuilding tasks for ${knownClusters.length} known cluster(s) in the new story.`,
+          `Stored release story ${storyId} no longer exists in Taiga — rebuilding story and tasks.`,
         );
-      for (const c of clustersNeedingTasks) {
-        const taskSubject = `${conciseError(c.errorSample)} — ${[...c.files].map((f: string) => path.basename(f)).join(', ')} (${c.tests.length} test${c.tests.length > 1 ? 's' : ''})`;
-        if (taiga && storyId) {
-          const { id: taskId, ref: taskRef } = await taiga.createTask(
-            storyId,
-            taskSubject,
-            clusterDescription(c),
+        storyId = undefined;
+        storyRef = undefined;
+        storyRecreated = true;
+        for (const key of Object.keys(state)) {
+          if (key.startsWith('file::')) {
+            delete state[key].taskId; // file tasks died with the story — rebuilt below
+            delete state[key].taskRef;
+          }
+        }
+      }
+
+      if (taiga && !storyId) {
+        const subject = `[release ${RELEASE}] Daily failures triage`;
+        const description = [
+          `Triage of daily test failures for release **${RELEASE}**.`,
+          '',
+          `Run date: ${today}`,
+          RUN_ID ? `Run: ${RUN_ID}` : '',
+          REPORT_URL ? `[HTML report](${REPORT_URL})` : '',
+          '',
+          'Each task below is one failure cluster (one root cause). Classify each as real bug or test to update.',
+          ...(changelog
+            ? [
+                '',
+                `**App changes since last triage (${changelog.total} commits, [compare](${changelog.compareUrl})):**`,
+                ...changelog.lines,
+              ]
+            : []),
+        ].join('\n');
+        const { id, ref } = await taiga.createUserStory(subject, description, [
+          ...storyTags,
+          releaseTag,
+        ]);
+        storyId = id;
+        storyRef = ref;
+        (state as any)[storyKey] = {
+          taigaId: id,
+          taigaRef: ref,
+          firstSeen: today,
+          lastSeen: today,
+          consecutiveRuns: 1,
+          seenInLastNRuns: [1],
+        };
+        console.log(`Created release user story #${ref} [${releaseTag}]`);
+        if (EPIC_REF) {
+          await taiga.linkStoryToEpic(await taiga.epicIdByRef(EPIC_REF), id);
+          console.log(`Linked story #${ref} under epic #${EPIC_REF}`);
+        }
+      } else if (!taiga) {
+        console.log(
+          `[dry-run] Would create/reuse release user story: [release ${RELEASE}] Daily failures triage [tags: ${[...storyTags, releaseTag].join(', ')}]${EPIC_REF ? ` under epic #${EPIC_REF}` : ''}`,
+        );
+      }
+
+      if (GROUP_BY === 'file') {
+        // One task per spec file, listing all its failing tests (from new clusters).
+        const byFile = new Map<string, Failure[]>();
+        for (const c of storyRecreated
+          ? [...newClusters, ...knownClusters]
+          : newClusters) {
+          for (const t of c.tests) {
+            byFile.set(t.file, [...(byFile.get(t.file) ?? []), t]);
+          }
+        }
+
+        for (const [file, tests] of byFile) {
+          const lines = tests.map(
+            (t) =>
+              `- \`${t.title}\`${t.qaseId ? ` (Qase: ${t.qaseId})` : ''}${t.retries ? ` — ${t.retries} retries` : ''}\n  \`\`\`\n  ${conciseError(t.error)}\n  \`\`\``,
           );
+          const fileKey = fileStateKey(file);
+          const fileEntry = state[fileKey]; // created above by the file-tracking block
+          const subject = `${path.basename(file)} — ${tests.length} failing test${tests.length > 1 ? 's' : ''}`;
+          if (taiga && storyId) {
+            if (fileEntry?.taskId) {
+              await taiga.commentTask(
+                fileEntry.taskId,
+                [`New failures on ${today}:`, ...lines].join('\n'),
+              );
+              if (fileEntry) fileEntry.subject = subject.slice(0, 120);
+              console.log(
+                `  ~ appended ${tests.length} test(s) to existing task for ${file}`,
+              );
+            } else {
+              const { id, ref } = await taiga.createTask(
+                storyId,
+                subject,
+                [
+                  `**Spec file:** \`${file}\``,
+                  '',
+                  `**Failing tests (${tests.length}):**`,
+                  ...lines,
+                  '',
+                  RUN_ID ? `Run: ${RUN_ID}` : '',
+                  REPORT_URL ? `[HTML report](${REPORT_URL})` : '',
+                ].join('\n'),
+              );
+              if (state[fileKey]) {
+                state[fileKey].taskId = id;
+                state[fileKey].taskRef = ref;
+                state[fileKey].subject = subject.slice(0, 120);
+                state[fileKey].taigaId = storyId;
+                state[fileKey].taigaRef = storyRef;
+              }
+              console.log(`  + task #${ref}: ${subject}`);
+            }
+          } else {
+            const qase = tests.map((t) => t.qaseId).filter(Boolean);
+            console.log(
+              `[dry-run]   + task: ${path.basename(file)} — ${tests.length} failing test(s)${qase.length ? ` [Qase: ${qase.join(', ')}]` : ''}`,
+            );
+          }
+        }
+        // Cluster fingerprints still track new/known/resolved against the release story.
+        for (const c of newClusters) {
           state[c.fingerprint].taigaId = storyId;
           state[c.fingerprint].taigaRef = storyRef;
-          state[c.fingerprint].taskId = taskId;
-          state[c.fingerprint].taskRef = taskRef;
-          state[c.fingerprint].subject = taskSubject.slice(0, 120);
-          console.log(`  + task #${taskRef}: ${taskSubject}`);
-        } else {
-          console.log(`[dry-run]   + task: ${taskSubject}`);
         }
-      }
-    }
-    if (taiga && storyId && knownClusters.length) {
-      await taiga.commentStory(
-        storyId,
-        `Re-run on ${today}: ${knownClusters.length} cluster(s) still failing, ${newClusters.length} new. Report: ${REPORT_URL}`,
-      );
-    }
-    // Team convention: closing a task (with a result comment) = TRIAGED.
-    // Known cluster + closed task -> acknowledged: reviewed, fix pending. No noise.
-    // Known cluster + open task   -> still needs triage.
-    if (taiga) {
-      for (const c of knownClusters) {
-        const e = state[c.fingerprint];
-        if (!e?.taskId) continue;
-        const st = await taiga.taskStatus(e.taskId);
-        if (st?.isClosed) acknowledged.set(c.fingerprint, 'triaged');
-      }
-      if (acknowledged.size)
-        console.log(
-          `${acknowledged.size} known cluster(s) already triaged (task closed).`,
-        );
-    }
-
-    if (taiga && storyId && changelog && !!storyState?.taigaId) {
-      // story pre-existed and the app changed since -> post the changelog as a comment
-      await taiga.commentStory(
-        storyId,
-        [
-          `App changed: \`${prevVersion!.version}\` -> \`${APP_VERSION}\` (${changelog.total} commits, [compare](${changelog.compareUrl}))`,
-          ...changelog.lines,
-        ].join('\n'),
-      );
-    }
-  } else {
-    // ----- Daily mode: one user story per cluster, one task per test -----
-    for (const c of newClusters) {
-      const subject = `[daily] ${conciseError(c.errorSample)} — ${[...c.files].map((f: string) => path.basename(f)).join(', ')} (${c.tests.length} test${c.tests.length > 1 ? 's' : ''})`;
-      const description = clusterDescription(c);
-      if (taiga) {
-        const { id, ref } = await taiga.createUserStory(
-          subject,
-          description,
-          storyTags,
-        );
-        state[c.fingerprint].taigaId = id;
-        state[c.fingerprint].taigaRef = ref;
-        console.log(`Created Taiga user story #${ref} for cluster ${c.fingerprint}`);
-        if (EPIC_REF)
-          await taiga.linkStoryToEpic(await taiga.epicIdByRef(EPIC_REF), id);
-        for (const t of c.tests) {
-          await taiga.createTask(
-            id,
-            `Review: ${t.title}`,
-            [
-              `File: \`${t.file}\``,
-              t.qaseId ? `Qase: ${t.qaseId}` : '',
-              t.retries ? `Retries: ${t.retries}` : '',
-              '```',
-              t.error,
-              '```',
-            ]
-              .filter(Boolean)
-              .join('\n'),
-          );
-        }
-        console.log(`  + ${c.tests.length} task(s) inside`);
       } else {
-        console.log(
-          `[dry-run] Would create user story: ${subject} [tags: ${storyTags.join(', ')}]`,
-        );
-        for (const t of c.tests)
-          console.log(`[dry-run]   + task: Review: ${t.title}`);
-      }
-    }
-
-    for (const c of knownClusters) {
-      const entry = state[c.fingerprint];
-      if (taiga && entry.taigaId) {
-        await taiga.commentStory(
-          entry.taigaId,
-          `Still failing on ${today} (${c.tests.length} tests, ${entry.consecutiveRuns} consecutive runs). Report: ${REPORT_URL}`,
-        );
-      }
-    }
-  }
-
-  // ----- Auto-close resolved tasks (error gone in the next triaged run) -----
-  if (taiga && resolvedInfo.length) {
-    const assigneeName = process.env.TAIGA_CLOSE_ASSIGNEE || 'qa.integrations.bot';
-    const statusName = process.env.TAIGA_CLOSED_STATUS || 'Closed';
-    let statusId: number | null = null;
-    let assigneeId: number | null = null;
-    try {
-      statusId = await taiga.taskStatusIdByName(statusName);
-      assigneeId = await taiga.userIdByUsername(assigneeName);
-      if (!statusId)
-        console.log(
-          `Auto-close skipped: task status "${statusName}" not found in project`,
-        );
-      if (!assigneeId)
-        console.log(
-          `Auto-close: user "${assigneeName}" not found in project — closing without reassigning`,
-        );
-    } catch (e) {
-      console.log(`Auto-close skipped: ${e instanceof Error ? e.message : e}`);
-    }
-    if (statusId) {
-      for (const r of resolvedInfo) {
-        if (!r.taskId) continue; // no own task recorded (file mode / pre-upgrade state) -> stays a manual candidate
-        try {
-          const st = await taiga.taskStatus(r.taskId);
-          if (st?.isClosed) {
-            // already triaged & closed by a human — just record the verification
-            await taiga.commentTask(
-              r.taskId,
-              `Verified by triage: not seen in the next triaged run (${today}).`,
+        const clustersNeedingTasks = storyRecreated
+          ? [...newClusters, ...knownClusters]
+          : newClusters;
+        if (storyRecreated && knownClusters.length)
+          console.log(
+            `Rebuilding tasks for ${knownClusters.length} known cluster(s) in the new story.`,
+          );
+        for (const c of clustersNeedingTasks) {
+          const taskSubject = `${conciseError(c.errorSample)} — ${[...c.files].map((f: string) => path.basename(f)).join(', ')} (${c.tests.length} test${c.tests.length > 1 ? 's' : ''})`;
+          if (taiga && storyId) {
+            const { id: taskId, ref: taskRef } = await taiga.createTask(
+              storyId,
+              taskSubject,
+              clusterDescription(c),
             );
+            state[c.fingerprint].taigaId = storyId;
+            state[c.fingerprint].taigaRef = storyRef;
+            state[c.fingerprint].taskId = taskId;
+            state[c.fingerprint].taskRef = taskRef;
+            state[c.fingerprint].subject = taskSubject.slice(0, 120);
+            console.log(`  + task #${taskRef}: ${taskSubject}`);
+          } else {
+            console.log(`[dry-run]   + task: ${taskSubject}`);
+          }
+        }
+      }
+      if (taiga && storyId && knownClusters.length) {
+        await taiga.commentStory(
+          storyId,
+          `Re-run on ${today}${RUN_ID ? ` (run ${RUN_ID})` : ''}: ${knownClusters.length} cluster(s) still failing, ${newClusters.length} new. Report: ${REPORT_URL}`,
+        );
+      }
+      // Team convention: closing a task (with a result comment) = TRIAGED.
+      // Known cluster + closed task -> acknowledged: reviewed, fix pending. No noise.
+      // Known cluster + open task   -> still needs triage.
+      if (taiga) {
+        for (const c of knownClusters) {
+          const e = state[c.fingerprint];
+          if (!e?.taskId) continue;
+          const st = await taiga.taskStatus(e.taskId);
+          if (st?.isClosed) acknowledged.set(c.fingerprint, 'triaged');
+        }
+        if (acknowledged.size)
+          console.log(
+            `${acknowledged.size} known cluster(s) already triaged (task closed).`,
+          );
+      }
+
+      if (taiga && storyId && changelog && !!storyState?.taigaId) {
+        // story pre-existed and the app changed since -> post the changelog as a comment
+        await taiga.commentStory(
+          storyId,
+          [
+            `App changed: \`${prevVersion!.version}\` -> \`${APP_VERSION}\` (${changelog.total} commits, [compare](${changelog.compareUrl}))`,
+            ...changelog.lines,
+          ].join('\n'),
+        );
+      }
+    } else {
+      // ----- Daily mode: one user story per cluster. One task per test, EXCEPT snapshot
+      // clusters (post-fingerprint-fix, a snapshot cluster = one spec file's worth of diffs,
+      // which are debugged together) get a single bundled task instead of N per-test ones.
+      for (const c of newClusters) {
+        const subject = `[daily] ${conciseError(c.errorSample)} — ${[...c.files].map((f: string) => path.basename(f)).join(', ')} (${c.tests.length} test${c.tests.length > 1 ? 's' : ''})`;
+        const description = clusterDescription(c);
+        const snapshotCluster = isSnapshotError(c.errorSample);
+        if (taiga) {
+          const { id, ref } = await taiga.createUserStory(
+            subject,
+            description,
+            storyTags,
+          );
+          state[c.fingerprint].taigaId = id;
+          state[c.fingerprint].taigaRef = ref;
+          console.log(
+            `Created Taiga user story #${ref} for cluster ${c.fingerprint}`,
+          );
+          if (EPIC_REF)
+            await taiga.linkStoryToEpic(await taiga.epicIdByRef(EPIC_REF), id);
+          const taskIds: number[] = [];
+          const taskRefs: number[] = [];
+          if (snapshotCluster) {
+            const { id: taskId, ref: taskRef } = await taiga.createTask(
+              id,
+              `${path.basename(c.tests[0].file)} — ${c.tests.length} screenshot diff${c.tests.length > 1 ? 's' : ''}`,
+              clusterDescription(c),
+            );
+            taskIds.push(taskId);
+            taskRefs.push(taskRef);
+          } else {
+            for (const t of c.tests) {
+              const { id: taskId, ref: taskRef } = await taiga.createTask(
+                id,
+                `Review: ${t.title}`,
+                [
+                  `File: \`${t.file}\``,
+                  t.qaseId ? `Qase: ${t.qaseId}` : '',
+                  t.retries ? `Retries: ${t.retries}` : '',
+                  '```',
+                  t.error,
+                  '```',
+                ]
+                  .filter(Boolean)
+                  .join('\n'),
+              );
+              taskIds.push(taskId);
+              taskRefs.push(taskRef);
+            }
+          }
+          state[c.fingerprint].taskIds = taskIds; // so auto-close can find and close every one of them
+          state[c.fingerprint].taskRefs = taskRefs;
+          console.log(`  + ${taskIds.length} task(s) inside`);
+        } else {
+          console.log(
+            `[dry-run] Would create user story: ${subject} [tags: ${storyTags.join(', ')}]`,
+          );
+          if (snapshotCluster) {
             console.log(
-              `Task #${r.taskRef} already closed (triaged) — added verification comment: ${r.subject ?? r.fp}`,
+              `[dry-run]   + task: ${path.basename(c.tests[0].file)} — ${c.tests.length} screenshot diff(s)`,
             );
           } else {
-            await taiga.closeTask(
-              r.taskId,
-              statusId,
-              assigneeId,
-              `Auto-closed by triage: not seen in the next triaged run (${today}).`,
-            );
-            console.log(
-              `Closed task #${r.taskRef}${assigneeId ? ` and assigned to ${assigneeName}` : ''}: ${r.subject ?? r.fp}`,
-            );
+            for (const t of c.tests)
+              console.log(`[dry-run]   + task: Review: ${t.title}`);
           }
-          r.closed = true;
-          delete state[r.fp]; // if it ever fails again it is a new cluster -> new task
-        } catch (e) {
-          console.log(
-            `Could not close task #${r.taskRef}: ${e instanceof Error ? e.message : e}`,
+        }
+      }
+
+      for (const c of knownClusters) {
+        const entry = state[c.fingerprint];
+        if (taiga && entry.taigaId) {
+          await taiga.commentStory(
+            entry.taigaId,
+            `Still failing on ${today}${RUN_ID ? ` (run ${RUN_ID})` : ''} (${c.tests.length} tests, ${entry.consecutiveRuns} consecutive runs). Report: ${REPORT_URL}`,
           );
         }
       }
     }
-  }
 
-  if (DRY_RUN) {
-    console.log(
-      '[dry-run] state NOT saved — dry runs leave no trace, so a later real run still sees these failures as new',
-    );
-  } else {
-    fs.mkdirSync(path.dirname(STATE_PATH), { recursive: true });
-    fs.writeFileSync(STATE_PATH, JSON.stringify(state, null, 2));
+    // ----- Auto-close resolved tasks (error gone in the next triaged run) -----
+    if (taiga && resolvedInfo.length) {
+      const assigneeName = process.env.TAIGA_CLOSE_ASSIGNEE || 'qa.integrations.bot';
+      const statusName = process.env.TAIGA_CLOSED_STATUS || 'Closed';
+      let statusId: number | null = null;
+      let assigneeId: number | null = null;
+      try {
+        statusId = await taiga.taskStatusIdByName(statusName);
+        assigneeId = await taiga.userIdByUsername(assigneeName);
+        if (!statusId)
+          console.log(
+            `Auto-close skipped: task status "${statusName}" not found in project`,
+          );
+        if (!assigneeId)
+          console.log(
+            `Auto-close: user "${assigneeName}" not found in project — closing without reassigning`,
+          );
+      } catch (e) {
+        console.log(`Auto-close skipped: ${e instanceof Error ? e.message : e}`);
+      }
+      if (statusId) {
+        for (const r of resolvedInfo) {
+          if (!r.taskIds.length) continue; // no own task recorded (pre-upgrade state) -> stays a manual candidate
+          let allOk = true;
+          // A resolved entry can carry several tasks (daily mode: one per test, or a bundled
+          // snapshot task) — close every one of them, not just the first.
+          for (let i = 0; i < r.taskIds.length; i++) {
+            const taskId = r.taskIds[i];
+            const taskRef = r.taskRefs[i];
+            try {
+              const st = await taiga.taskStatus(taskId);
+              if (st?.isClosed) {
+                // already triaged & closed by a human — just record the verification
+                await taiga.commentTask(
+                  taskId,
+                  `Verified by triage: not seen in the next triaged run (${today}).`,
+                );
+                console.log(
+                  `Task #${taskRef ?? taskId} already closed (triaged) — added verification comment: ${r.subject ?? r.fp}`,
+                );
+              } else {
+                await taiga.closeTask(
+                  taskId,
+                  statusId,
+                  assigneeId,
+                  `Auto-closed by triage: not seen in the next triaged run (${today}).`,
+                );
+                console.log(
+                  `Closed task #${taskRef ?? taskId}${assigneeId ? ` and assigned to ${assigneeName}` : ''}: ${r.subject ?? r.fp}`,
+                );
+              }
+            } catch (e) {
+              allOk = false;
+              console.log(
+                `Could not close task #${taskRef ?? taskId}: ${e instanceof Error ? e.message : e}`,
+              );
+            }
+          }
+          if (allOk) {
+            r.closed = true;
+            delete state[r.fp]; // if it ever fails again it is a new cluster -> new task
+          }
+        }
+      }
+    }
+  } finally {
+    // Runs even if the Taiga section above threw partway through — saves every id already
+    // created/closed so far instead of losing it.
+    if (DRY_RUN) {
+      console.log(
+        '[dry-run] state NOT saved — dry runs leave no trace, so a later real run still sees these failures as new',
+      );
+    } else {
+      fs.mkdirSync(path.dirname(STATE_PATH), { recursive: true });
+      fs.writeFileSync(STATE_PATH, JSON.stringify(state, null, 2));
+    }
   }
 
   // ----- Digest (markdown: stdout, job summary, and .triage/digest.md) -----
-  const digest: string[] = [`## Daily triage — ${today}`, ''];
+  const digest: string[] = [
+    `## Triage${RELEASE ? ` — release ${RELEASE}` : ' — daily'}${CLOSE_ONLY ? ' (close-only sweep)' : ''} — ${today}`,
+    '',
+  ];
   digest.push(
     `**${hardFailures.length} failures** in **${clusters.size} clusters** · ${flakyTests.length} flaky · ${resolved.length} resolved`,
   );
@@ -849,9 +1068,15 @@ async function main() {
       `App changes since last triage: **${changelog.total} commits** — [compare](${changelog.compareUrl})`,
     );
   }
+  if (RUN_ID) digest.push(`Run: \`${RUN_ID}\``);
   if (REPORT_URL) digest.push(`[Full HTML report](${REPORT_URL})`);
+  if (CLOSE_ONLY)
+    digest.push(
+      '',
+      `_--close-only sweep: nothing new was filed (${newClusters.length + knownClusters.length} cluster(s) left untouched for the next full triage)._`,
+    );
   digest.push('');
-  if (newClusters.length) {
+  if (newClusters.length && !CLOSE_ONLY) {
     digest.push(`### New clusters (${newClusters.length})`);
     for (const c of newClusters) {
       const entry = state[c.fingerprint];
@@ -861,7 +1086,7 @@ async function main() {
     }
     digest.push('');
   }
-  if (knownClusters.length) {
+  if (knownClusters.length && !CLOSE_ONLY) {
     digest.push(`### known clusters still failing (${knownClusters.length})`);
     for (const c of knownClusters) {
       const e = state[c.fingerprint];
@@ -877,10 +1102,12 @@ async function main() {
   if (resolvedInfo.length) {
     digest.push(`### resolved (gone next run)`);
     for (const r of resolvedInfo) {
-      const link = r.taskRef ? taigaTaskLink(r.taskRef) : taigaLink(r.storyRef);
+      const link = r.taskRefs.length
+        ? r.taskRefs.map((ref) => taigaTaskLink(ref)).join(', ')
+        : taigaLink(r.storyRef);
       const label = r.subject ? ` — \`${r.subject}\`` : '';
       digest.push(
-        `- ${link}${label}${r.closed ? ' → auto-closed & assigned' : r.taskId ? ' → pending auto-close' : ' → close manually (no task recorded)'}`,
+        `- ${link}${label}${r.closed ? ' → auto-closed & assigned' : r.taskIds.length ? ' → pending auto-close' : ' → close manually (no task recorded — run with --close-ref)'}`,
       );
     }
   }
@@ -894,9 +1121,9 @@ async function main() {
     ? ((state as any)['__release_story__'] as StateEntry | undefined)?.taigaRef
     : undefined;
   const mm: string[] = [];
-  const verdict = `**:mag: Triage${RELEASE ? ` release ${RELEASE}` : ''}** — ${newClusters.length} new · ${knownClusters.length} known${acknowledged.size ? ` (${acknowledged.size} triaged)` : ''} · ${resolved.length} resolved${releaseStoryRef ? ` · ${taigaLink(releaseStoryRef)}` : ''}${APP_VERSION ? `\napp \`${APP_VERSION}\`${versionChanged ? ` :warning: changed from \`${prevVersion!.version}\`${changelog ? ` ([${changelog.total} commits](${changelog.compareUrl}))` : ''}` : ''}` : ''}`;
+  const verdict = `**:mag: Triage${RELEASE ? ` release ${RELEASE}` : ''}${CLOSE_ONLY ? ' (close-only sweep)' : ''}** — ${CLOSE_ONLY ? `${newClusters.length + knownClusters.length} cluster(s) left untouched` : `${newClusters.length} new · ${knownClusters.length} known${acknowledged.size ? ` (${acknowledged.size} triaged)` : ''}`} · ${resolved.length} resolved${releaseStoryRef ? ` · ${taigaLink(releaseStoryRef)}` : ''}${APP_VERSION ? `\napp \`${APP_VERSION}\`${versionChanged ? ` :warning: changed from \`${prevVersion!.version}\`${changelog ? ` ([${changelog.total} commits](${changelog.compareUrl}))` : ''}` : ''}` : ''}`;
   mm.push(verdict);
-  if (newClusters.length) {
+  if (newClusters.length && !CLOSE_ONLY) {
     mm.push('', '**New:**');
     for (const c of newClusters) {
       mm.push(
@@ -910,17 +1137,17 @@ async function main() {
     if (closed.length)
       mm.push(
         '',
-        `**Auto-closed (gone next run):** ${closed.map((r) => taigaTaskLink(r.taskRef)).join(', ')}`,
+        `**Auto-closed (gone next run):** ${closed.map((r) => r.taskRefs.map((ref) => taigaTaskLink(ref)).join(', ')).join(', ')}`,
       );
     if (manual.length)
       mm.push(
         '',
-        `**Resolved — close manually:** ${manual.map((r) => (r.taskRef ? taigaTaskLink(r.taskRef) : taigaLink(r.storyRef))).join(', ')}`,
+        `**Resolved — close manually:** ${manual.map((r) => (r.taskRefs.length ? r.taskRefs.map((ref) => taigaTaskLink(ref)).join(', ') : taigaLink(r.storyRef))).join(', ')}`,
       );
   }
   mm.push(
     '',
-    `${hardFailures.length} failures · ${flakyTests.length} flaky${REPORT_URL ? ` · [HTML report](${REPORT_URL})` : ''}`,
+    `${hardFailures.length} failures · ${flakyTests.length} flaky${RUN_ID ? ` · run \`${RUN_ID}\`` : ''}${REPORT_URL ? ` · [HTML report](${REPORT_URL})` : ''}`,
   );
   const nothingChanged =
     newClusters.length === 0 && resolved.length === 0 && knownClusters.length > 0;
@@ -1089,6 +1316,7 @@ function clusterDescription(c: Cluster): string {
     c.errorSample,
     '```',
     '',
+    RUN_ID ? `Run: ${RUN_ID}` : '',
     REPORT_URL ? `[HTML report](${REPORT_URL})` : '',
     `_Cluster \`${c.fingerprint}\` — auto-created by daily triage. Classify: real bug vs test to update._`,
   ];


### PR DESCRIPTION
# Done Definition Checks

## Description

Fixes four triage-workflow issues plus their shared root cause, found while
digging into why auto-close wasn't reliable.

- **Multi Qase-ID tests weren't showing in "Qase IDs affected."** `qase([1234, 1235], ...)` renders as `(Qase ID: 1234,1235)`; the old regex stopped at the comma and kept only the first ID. Fixed extraction to capture the full list.
- **Snapshot failures spawned one task per diff instead of one per file.** Fingerprinting now clusters `toHaveScreenshot` failures strictly by spec file (error text — snapshot name, diff stats — is no longer part of the hash), and daily mode bundles a snapshot cluster into a single task instead of one per test.
- **Auto-close was silently broken in two of the three modes.** Only `group_by: cluster` ever recorded a task id in state; daily mode and `group_by: file` only tracked the story, so their tasks could never be found for closing. Both now track every task they create (`taskIds[]`/`taskRefs[]` for daily mode, per-file `file::` state entries for file mode), so auto-close works in all three.
- **New `--close-only` and `--close-ref` flags** to close resolved tasks without filing anything new: `--close-only` sweeps and closes via the normal detection, `--close-ref <ref>` force-closes specific tasks directly (for backlog from before this fix, or state loss).
- **Run ID / debug info.** New `--run-id` flag (or auto-parsed from `--report-url`), logged at start of every run and stamped into the digest, Taiga descriptions, and Mattermost. `release-triage.yml` now passes it through.
- **Reliability:** state is now saved in a `finally`, so a mid-run throw (Taiga 500, network blip) doesn't strand already-created tasks out of state and cause duplicates on the next run.
- Fixed a pre-existing bug where the digest header always said "Daily triage" even in release mode.

