### PR TITLE
refactor(triage): add close only flag

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -35,9 +35,9 @@ During **freeze week / release promotion**, once there's a scheduled daily PRE r
    - Parses the Playwright results and separates real failures from flaky tests (failed then passed on retry — flaky ones are counted in the digest but not filed).
    - **Clusters failures by root cause**, not by test: it normalizes each error message (strips timestamps, ids, line numbers, etc.) so the same underlying bug filed from different tests/runs hashes to the same cluster. Screenshot/visual-diff failures are clustered **strictly per spec file** instead — the error text (snapshot name, diff stats) is never part of that fingerprint, so every `toHaveScreenshot` failure in one file collapses into a single cluster/task no matter how many different diffs it covers.
    - Creates the release story in Taiga if it doesn't exist yet (subject `[release <tag>] Daily failures triage`, tagged `needs-triage` + `release-<tag>`, optionally linked under `epic_ref`).
-   - Adds **one task per new cluster** (or per file, if `group_by: file`) — see "What's in a task" below.
+   - Adds **one task per new cluster** (or per file with `group_by: file`, or per folder for screenshot failures with `group_by: folder` — functional bugs still get their own task) — see "What's in a task" below.
    - For clusters already known and still failing, comments on the story instead of creating a new task, so it doesn't spam duplicates.
-   - **Auto-closes tasks for clusters whose error is no longer seen in the next triaged run** — closed status, assigned to `qa.integrations.bot`, with a comment explaining why. If someone already closed the task manually (see "Triage convention" below), it just adds a verification comment instead. This tracks every task it creates (in both `group_by: cluster` and `group_by: file` mode) so nothing is silently un-closeable — see "Ad-hoc closing" below for sweeping a backlog or fixing a stray task by hand.
+   - **Auto-closes tasks for clusters whose error is no longer seen in the next triaged run** — closed status, assigned to `qa.integrations.bot`, with a comment explaining why. If someone already closed the task manually (see "Triage convention" below), it just adds a verification comment instead. This tracks every task it creates in all three `group_by` modes so nothing is silently un-closeable — see "Ad-hoc closing" below for sweeping a backlog or fixing a stray task by hand.
 5. **Saves the updated state** back to S3 so the next run knows what's open, closed, and how many consecutive runs each cluster has failed/passed. State is saved even if the run throws partway through (a Taiga hiccup, a network blip), so a failed run doesn't strand already-created tasks out of state and cause duplicates on the next run.
 6. **Posts a digest** (new clusters / still-failing clusters / resolved clusters, plus flaky count, run id, and app version) to the job summary and to Mattermost.
 
@@ -73,6 +73,8 @@ Each task represents one failure cluster and includes:
 
 In `group_by: file` mode, tasks are per spec file instead, listing every failing test in that file (Qase IDs appear inline per test rather than as a separate summary line).
 
+In `group_by: folder` mode, **screenshot/visual-diff failures** are bundled into one task per immediate parent folder (e.g. `dashboard/`), listing every affected spec file and its failing tests underneath — meant to be claimed as one unit of work when a shared cause (a viewport or theme change, say) invalidates snapshots across many files at once, so the update work can be split by folder without people stepping on each other. Repeated runs append newly-diffing files to the same folder task rather than opening a new one. **Functional (non-screenshot) failures are unaffected** — they still get their own one-task-per-cluster treatment, since each is a distinct bug rather than part of a shared visual cause.
+
 ### Triage convention
 
 **Closing a task in Taiga = "triaged" (reviewed, fix pending).** The workflow respects that: a known cluster with a closed task shows as "triaged" in the digest instead of "needs triage", so it doesn't keep nagging once someone's looked at it. It only gets reopened automatically if it starts failing again as a _new_ cluster later.
@@ -86,7 +88,7 @@ In `group_by: file` mode, tasks are per spec file instead, listing every failing
 | --------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `release_tag`   | ✅       | e.g. `2.17`. Taiga story gets tagged `release-2.17`.                                                                                               |
 | `report_run_id` | ❌       | Only set if you want to triage a specific run instead of the latest scheduled daily run.                                                           |
