### PR TITLE
fix(tests): fix a direct error (717) and potentially other flakies when downloading files

### DIFF
--- a/pages/dashboard/dashboard-page.js
+++ b/pages/dashboard/dashboard-page.js
@@ -528,18 +528,22 @@ exports.DashboardPage = class DashboardPage extends BasePage {
 
   async downloadFileViaRightClick() {
     await this.fileTile.click({ button: 'right' });
-    await this.downloadFilePenpotMenuItem.click();
 
-    await this.page.waitForEvent('download');
+    await Promise.all([
+      this.page.waitForEvent('download'),
+      this.downloadFilePenpotMenuItem.click(),
+    ]);
     await expect(this.downloadFileTickIcon).toBeVisible();
     await this.downloadFileCloseButton.click();
   }
 
   async downloadFileViaOptionsIcon() {
     await this.clickOnFileOptions();
-    await this.downloadFilePenpotMenuItem.click();
 
-    await this.page.waitForEvent('download');
+    await Promise.all([
+      this.page.waitForEvent('download'),
+      this.downloadFilePenpotMenuItem.click(),
+    ]);
     await expect(this.downloadFileTickIcon).toBeVisible();
     await this.downloadFileCloseButton.click();
   }

--- a/pages/workspace/design-panel-page.js
+++ b/pages/workspace/design-panel-page.js
@@ -1430,8 +1430,8 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
   }
 
   async clickExportElementButton(page) {
-    await this.exportElementButton.click();
-    await page.waitForEvent('download');
+    page.waitForEvent('download');
+    this.exportElementButton.click();
   }
 
   async clickAddGuidesButton() {

--- a/pages/workspace/main-page.js
+++ b/pages/workspace/main-page.js
@@ -851,8 +851,10 @@ exports.MainPage = class MainPage extends BasePage {
   }
 
   async downloadPenpotFileViaMenu() {
-    await this.downloadPenpotFileMenuSubItem.click();
-    await this.page.waitForEvent('download');
+    await Promise.all([
+      this.page.waitForEvent('download'),
+      this.downloadPenpotFileMenuSubItem.click(),
+    ]);
     await expect(this.downloadFileTickIcon).toBeVisible();
     await this.downloadFileCloseButton.click();
   }
@@ -861,8 +863,10 @@ exports.MainPage = class MainPage extends BasePage {
     await this.exportBoardsAsPDFFileMenuSubItem.click();
     await expect(this.exportAsPDFModalTitle).toBeVisible();
     await expect(this.exportAsPDFModalButton).toBeVisible();
-    await this.exportAsPDFModalButton.click();
-    await this.page.waitForEvent('download');
+    await Promise.all([
+      this.page.waitForEvent('download'),
+      this.exportAsPDFModalButton.click(),
+    ]);
     await expect(this.exportAsPDFCompleteToastText).toBeVisible();
     await expect(this.page.getByText(`${numBoards} / ${numBoards}`)).toBeVisible();
   }

--- a/pages/workspace/tokens/tools-component.ts
+++ b/pages/workspace/tokens/tools-component.ts
@@ -112,8 +112,10 @@ export class ToolsComponent {
   }
 
   async exportToken() {
-    await this.confirmExportButton.click();
-    await this.page.waitForEvent('download');
+    await Promise.all([
+      this.page.waitForEvent('download'),
+      this.confirmExportButton.click(),
+    ]);
   }
 
   async checkExportFileItemCount(expectedCount: number) {


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

_If relevant, include the Taiga URL_
[Taiga Ticket: 2165](https://tree.taiga.io/project/kaleidos-qa/task/2165)

## Description

This PR resolves Qase ID 717, which doesn't receive the download event after clicking to export the file.
It also propagates the same fix in other occurrences to avoid this problem from happening.

_What problem are you trying to solve?_

The problem is that the test is registering its listener after `this.exportElementButton.click()` has already resolved, potentially triggering the download. 
If the download fires fast enough, the event listener isn't attached yet and the wait times out. 

It's explained more on this [website](https://tally-b.medium.com/the-illustrated-guide-to-using-promise-all-in-playwright-tests-af7a98af3f32). 

## Solution

The fix is to start waiting for the event before triggering the click, using `Promise.all`.

`Promise.all([a, b])` evaluates a and b left-to-right synchronously before awaiting either.

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots
- [ ] The tests run OK

## Screenshots 📸 (optional)

<img width="891" height="404" alt="image" src="https://github.com/user-attachments/assets/f6c1f100-b3e3-4c87-bc51-090c8a371d1d" />

## Anything Else? (optional)

The other 28 tests affected by the same change have been executed locally, with just a non-related failure.

<img width="791" height="175" alt="image" src="https://github.com/user-attachments/assets/85fb0609-d4b3-4bdb-9307-2de403617e90" />