-| `group_by`      | ❌       | `cluster` (default) or `file` — controls task granularity in the story.                                                                            |
+| `group_by`      | ❌       | `cluster` (default), `file`, or `folder` — controls task granularity in the story. See "What's in a task" for what `folder` mode does.             |
 | `epic_ref`      | ❌       | Taiga epic number to link the story under.                                                                                                         |
 | `reset_state`   | ❌       | `true` to forget all prior triage state for this tag (treats every failure as new). **Delete the old Taiga story yourself first** if you use this. |
 | `close_only`    | ❌       | `true` to sweep and close resolved tasks only — files nothing new. Cannot be combined with `reset_state` (the run fails fast if both are ticked).  |

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -61,11 +61,13 @@ TAIGA_URL=... TAIGA_USERNAME=... TAIGA_PASSWORD=... TAIGA_PROJECT=... \
 
 Every run logs a one-line summary of its inputs (results path, state path, mode, run id, app version, flags) at the top of the job log. The run id of the `results.json` being triaged (the daily regression run, not the triage workflow's own run) is also stamped into the digest, Taiga story/task descriptions, and the Mattermost post, so it's always traceable back to its source without decoding the report URL.
 
+If the job log shows `⚠️ Fingerprint scheme changed since this state was last saved`, the script itself changed how it identifies a failure (e.g. a clustering fix) since the last run. To avoid mistaking "this failure's identity just changed" for "this is fixed," the run **skips auto-closing anything** that one time — still-failing clusters simply refile as "new" under their updated fingerprint, so dedupe the new task against the old one by hand. This self-resolves on the very next run; no action needed unless you also want to manually `--close-ref` any old entries you've confirmed are genuinely fixed (they're no longer auto-closeable once their fingerprint scheme is stale).
+
 ### What's in a task
 
 Each task represents one failure cluster and includes:
 
-- A one-line subject: the concise error + affected spec file(s) + test count, e.g. `expect(locator).toBeVisible() failed @ Cancel subscription — checkout.spec.ts (3 tests)`
+- A one-line subject: the first Qase ID among the cluster's tests (if any are tagged), then the concise error + affected spec file(s) + test count, e.g. `Qase 1234 — expect(locator).toBeVisible() failed @ Cancel subscription — checkout.spec.ts (3 tests)`
 - Spec files affected, and a **Qase IDs affected** summary line aggregating every Qase ID across the cluster's tests — including tests tagged with more than one ID (`qase([1234, 1235], ...)`), which are listed in full rather than truncated to the first
 - The full list of failing tests in that cluster, each with its own Qase ID(s) (if tagged) and retry count
 - The raw error for the cluster

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -45,10 +45,17 @@ During **freeze week / release promotion**, once there's a scheduled daily PRE r
 
 ### Ad-hoc closing
 
-Two flags let you close resolved tasks without running (and filing) a full triage:
+Two ways to close resolved tasks without filing a full triage:
 
-- `--close-only` — runs the normal parse → cluster → detect-resolved pipeline but skips creating any new story/task; it only sweeps and closes tasks whose error is no longer present in the given `results.json`. Writes `.triage/digest.md` as usual (a trimmed version: what got closed, nothing about "new"/"known" since nothing was filed). Useful for clearing a backlog of resolved tasks on demand.
-- `--close-ref <taskRef> [--close-ref <taskRef> ...]` — force-closes specific Taiga tasks by their visible ref number (`#1234`), bypassing `results.json`/state entirely. Escape hatch for one-off closes or tasks that predate this tracking (e.g. old `group_by: file` tasks created before per-file tracking existed). Purely a manual CLI action: it does **not** write `.triage/digest.md` or post to Mattermost, so don't wire it into a step that `cat`s the digest afterward expecting fresh output.
+- **`close_only` workflow input** — tick it when running "Report triage" from the Actions tab. Runs the same pipeline (finds the report, pulls state) but skips creating any new story/task; it only sweeps and closes tasks whose error is no longer present in the given run. Do not combine with `reset_state` — the workflow rejects that combination outright, since resetting state right before a close-only sweep would wipe out the very data it needs to know what's resolved.
+- **`--close-ref <taskRef> [--close-ref <taskRef> ...]`** — CLI only (not wired into the workflow), force-closes specific Taiga tasks by their visible ref number (`#1234`), bypassing `results.json`/state entirely. Escape hatch for one-off closes or tasks that predate this tracking (e.g. old `group_by: file` tasks created before per-file tracking existed). Does **not** write `.triage/digest.md` or post to Mattermost.
+
+Running `--close-only` by hand from a checkout works the same way, with the same Taiga env vars as the scheduled workflow:
+
+```bash
+TAIGA_URL=... TAIGA_USERNAME=... TAIGA_PASSWORD=... TAIGA_PROJECT=... \
+  npx tsx scripts/triage.ts --results results.json --state .triage/state.json --close-only
+```
 
 ### Debugging a run
 
@@ -82,6 +89,7 @@ In `group_by: file` mode, tasks are per spec file instead, listing every failing
 | `group_by`      | ❌       | `cluster` (default) or `file` — controls task granularity in the story.                                                                            |
 | `epic_ref`      | ❌       | Taiga epic number to link the story under.                                                                                                         |
 | `reset_state`   | ❌       | `true` to forget all prior triage state for this tag (treats every failure as new). **Delete the old Taiga story yourself first** if you use this. |
+| `close_only`    | ❌       | `true` to sweep and close resolved tasks only — files nothing new. Cannot be combined with `reset_state` (the run fails fast if both are ticked).  |
 
 ### Good to know
 

--- a/.github/workflows/release-triage.yml
+++ b/.github/workflows/release-triage.yml
@@ -19,13 +19,14 @@ on:
         description: 'Override: specific run id to triage (default: last scheduled daily run on main)'
         required: false
       group_by:
-        description: 'Task granularity inside the release story'
+        description: 'Task granularity inside the release story. folder: snapshot failures bundled per immediate parent folder (claimable per-folder for splitting snapshot-update work); functional bugs stay one-per-cluster'
         required: false
         default: 'cluster'
         type: choice
         options:
           - cluster
           - file
+          - folder
       epic_ref:
         description: 'Optional: Taiga epic ref (number only, e.g. 118) to link the story under'
         required: false

--- a/.github/workflows/release-triage.yml
+++ b/.github/workflows/release-triage.yml
@@ -5,6 +5,7 @@
 # Creates ONE Taiga user story tagged "release-<tag>" containing one task
 # per failure cluster. Re-running with the same tag adds only NEW clusters
 # to the SAME story (no duplicates) thanks to the per-release state file.
+# Tick close_only to sweep and close resolved tasks instead, without filing anything new.
 
 name: Report triage
 
@@ -33,6 +34,11 @@ on:
         required: false
         default: false
         type: boolean
+      close_only:
+        description: 'Close-only sweep: close tasks whose error is no longer failing — files nothing new. Do not combine with reset_state.'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -43,6 +49,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: PRE # grants access to MATTERMOST_WEBHOOK_DAILY_REPORT (environment secret)
     steps:
+      - name: Reject reset_state + close_only together
+        if: ${{ inputs.reset_state == true && inputs.close_only == true }}
+        run: |
+          echo "reset_state wipes triage state right before close_only would need it to find what's resolved — pick one." >&2
+          exit 1
+
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
@@ -105,6 +117,11 @@ jobs:
 
       - name: Run report triage
         run: |
+          CLOSE_ONLY_FLAG=""
+          if [ "${{ inputs.close_only }}" = "true" ]; then
+            CLOSE_ONLY_FLAG="--close-only"
+            echo "Close-only sweep: closing resolved tasks, filing nothing new."
+          fi
           npx tsx scripts/triage.ts \
             --results results.json \
             --state .triage/state.json \
@@ -113,7 +130,8 @@ jobs:
             --epic-ref "${{ inputs.epic_ref }}" \
             --app-version "${{ steps.appver.outputs.version }}" \
             --run-id "${{ steps.report.outputs.run_id }}" \
-            --report-url "https://kaleidos-qa-reports.s3.eu-west-1.amazonaws.com/run-${{ steps.report.outputs.run_id }}/index.html"
+            --report-url "https://kaleidos-qa-reports.s3.eu-west-1.amazonaws.com/run-${{ steps.report.outputs.run_id }}/index.html" \
+            $CLOSE_ONLY_FLAG
         env:
           GITHUB_TOKEN: ${{ github.token }} # raises GitHub API rate limit for the app-repo changelog fetch
           # APP_REPO: penpot/penpot                            # default; override if the app repo moves

--- a/scripts/triage.ts
+++ b/scripts/triage.ts
@@ -207,6 +207,8 @@ function isSnapshotError(msg: string): boolean {
   );
 }
 
+// Changing this function's output for any input that used to hash differently requires bumping
+// FINGERPRINT_SCHEMA_VERSION below — see there for why.
 function fingerprint(fail: Failure): string {
   // Hybrid clustering:
   // - snapshot/visual errors: per spec file, full stop. The error message carries
@@ -221,6 +223,15 @@ function fingerprint(fail: Failure): string {
     : `${normalizeError(fail.error)}|${locatorKey(fail.error)}`;
   return crypto.createHash('sha1').update(basis).digest('hex').slice(0, 12);
 }
+
+// Bump whenever fingerprint(), normalizeError(), or locatorKey() changes what hash an existing
+// failure produces. Resolved-detection treats fingerprint absence as "fixed" — a silent hash
+// change makes every previously-tracked cluster look resolved and auto-closes it, whether or not
+// anything was actually fixed. This happened for real: v1 -> v2 dropped the error text from the
+// snapshot basis (keying on file alone), and every already-tracked screenshot task got wrongly
+// closed on the first run after that shipped. The version-gate in main() is the fix — it skips
+// resolved-detection for one run when this doesn't match the state file's recorded version.
+const FINGERPRINT_SCHEMA_VERSION = 2;
 
 /** Locator with dynamic fragments neutralized but quoted text preserved. */
 function locatorKey(msg: string): string {
@@ -484,9 +495,6 @@ class Taiga {
 // ---------- Main ----------
 
 async function main() {
-  // --close-ref: force-close specific task refs directly, bypassing results.json/state/clustering
-  // entirely. Escape hatch for tasks this script has no other way to find (orphaned before the
-  // per-file/per-test tracking below existed, or any other one-off manual close).
   if (CLOSE_REFS.length) {
     console.log(
       `[close-ref] Closing ${CLOSE_REFS.length} task(s) directly: ${CLOSE_REFS.join(', ')}`,
@@ -543,6 +551,22 @@ async function main() {
     ? JSON.parse(fs.readFileSync(STATE_PATH, 'utf8'))
     : {};
 
+  // Missing version = state predates this check entirely (schema v1, the original scheme).
+  const storedFingerprintVersion = (state as any)['__fingerprint_version__'] ?? 1;
+  const fingerprintSchemaChanged =
+    storedFingerprintVersion !== FINGERPRINT_SCHEMA_VERSION;
+  if (fingerprintSchemaChanged) {
+    console.log(
+      `⚠️  Fingerprint scheme changed since this state was last saved (v${storedFingerprintVersion} -> v${FINGERPRINT_SCHEMA_VERSION}). ` +
+        `Skipping resolved-detection for this run only, so tasks whose identity just changed aren't ` +
+        `mistaken for fixed and auto-closed. Still-failing clusters will refile as "new" under their ` +
+        `updated fingerprint — dedupe against the old task by hand. Genuinely-resolved old entries ` +
+        `won't be auto-closeable anymore; close them with --close-ref once confirmed.`,
+    );
+  }
+  if (!DRY_RUN)
+    (state as any)['__fingerprint_version__'] = FINGERPRINT_SCHEMA_VERSION;
+
   const today = new Date().toISOString().slice(0, 10);
 
   // ----- App version tracking -----
@@ -596,7 +620,8 @@ async function main() {
       state[fp].consecutiveRuns = 0;
       if (
         state[fp].seenInLastNRuns.slice(0, 1).every((x) => x === 0) &&
-        state[fp].taigaRef
+        state[fp].taigaRef &&
+        !fingerprintSchemaChanged
       ) {
         resolved.push(fp); // gone in the next run -> candidate for closing
       }
@@ -842,7 +867,7 @@ async function main() {
           );
           const fileKey = fileStateKey(file);
           const fileEntry = state[fileKey]; // created above by the file-tracking block
-          const subject = `${path.basename(file)} — ${tests.length} failing test${tests.length > 1 ? 's' : ''}`;
+          const subject = `${qaseSubjectPrefix(tests)}${path.basename(file)} — ${tests.length} failing test${tests.length > 1 ? 's' : ''}`;
           if (taiga && storyId) {
             if (fileEntry?.taskId) {
               await taiga.commentTask(
@@ -877,9 +902,8 @@ async function main() {
               console.log(`  + task #${ref}: ${subject}`);
             }
           } else {
-            const qase = tests.map((t) => t.qaseId).filter(Boolean);
             console.log(
-              `[dry-run]   + task: ${path.basename(file)} — ${tests.length} failing test(s)${qase.length ? ` [Qase: ${qase.join(', ')}]` : ''}`,
+              `[dry-run]   + task: ${qaseSubjectPrefix(tests)}${path.basename(file)} — ${tests.length} failing test(s)`,
             );
           }
         }
@@ -907,7 +931,7 @@ async function main() {
           );
 
         for (const c of functionalClusters) {
-          const taskSubject = `${conciseError(c.errorSample)} — ${[...c.files].map((f: string) => path.basename(f)).join(', ')} (${c.tests.length} test${c.tests.length > 1 ? 's' : ''})`;
+          const taskSubject = `${qaseSubjectPrefix(c.tests)}${conciseError(c.errorSample)} — ${[...c.files].map((f: string) => path.basename(f)).join(', ')} (${c.tests.length} test${c.tests.length > 1 ? 's' : ''})`;
           if (taiga && storyId) {
             const { id: taskId, ref: taskRef } = await taiga.createTask(
               storyId,
@@ -947,7 +971,7 @@ async function main() {
           );
           const folderKey = folderStateKey(folder);
           const folderEntry = state[folderKey]; // created above by the folder-tracking block
-          const subject = `${folder}/ — ${tests.length} screenshot diff${tests.length > 1 ? 's' : ''} across ${byFile.size} file${byFile.size > 1 ? 's' : ''}`;
+          const subject = `${qaseSubjectPrefix(tests)}${folder}/ — ${tests.length} screenshot diff${tests.length > 1 ? 's' : ''} across ${byFile.size} file${byFile.size > 1 ? 's' : ''}`;
           if (taiga && storyId) {
             if (folderEntry?.taskId) {
               await taiga.commentTask(
@@ -1004,7 +1028,7 @@ async function main() {
             `Rebuilding tasks for ${knownClusters.length} known cluster(s) in the new story.`,
           );
         for (const c of clustersNeedingTasks) {
-          const taskSubject = `${conciseError(c.errorSample)} — ${[...c.files].map((f: string) => path.basename(f)).join(', ')} (${c.tests.length} test${c.tests.length > 1 ? 's' : ''})`;
+          const taskSubject = `${qaseSubjectPrefix(c.tests)}${conciseError(c.errorSample)} — ${[...c.files].map((f: string) => path.basename(f)).join(', ')} (${c.tests.length} test${c.tests.length > 1 ? 's' : ''})`;
           if (taiga && storyId) {
             const { id: taskId, ref: taskRef } = await taiga.createTask(
               storyId,
@@ -1080,7 +1104,7 @@ async function main() {
           if (snapshotCluster) {
             const { id: taskId, ref: taskRef } = await taiga.createTask(
               id,
-              `${path.basename(c.tests[0].file)} — ${c.tests.length} screenshot diff${c.tests.length > 1 ? 's' : ''}`,
+              `${qaseSubjectPrefix(c.tests)}${path.basename(c.tests[0].file)} — ${c.tests.length} screenshot diff${c.tests.length > 1 ? 's' : ''}`,
               clusterDescription(c),
             );
             taskIds.push(taskId);
@@ -1114,7 +1138,7 @@ async function main() {
           );
           if (snapshotCluster) {
             console.log(
-              `[dry-run]   + task: ${path.basename(c.tests[0].file)} — ${c.tests.length} screenshot diff(s)`,
+              `[dry-run]   + task: ${qaseSubjectPrefix(c.tests)}${path.basename(c.tests[0].file)} — ${c.tests.length} screenshot diff(s)`,
             );
           } else {
             for (const t of c.tests)
@@ -1343,6 +1367,17 @@ function shortError(msg: string): string {
 function qaseList(c: Cluster): string {
   const ids = c.tests.map((t) => t.qaseId).filter(Boolean);
   return ids.length ? ` [Qase: ${ids.join(', ')}]` : '';
+}
+
+/**
+ * First Qase ID among a set of failing tests, to prepend to a task subject that bundles several
+ * tests — so a Taiga task list is scannable for "which Qase case is this" without opening each
+ * one. The existing "(N tests)"-style count elsewhere in the same subject already covers how many
+ * others are failing, so this deliberately doesn't repeat that count.
+ */
+function qaseSubjectPrefix(tests: Failure[]): string {
+  const first = tests.map((t) => t.qaseId).find(Boolean);
+  return first ? `Qase ${first} — ` : '';
 }
 
 /**

--- a/scripts/triage.ts
+++ b/scripts/triage.ts
@@ -45,7 +45,7 @@ const RESULTS_PATH = arg('results', 'playwright-report/results.json');
 const STATE_PATH = arg('state', '.triage/state.json');
 const REPORT_URL = arg('report-url', '');
 const RELEASE = arg('release', ''); // e.g. "2.17" -> single story tagged release-2.17 with one task per cluster
-const GROUP_BY = arg('group-by', 'cluster'); // release-mode tasks: 'cluster' (one per root cause) or 'file' (one per spec file)
+const GROUP_BY = arg('group-by', 'cluster'); // release-mode tasks: 'cluster' (one per root cause), 'file' (one per spec file), or 'folder' (one per immediate parent folder, snapshot failures only — functional clusters stay one-per-cluster)
 const EPIC_REF = arg('epic-ref', ''); // optional: Taiga epic ref (#number) to link created stories under
 const APP_VERSION = arg('app-version', ''); // optional: deployed app version this report ran against
 // Debug: which run's results.json this triage was executed over. Falls back to parsing it out of
@@ -586,7 +586,8 @@ async function main() {
     }
   }
   for (const fp of Object.keys(state)) {
-    if (fp.startsWith('__') || fp.startsWith('file::')) continue; // internal bookkeeping / per-file tracking (below), not a cluster
+    if (fp.startsWith('__') || fp.startsWith('file::') || fp.startsWith('folder::'))
+      continue; // internal bookkeeping / per-file / per-folder tracking (below), not a cluster
     if (!clusters.has(fp)) {
       state[fp].seenInLastNRuns = [0, ...(state[fp].seenInLastNRuns ?? [])].slice(
         0,
@@ -645,6 +646,56 @@ async function main() {
           state[key].taskId
         ) {
           resolved.push(key); // file has no failing tests in this run -> candidate for closing
+        }
+      }
+    }
+  }
+
+  // ----- Release + group-by=folder: same idea as file-mode, but scoped to snapshot/visual-diff
+  // failures only, bucketed by immediate parent folder — the "claim this and update snapshots"
+  // unit when one shared cause (e.g. a viewport change) invalidates screenshots across many spec
+  // files at once. Functional (non-snapshot) clusters are untouched by this block — they keep
+  // one-task-per-cluster treatment below, since each is a distinct bug, not a shared visual cause.
+  const folderStateKey = (folder: string) => `folder::${folder}`;
+  if (RELEASE && GROUP_BY === 'folder') {
+    const failingFolders = new Set<string>();
+    for (const c of clusters.values()) {
+      if (!isSnapshotError(c.errorSample)) continue;
+      for (const t of c.tests) failingFolders.add(path.dirname(t.file));
+    }
+
+    for (const folder of failingFolders) {
+      const key = folderStateKey(folder);
+      if (state[key]) {
+        state[key].lastSeen = today;
+        state[key].consecutiveRuns = (state[key].consecutiveRuns ?? 0) + 1;
+        state[key].seenInLastNRuns = [
+          1,
+          ...(state[key].seenInLastNRuns ?? []),
+        ].slice(0, 10);
+      } else {
+        state[key] = {
+          firstSeen: today,
+          lastSeen: today,
+          consecutiveRuns: 1,
+          seenInLastNRuns: [1],
+        };
+      }
+    }
+    for (const key of Object.keys(state)) {
+      if (!key.startsWith('folder::')) continue;
+      const folder = key.slice('folder::'.length);
+      if (!failingFolders.has(folder)) {
+        state[key].seenInLastNRuns = [
+          0,
+          ...(state[key].seenInLastNRuns ?? []),
+        ].slice(0, 10);
+        state[key].consecutiveRuns = 0;
+        if (
+          state[key].seenInLastNRuns.slice(0, 1).every((x) => x === 0) &&
+          state[key].taskId
+        ) {
+          resolved.push(key); // folder has no failing snapshot tests in this run -> candidate for closing
         }
       }
     }
@@ -723,8 +774,8 @@ async function main() {
         storyRef = undefined;
         storyRecreated = true;
         for (const key of Object.keys(state)) {
-          if (key.startsWith('file::')) {
-            delete state[key].taskId; // file tasks died with the story — rebuilt below
+          if (key.startsWith('file::') || key.startsWith('folder::')) {
+            delete state[key].taskId; // file/folder tasks died with the story — rebuilt below
             delete state[key].taskRef;
           }
         }
@@ -836,6 +887,113 @@ async function main() {
         for (const c of newClusters) {
           state[c.fingerprint].taigaId = storyId;
           state[c.fingerprint].taigaRef = storyRef;
+        }
+      } else if (GROUP_BY === 'folder') {
+        // Snapshot clusters get bundled by immediate parent folder (one claimable task covering
+        // every spec file in it); functional clusters keep the usual one-task-per-cluster treatment,
+        // since they're distinct bugs rather than a shared visual cause.
+        const clustersInScope = storyRecreated
+          ? [...newClusters, ...knownClusters]
+          : newClusters;
+        const snapshotClusters = clustersInScope.filter((c) =>
+          isSnapshotError(c.errorSample),
+        );
+        const functionalClusters = clustersInScope.filter(
+          (c) => !isSnapshotError(c.errorSample),
+        );
+        if (storyRecreated && knownClusters.length)
+          console.log(
+            `Rebuilding tasks for ${knownClusters.length} known cluster(s) in the new story.`,
+          );
+
+        for (const c of functionalClusters) {
+          const taskSubject = `${conciseError(c.errorSample)} — ${[...c.files].map((f: string) => path.basename(f)).join(', ')} (${c.tests.length} test${c.tests.length > 1 ? 's' : ''})`;
+          if (taiga && storyId) {
+            const { id: taskId, ref: taskRef } = await taiga.createTask(
+              storyId,
+              taskSubject,
+              clusterDescription(c),
+            );
+            state[c.fingerprint].taigaId = storyId;
+            state[c.fingerprint].taigaRef = storyRef;
+            state[c.fingerprint].taskId = taskId;
+            state[c.fingerprint].taskRef = taskRef;
+            state[c.fingerprint].subject = taskSubject.slice(0, 120);
+            console.log(`  + task #${taskRef}: ${taskSubject}`);
+          } else {
+            console.log(`[dry-run]   + task: ${taskSubject}`);
+          }
+        }
+
+        const byFolder = new Map<string, Failure[]>();
+        for (const c of snapshotClusters) {
+          for (const t of c.tests) {
+            const folder = path.dirname(t.file);
+            byFolder.set(folder, [...(byFolder.get(folder) ?? []), t]);
+          }
+        }
+        for (const [folder, tests] of byFolder) {
+          const byFile = new Map<string, Failure[]>();
+          for (const t of tests)
+            byFile.set(t.file, [...(byFile.get(t.file) ?? []), t]);
+          const fileSections = [...byFile.entries()].map(
+            ([file, fileTests]) =>
+              `**${path.basename(file)}** (${fileTests.length}):\n` +
+              fileTests
+                .map(
+                  (t) => `- \`${t.title}\`${t.qaseId ? ` (Qase: ${t.qaseId})` : ''}`,
+                )
+                .join('\n'),
+          );
+          const folderKey = folderStateKey(folder);
+          const folderEntry = state[folderKey]; // created above by the folder-tracking block
+          const subject = `${folder}/ — ${tests.length} screenshot diff${tests.length > 1 ? 's' : ''} across ${byFile.size} file${byFile.size > 1 ? 's' : ''}`;
+          if (taiga && storyId) {
+            if (folderEntry?.taskId) {
+              await taiga.commentTask(
+                folderEntry.taskId,
+                [`New/updated diffs on ${today}:`, ...fileSections].join('\n\n'),
+              );
+              if (folderEntry) folderEntry.subject = subject.slice(0, 120);
+              console.log(
+                `  ~ appended ${tests.length} test(s) to existing folder task for ${folder}/`,
+              );
+            } else {
+              const { id, ref } = await taiga.createTask(
+                storyId,
+                subject,
+                [
+                  `**Folder:** \`${folder}/\``,
+                  '',
+                  `Screenshot diffs across ${byFile.size} spec file${byFile.size > 1 ? 's' : ''} — claim this task to update snapshots for the whole folder.`,
+                  '',
+                  ...fileSections,
+                  '',
+                  RUN_ID ? `Run: ${RUN_ID}` : '',
+                  REPORT_URL ? `[HTML report](${REPORT_URL})` : '',
+                ].join('\n'),
+              );
+              if (state[folderKey]) {
+                state[folderKey].taskId = id;
+                state[folderKey].taskRef = ref;
+                state[folderKey].subject = subject.slice(0, 120);
+                state[folderKey].taigaId = storyId;
+                state[folderKey].taigaRef = storyRef;
+              }
+              console.log(`  + task #${ref}: ${subject}`);
+            }
+          } else {
+            console.log(`[dry-run]   + task: ${subject}`);
+          }
+        }
+        // Cluster fingerprints still track new/known/resolved against the release story. Functional
+        // clusters already got their own taigaId/taigaRef above; snapshot clusters need the same
+        // fallback link (their real task lives under folder::, not their own fingerprint).
+        for (const c of newClusters) {
+          if (isSnapshotError(c.errorSample)) {
+            state[c.fingerprint].taigaId = storyId;
+            state[c.fingerprint].taigaRef = storyRef;
+          }
         }
       } else {
         const clustersNeedingTasks = storyRecreated


### PR DESCRIPTION
# Done Definition Checks

## Description

Triage workflow fixes and features, prompted by digging into why auto-close
wasn't reliable and by two follow-up requests (folder-level snapshot
grouping, visible Qase IDs on task subjects).

**Bug fixes**
- Multi Qase-ID tests (`qase([1234, 1235], ...)`) were truncated to the first
  ID everywhere they're displayed — fixed the extraction regex to capture
  the full list.
- Snapshot/`toHaveScreenshot` failures now cluster **strictly per spec
  file** (error text — snapshot name, diff stats — is no longer part of the
  fingerprint), so a file with several different diffs gets one task
  instead of one per diff. Daily mode bundles them into a single task too,
  instead of one per test.
- **Auto-close was silently broken in two of three modes.** Only
  `group_by: cluster` ever recorded a task id in state; daily mode and
  `group_by: file` tasks were never linked back, so they could never be
  found for closing. Both now track every task they create.
- Digest header always said "Daily triage" even in release mode — now
  reflects the actual mode/release tag.
- **Reliability:** state is saved in a `finally`, so a mid-run throw
  doesn't strand already-created tasks out of state (which risked
  duplicates on the next run).

**New capabilities**
- `--close-only` (and a `close_only` workflow input, guarded against
  combining with `reset_state`) — sweeps and closes resolved tasks without
  filing anything new.
- `--close-ref <ref>` — force-closes specific Taiga tasks directly, for
  backlog from before this fix or state loss.
- `--run-id` (or auto-parsed from `--report-url`) — logged at the start of
  every run and stamped into the digest, Taiga descriptions, and
  Mattermost.
- `--group-by folder` — screenshot failures across many spec files in the
  same folder get bundled into **one claimable task per folder** (for
  splitting mass snapshot-update work, e.g. after a viewport change).
  Functional bugs are untouched by this — they keep one task per cluster.
- Task subjects now lead with `Qase <first ID> —` when any test in the
  bundle is tagged, so a Taiga task list is scannable without opening each
  one.

**Found and fixed during testing:** a fingerprint-hash change (part of the
snapshot-clustering fix above) caused an already-tracked screenshot task to
get wrongly auto-closed, because its identity changed but the underlying
failure hadn't stopped. Added `FINGERPRINT_SCHEMA_VERSION` — the script now
detects when its own hashing scheme changed since the state file was last
saved and skips auto-close for one run instead of silently treating
everything under the old scheme as resolved.

## Docs

`.github/workflows/README.md` updated throughout to match: corrected task
subject/content examples, documented `folder` mode, `close_only`/
`--close-ref`, and what the `⚠️ Fingerprint scheme changed` warning means if
it's ever seen in a job log.


