### PR TITLE
fix(tests): include isTeamSelected to createTeam method (2430, 2450, 2441, 2444)

### DIFF
--- a/pages/dashboard/team-page.js
+++ b/pages/dashboard/team-page.js
@@ -154,6 +154,7 @@ exports.TeamPage = class TeamPage extends BasePage {
     await this.teamNameInput.fill(teamName);
     await this.createNewTeamButton.click();
     await this.waitForCreateNewTeamButtonToBeHidden(30000);
+    await this.isTeamSelected(teamName);
   }
 
   async isTeamSelected(teamName) {

--- a/pages/workspace/design-panel-page.js
+++ b/pages/workspace/design-panel-page.js
@@ -1430,8 +1430,10 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
   }
 
   async clickExportElementButton(page) {
-    page.waitForEvent('download');
-    this.exportElementButton.click();
+    await Promise.all([
+      page.waitForEvent('download'),
+      this.exportElementButton.click(),
+    ]);
   }
 
   async clickAddGuidesButton() {

--- a/tests/action-menu/copy-link.spec.ts
+++ b/tests/action-menu/copy-link.spec.ts
@@ -32,7 +32,6 @@ mainTest.beforeEach(async ({ page }) => {
   registerPage = new RegisterPage(page);
   dashboardPage = new DashboardPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.waitForViewportVisible();
   await mainPage.isMainPageLoaded();

--- a/tests/action-menu/copy-paste-properties.spec.ts
+++ b/tests/action-menu/copy-paste-properties.spec.ts
@@ -35,7 +35,6 @@ mainTest.beforeEach(async ({ page }) => {
   inspectPanelPage = new InspectPanelPage(page);
   pagesPanelPage = new PagesPanelPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.waitForViewportVisible();
   await mainPage.isMainPageLoaded();

--- a/tests/action-menu/paste-replace.spec.ts
+++ b/tests/action-menu/paste-replace.spec.ts
@@ -21,7 +21,6 @@ mainTest.beforeEach(async ({ page }) => {
   layersPanelPage = new LayersPanelPage(page);
 
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.createDefaultRectangleByCoordinates(100, 100);

--- a/tests/assets/assets-colors.spec.ts
+++ b/tests/assets/assets-colors.spec.ts
@@ -27,7 +27,6 @@ mainTest.beforeEach(async ({ page }) => {
   colorPalettePopUp = new ColorPalettePage(page);
   designPanelPage = new DesignPanelPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.clickMoveButton();

--- a/tests/assets/assets-shortcuts-panel.spec.ts
+++ b/tests/assets/assets-shortcuts-panel.spec.ts
@@ -17,7 +17,6 @@ mainTest.beforeEach(async ({ page }) => {
   dashboardPage = new DashboardPage(page);
   mainPage = new MainPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
 });

--- a/tests/assets/assets-typographies.spec.ts
+++ b/tests/assets/assets-typographies.spec.ts
@@ -20,7 +20,6 @@ mainTest.beforeEach(async ({ page }) => {
   mainPage = new MainPage(page);
   assetsPanelPage = new AssetsPanelPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
 });

--- a/tests/assets/shared-libraries/shared-libraries.spec.ts
+++ b/tests/assets/shared-libraries/shared-libraries.spec.ts
@@ -64,7 +64,6 @@ mainTest.describe(() => {
     await mainPage.clickPencilBoxButton();
 
     await teamPage.createTeam(team2);
-    await teamPage.isTeamSelected(team2);
     await teamPage.switchTeam(team1);
 
     await dashboardPage.moveFileToOtherTeamViaRightClick('New File 1', team2);

--- a/tests/color/color-picker.spec.ts
+++ b/tests/color/color-picker.spec.ts
@@ -29,7 +29,6 @@ mainTest.beforeEach(async ({ page }) => {
   mainPage = new MainPage(page);
   layersPanelPage = new LayersPanelPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.clickMoveButton();

--- a/tests/components/main-components/component-grid-layout.spec.ts
+++ b/tests/components/main-components/component-grid-layout.spec.ts
@@ -33,7 +33,6 @@ mainTest.beforeEach(async ({ page }) => {
   layersPanelPage = new LayersPanelPage(page);
   colorPalettePage = new ColorPalettePage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
 });

--- a/tests/components/main-components/context-menu/context-menu-options-annotations.spec.ts
+++ b/tests/components/main-components/context-menu/context-menu-options-annotations.spec.ts
@@ -26,7 +26,6 @@ mainTest.beforeEach(async ({ page }) => {
   designPanelPage = new DesignPanelPage(page);
 
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
 });

--- a/tests/composition/composition-board.spec.ts
+++ b/tests/composition/composition-board.spec.ts
@@ -26,7 +26,6 @@ mainTest.beforeEach(async ({ page }) => {
   designPanelPage = new DesignPanelPage(page);
   layersPanelPage = new LayersPanelPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.clickMoveButton();

--- a/tests/composition/composition-comments.spec.ts
+++ b/tests/composition/composition-comments.spec.ts
@@ -38,7 +38,6 @@ mainTest.beforeEach(async ({ page }) => {
   registerPage = new RegisterPage(page);
 
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   mainProfileName = await profilePage.getUserName();
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();

--- a/tests/composition/composition-curve.spec.ts
+++ b/tests/composition/composition-curve.spec.ts
@@ -20,7 +20,6 @@ mainTest.beforeEach(async ({ page }) => {
   mainPage = new MainPage(page);
   layersPanelPage = new LayersPanelPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
 });

--- a/tests/composition/composition-ellipse.spec.ts
+++ b/tests/composition/composition-ellipse.spec.ts
@@ -26,7 +26,6 @@ mainTest.beforeEach(async ({ page }) => {
   dashboardPage = new DashboardPage(page);
   mainPage = new MainPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
 });

--- a/tests/composition/composition-flex-layout.spec.ts
+++ b/tests/composition/composition-flex-layout.spec.ts
@@ -23,7 +23,6 @@ mainTest.beforeEach(async ({ page }) => {
   layersPanelPage = new LayersPanelPage(page);
   mainPage = new MainPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
 });

--- a/tests/composition/composition-grid-layout.spec.ts
+++ b/tests/composition/composition-grid-layout.spec.ts
@@ -30,7 +30,6 @@ mainTest.beforeEach(async ({ page }) => {
   colorPalettePage = new ColorPalettePage(page);
 
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
 });

--- a/tests/composition/composition-path-node-panel.spec.ts
+++ b/tests/composition/composition-path-node-panel.spec.ts
@@ -17,7 +17,6 @@ mainTest.beforeEach(async ({ page }) => {
   teamPage = new TeamPage(page);
   dashboardPage = new DashboardPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
 });

--- a/tests/composition/composition-path.spec.ts
+++ b/tests/composition/composition-path.spec.ts
@@ -27,7 +27,6 @@ mainTest.beforeEach(async ({ page }) => {
   layersPanelPage = new LayersPanelPage(page);
 
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
 });

--- a/tests/composition/composition-rectangle.spec.ts
+++ b/tests/composition/composition-rectangle.spec.ts
@@ -26,7 +26,6 @@ mainTest.beforeEach(async ({ page }) => {
   designPanelPage = new DesignPanelPage(page);
   layersPanelPage = new LayersPanelPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
 });

--- a/tests/composition/image/image-composition.spec.ts
+++ b/tests/composition/image/image-composition.spec.ts
@@ -26,7 +26,6 @@ mainTest.beforeEach(async ({ page }) => {
   mainPage = new MainPage(page);
   teamPage = new TeamPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.clickMoveButton();

--- a/tests/composition/image/image-import.spec.ts
+++ b/tests/composition/image/image-import.spec.ts
@@ -22,7 +22,6 @@ mainTest.beforeEach(async ({ page }) => {
   mainPage = new MainPage(page);
   teamPage = new TeamPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.clickMoveButton();

--- a/tests/composition/image/image-options.spec.ts
+++ b/tests/composition/image/image-options.spec.ts
@@ -23,7 +23,6 @@ mainTest.beforeEach(async ({ page }) => {
   mainPage = new MainPage(page);
   teamPage = new TeamPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.clickMoveButton();

--- a/tests/composition/text/composition-text.spec.ts
+++ b/tests/composition/text/composition-text.spec.ts
@@ -29,7 +29,6 @@ mainTest.beforeEach(async ({ page }) => {
   dashboardPage = new DashboardPage(page);
   mainPage = new MainPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
 });

--- a/tests/composition/text/text-creation.spec.ts
+++ b/tests/composition/text/text-creation.spec.ts
@@ -17,7 +17,6 @@ mainTest.beforeEach(async ({ page }) => {
   dashboardPage = new DashboardPage(page);
   mainPage = new MainPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
 });

--- a/tests/composition/text/text-options.spec.ts
+++ b/tests/composition/text/text-options.spec.ts
@@ -20,7 +20,6 @@ mainTest.beforeEach(async ({ page }) => {
   dashboardPage = new DashboardPage(page);
   mainPage = new MainPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
 });

--- a/tests/composition/text/text-search.spec.ts
+++ b/tests/composition/text/text-search.spec.ts
@@ -22,7 +22,6 @@ mainTest.beforeEach(async ({ page }) => {
   dashboardPage = new DashboardPage(page);
   mainPage = new MainPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
 });

--- a/tests/dashboard/dashboard-files.spec.ts
+++ b/tests/dashboard/dashboard-files.spec.ts
@@ -17,7 +17,6 @@ mainTest.beforeEach(async ({ page }) => {
   mainPage = new MainPage(page);
 
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.isHeaderDisplayed('Projects');
   await dashboardPage.hideLibrariesAndTemplatesCarrousel();
 });

--- a/tests/dashboard/dashboard-fonts.spec.ts
+++ b/tests/dashboard/dashboard-fonts.spec.ts
@@ -14,7 +14,6 @@ mainTest.beforeEach(async ({ page }) => {
   dashboardPage = new DashboardPage(page);
 
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
 });
 
 mainTest(qase([1152], 'Upload single font'), async () => {

--- a/tests/dashboard/dashboard-import.spec.ts
+++ b/tests/dashboard/dashboard-import.spec.ts
@@ -17,7 +17,6 @@ mainTest.beforeEach(async ({ page }) => {
   mainPage = new MainPage(page);
 
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.isHeaderDisplayed('Projects');
   await dashboardPage.hideLibrariesAndTemplatesCarrousel();
 });

--- a/tests/dashboard/dashboard-search.spec.ts
+++ b/tests/dashboard/dashboard-search.spec.ts
@@ -17,7 +17,6 @@ mainTest.beforeEach(async ({ page }) => {
   mainPage = new MainPage(page);
 
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.isHeaderDisplayed('Projects');
   await dashboardPage.hideLibrariesAndTemplatesCarrousel();
 });

--- a/tests/dashboard/teams/settings/teams-settings.spec.ts
+++ b/tests/dashboard/teams/settings/teams-settings.spec.ts
@@ -25,7 +25,6 @@ mainTest.beforeEach(async ({ page }) => {
 mainTest(qase([1200], 'Team Settings - upload team profile picture'), async () => {
   await mainTest.step('Create a team and open team settings', async () => {
     await teamPage.createTeam(team);
-    await teamPage.isTeamSelected(team);
     await teamPage.openTeamSettingsPageViaOptionsMenu();
   });
 
@@ -54,7 +53,6 @@ mainTest(qase([1202], "Team. Settings - check 'Team members' info"), async () =>
     await profilePage.waitInfoMessageHidden();
     await profilePage.backToDashboardFromAccount();
     await teamPage.createTeam(team);
-    await teamPage.isTeamSelected(team);
     await teamPage.openTeamSettingsPageViaOptionsMenu();
   });
 
@@ -70,7 +68,6 @@ mainTest(qase([1203], "Team. Settings - check 'Team projects' info"), async () =
 
   await mainTest.step('Create projects and files for the team', async () => {
     await teamPage.createTeam(team);
-    await teamPage.isTeamSelected(team);
     await dashboardPage.createProject(projectFirst);
     await dashboardPage.pinProjectByName(projectFirst);
     await dashboardPage.createProject(projectSecond);
@@ -99,7 +96,6 @@ mainTest(qase([1203], "Team. Settings - check 'Team projects' info"), async () =
 mainTest(qase([1208], 'Delete a team via owner'), async () => {
   await mainTest.step('Create and delete the team', async () => {
     await teamPage.createTeam(team);
-    await teamPage.isTeamSelected(team);
     await teamPage.deleteTeam(team);
     await teamPage.isTeamDeleted(team);
   });

--- a/tests/dashboard/teams/teams-bad-url.spec.ts
+++ b/tests/dashboard/teams/teams-bad-url.spec.ts
@@ -33,7 +33,6 @@ mainTest.describe('Validate bad URL logged as SECOND_EMAIL', () => {
     await initPages({ page });
 
     await teamPage.createTeam(team);
-    await teamPage.isTeamSelected(team);
     await dashboardPage.createFileViaPlaceholder();
     await mainPage.isMainPageLoaded();
   });
@@ -139,7 +138,6 @@ mainTest(
       `Create a team, and invite "${firstEmail}" to the team as Admin`,
       async () => {
         await teamPage.createTeam(team);
-        await teamPage.isTeamSelected(team);
 
         await teamPage.openInvitationsPageViaOptionsMenu();
         await teamPage.clickInviteMembersToTeamButton();
@@ -190,7 +188,6 @@ mainTest(
 
     await mainTest.step(`Create a team and a file`, async () => {
       await teamPage.createTeam(team);
-      await teamPage.isTeamSelected(team);
 
       await dashboardPage.createFileViaPlaceholder();
       await mainPage.isMainPageLoaded();
@@ -220,7 +217,6 @@ mainTest(
 
     await mainTest.step(`Create a team and a file with a board`, async () => {
       await teamPage.createTeam(team);
-      await teamPage.isTeamSelected(team);
 
       await dashboardPage.createFileViaPlaceholder();
       await mainPage.isMainPageLoaded();

--- a/tests/dashboard/teams/teams-invitations.spec.ts
+++ b/tests/dashboard/teams/teams-invitations.spec.ts
@@ -34,7 +34,6 @@ mainTest.beforeEach(async ({ page }: { page: Page }) => {
 
 mainTest(qase(1164, 'Open the form via Invitations tab'), async () => {
   await teamPage.createTeam(team);
-  await teamPage.isTeamSelected(team);
   await teamPage.openInvitationsPageViaOptionsMenu();
   await teamPage.clickInviteMembersToTeamButton();
   await teamPage.isInviteMembersPopUpHeaderVisible();
@@ -45,7 +44,6 @@ registerTest(
   qase(1165, 'Open the form via Team Hero ("Invite members" button)'),
   async () => {
     await teamPage.createTeam(team);
-    await teamPage.isTeamSelected(team);
     await teamPage.clickInviteMembersTeamHeroButton();
     await teamPage.isInviteMembersPopUpHeaderVisible();
     await teamPage.deleteTeam(team);
@@ -56,7 +54,6 @@ mainTest(qase(1166, 'Invite via owner (single invitation, editor)'), async () =>
   const email = createInviteEmail('editor');
 
   await teamPage.createTeam(team);
-  await teamPage.isTeamSelected(team);
   await teamPage.openInvitationsPageViaOptionsMenu();
   await teamPage.clickInviteMembersToTeamButton();
   await teamPage.isInviteMembersPopUpHeaderVisible();
@@ -75,7 +72,6 @@ mainTest(qase(1167, 'Invite via owner (single invitation, admin)'), async () => 
   const email = createInviteEmail('admin');
 
   await teamPage.createTeam(team);
-  await teamPage.isTeamSelected(team);
   await teamPage.openInvitationsPageViaOptionsMenu();
   await teamPage.clickInviteMembersToTeamButton();
   await teamPage.isInviteMembersPopUpHeaderVisible();
@@ -95,7 +91,6 @@ mainTest(qase(1167, 'Invite via owner (single invitation, admin)'), async () => 
 
 mainTest(qase(1175, 'Fail to send invitation to existing team member'), async () => {
   await teamPage.createTeam(team);
-  await teamPage.isTeamSelected(team);
   await teamPage.openInvitationsPageViaOptionsMenu();
   await teamPage.clickInviteMembersToTeamButton();
 
@@ -129,7 +124,6 @@ registerTest.describe(
         await dashboardPage.isDashboardOpenedAfterLogin();
 
         await teamPage.createTeam(team);
-        await teamPage.isTeamSelected(team);
 
         await teamPage.openInvitationsPageViaOptionsMenu();
         await teamPage.clickInviteMembersToTeamButton();
@@ -180,7 +174,6 @@ mainTest.describe(
         const secondEmail = createInviteEmail('editor', secondEditor);
 
         await teamPage.createTeam(team);
-        await teamPage.isTeamSelected(team);
         await teamPage.openInvitationsPageViaOptionsMenu();
         await teamPage.clickInviteMembersToTeamButton();
         await teamPage.isInviteMembersPopUpHeaderVisible();
@@ -254,7 +247,6 @@ mainTest(qase(1176, 'Resend multiple invitations via owner'), async () => {
   const email3 = createInviteEmail('editor', 'editor3');
 
   await teamPage.createTeam(team);
-  await teamPage.isTeamSelected(team);
   await teamPage.openInvitationsPageViaOptionsMenu();
   await teamPage.clickInviteMembersToTeamButton();
   await teamPage.isInviteMembersPopUpHeaderVisible();
@@ -277,7 +269,6 @@ mainTest(qase(1178, 'Delete multiple invitations via owner'), async () => {
   const email3 = createInviteEmail('editor', 'editor3');
 
   await teamPage.createTeam(team);
-  await teamPage.isTeamSelected(team);
   await teamPage.openInvitationsPageViaOptionsMenu();
   await teamPage.clickInviteMembersToTeamButton();
   await teamPage.isInviteMembersPopUpHeaderVisible();
@@ -298,7 +289,6 @@ mainTest(qase(1181, 'Change role in invitation via owner'), async () => {
   const email = createInviteEmail('editor', 'role');
 
   await teamPage.createTeam(team);
-  await teamPage.isTeamSelected(team);
   await teamPage.openInvitationsPageViaOptionsMenu();
   await teamPage.clickInviteMembersToTeamButton();
   await teamPage.isInviteMembersPopUpHeaderVisible();

--- a/tests/dashboard/teams/teams-leave-team.spec.ts
+++ b/tests/dashboard/teams/teams-leave-team.spec.ts
@@ -42,7 +42,6 @@ async function setupInvitedUser(
 
   // Create team
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
 
   // Send invite
   await teamPage.openInvitationsPageViaOptionsMenu();

--- a/tests/dashboard/teams/teams-management.spec.ts
+++ b/tests/dashboard/teams/teams-management.spec.ts
@@ -17,9 +17,7 @@ mainTest(qase([1163], 'Team.Switch between teams'), async () => {
 
   await mainTest.step('Create two teams and switch between them', async () => {
     await teamPage.createTeam(team1);
-    await teamPage.isTeamSelected(team1);
     await teamPage.createTeam(team2);
-    await teamPage.isTeamSelected(team2);
     await teamPage.switchTeam(team1);
     await teamPage.switchTeam(team2);
   });

--- a/tests/dashboard/teams/teams-members.spec.ts
+++ b/tests/dashboard/teams/teams-members.spec.ts
@@ -42,7 +42,6 @@ registerTest.describe('Members - As Owner - Change roles', () => {
       await loginPage.clickLoginButton();
       await dashboardPage.isDashboardOpenedAfterLogin();
       await teamPage.createTeam(team);
-      await teamPage.isTeamSelected(team);
       await teamPage.openInvitationsPageViaOptionsMenu();
       await teamPage.clickInviteMembersToTeamButton();
     },
@@ -183,7 +182,6 @@ mainTest(qase([1196], 'Team. Members - leave team (as owner)'), async ({ page })
 
   await mainTest.step('Create team and invite admin member', async () => {
     await teamPage.createTeam(team);
-    await teamPage.isTeamSelected(team);
     await teamPage.openInvitationsPageViaOptionsMenu();
     await teamPage.clickInviteMembersToTeamButton();
     await teamPage.isInviteMembersPopUpHeaderVisible();

--- a/tests/dashboard/teams/teams-permissions.spec.ts
+++ b/tests/dashboard/teams/teams-permissions.spec.ts
@@ -49,7 +49,6 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       const secondEmail = `${process.env.GMAIL_NAME}+${secondAdmin}${process.env.GMAIL_DOMAIN}`;
 
       await teamPage.createTeam(team);
-      await teamPage.isTeamSelected(team);
       await teamPage.openInvitationsPageViaOptionsMenu();
       await teamPage.clickInviteMembersToTeamButton();
       await teamPage.selectInvitationRoleInPopUp('Admin');
@@ -100,7 +99,6 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       const secondEmail = `${process.env.GMAIL_NAME}+${secondUser}${process.env.GMAIL_DOMAIN}`;
 
       await teamPage.createTeam(team);
-      await teamPage.isTeamSelected(team);
       await teamPage.openInvitationsPageViaOptionsMenu();
       await teamPage.clickInviteMembersToTeamButton();
       await teamPage.isInviteMembersPopUpHeaderVisible();
@@ -165,7 +163,6 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       const firstEmail = `${process.env.GMAIL_NAME}+${firstAdmin}${process.env.GMAIL_DOMAIN}`;
       const secondEmail = `${process.env.GMAIL_NAME}+${secondAdmin}${process.env.GMAIL_DOMAIN}`;
       await teamPage.createTeam(team);
-      await teamPage.isTeamSelected(team);
       await teamPage.openInvitationsPageViaOptionsMenu();
       await teamPage.clickInviteMembersToTeamButton();
       await teamPage.isInviteMembersPopUpHeaderVisible();
@@ -249,7 +246,6 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       const firstEmail = `${process.env.GMAIL_NAME}+${firstAdmin}${process.env.GMAIL_DOMAIN}`;
       const secondEmail = `${process.env.GMAIL_NAME}+${secondAdmin}${process.env.GMAIL_DOMAIN}`;
       await teamPage.createTeam(team);
-      await teamPage.isTeamSelected(team);
       await teamPage.openInvitationsPageViaOptionsMenu();
       await teamPage.clickInviteMembersToTeamButton();
       await teamPage.isInviteMembersPopUpHeaderVisible();
@@ -316,7 +312,6 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       const firstAdmin = random().concat('autotest');
       const firstEmail = `${process.env.GMAIL_NAME}+${firstAdmin}${process.env.GMAIL_DOMAIN}`;
       await teamPage.createTeam(team);
-      await teamPage.isTeamSelected(team);
       await teamPage.openInvitationsPageViaOptionsMenu();
       await teamPage.clickInviteMembersToTeamButton();
       await teamPage.isInviteMembersPopUpHeaderVisible();
@@ -357,7 +352,6 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       const firstEmail = `${process.env.GMAIL_NAME}+${firstAdmin}${process.env.GMAIL_DOMAIN}`;
       const secondEmail = `${process.env.GMAIL_NAME}+${secondAdmin}${process.env.GMAIL_DOMAIN}`;
       await teamPage.createTeam(team);
-      await teamPage.isTeamSelected(team);
       await teamPage.openInvitationsPageViaOptionsMenu();
       await teamPage.clickInviteMembersToTeamButton();
       await teamPage.isInviteMembersPopUpHeaderVisible();
@@ -404,7 +398,6 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       const firstAdmin = random().concat('autotest');
       const firstEmail = `${process.env.GMAIL_NAME}+${firstAdmin}${process.env.GMAIL_DOMAIN}`;
       await teamPage.createTeam(team);
-      await teamPage.isTeamSelected(team);
       await teamPage.openInvitationsPageViaOptionsMenu();
       await teamPage.clickInviteMembersToTeamButton();
       await teamPage.isInviteMembersPopUpHeaderVisible();
@@ -456,7 +449,6 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       const firstEmail = `${process.env.GMAIL_NAME}+${firstAdmin}${process.env.GMAIL_DOMAIN}`;
       const secondEmail = `${process.env.GMAIL_NAME}+${secondAdmin}${process.env.GMAIL_DOMAIN}`;
       await teamPage.createTeam(team);
-      await teamPage.isTeamSelected(team);
       await teamPage.openInvitationsPageViaOptionsMenu();
       await teamPage.clickInviteMembersToTeamButton();
       await teamPage.isInviteMembersPopUpHeaderVisible();
@@ -519,7 +511,6 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       const firstEmail = `${process.env.GMAIL_NAME}+${firstAdmin}${process.env.GMAIL_DOMAIN}`;
       const secondEmail = `${process.env.GMAIL_NAME}+${secondAdmin}${process.env.GMAIL_DOMAIN}`;
       await teamPage.createTeam(team);
-      await teamPage.isTeamSelected(team);
       await teamPage.openInvitationsPageViaOptionsMenu();
       await teamPage.clickInviteMembersToTeamButton();
       await teamPage.isInviteMembersPopUpHeaderVisible();
@@ -588,7 +579,6 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       const firstEmail = `${process.env.GMAIL_NAME}+${firstAdmin}${process.env.GMAIL_DOMAIN}`;
       const secondEmail = `${process.env.GMAIL_NAME}+${secondAdmin}${process.env.GMAIL_DOMAIN}`;
       await teamPage.createTeam(team);
-      await teamPage.isTeamSelected(team);
       await teamPage.openInvitationsPageViaOptionsMenu();
       await teamPage.clickInviteMembersToTeamButton();
       await teamPage.isInviteMembersPopUpHeaderVisible();

--- a/tests/dashboard/teams/teams-rename.spec.ts
+++ b/tests/dashboard/teams/teams-rename.spec.ts
@@ -34,7 +34,6 @@ mainTest.describe('Rename a team', () => {
   mainTest(qase([1205], 'Rename a team via owner'), async () => {
     await mainTest.step('Create and rename the team as owner', async () => {
       await teamPage.createTeam(team);
-      await teamPage.isTeamSelected(team);
       await teamPage.renameTeam(teamNew);
       await teamPage.isTeamSelected(teamNew);
     });
@@ -52,7 +51,6 @@ mainTest.describe('Rename a team', () => {
 
       await mainTest.step('Create team and invite editor user', async () => {
         await teamPage.createTeam(team);
-        await teamPage.isTeamSelected(team);
         await teamPage.openInvitationsPageViaOptionsMenu();
         await teamPage.clickInviteMembersToTeamButton();
         await teamPage.isInviteMembersPopUpHeaderVisible();

--- a/tests/dashboard/teams/teams-request-access.spec.ts
+++ b/tests/dashboard/teams/teams-request-access.spec.ts
@@ -60,7 +60,6 @@ async function setupTeamAndFile(
   const mainPage = new MainPage(page);
 
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.waitForViewportVisible();
 

--- a/tests/dashboard/teams/teams-viewer-role.spec.ts
+++ b/tests/dashboard/teams/teams-viewer-role.spec.ts
@@ -61,7 +61,6 @@ async function setupViewerUser(
 
   // Create team & file
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.waitForViewportVisible();
   await mainPage.createDefaultRectangleByCoordinates(200, 300);

--- a/tests/dashboard/trash/dashboard-trash.spec.ts
+++ b/tests/dashboard/trash/dashboard-trash.spec.ts
@@ -31,7 +31,6 @@ mainTest.describe('As Owner', () => {
     deletedPage = new DeletedPage(page);
 
     await teamPage.createTeam(teamName);
-    await teamPage.isTeamSelected(teamName);
     await dashboardPage.isHeaderDisplayed('Projects');
     await dashboardPage.hideLibrariesAndTemplatesCarrousel();
   });

--- a/tests/panels-features/blur/panels-features-blur.spec.ts
+++ b/tests/panels-features/blur/panels-features-blur.spec.ts
@@ -23,7 +23,6 @@ mainTest.beforeEach(async ({ page }) => {
   dashboardPage = new DashboardPage(page);
   mainPage = new MainPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
 });

--- a/tests/panels-features/history/panels-features-history-panel.spec.ts
+++ b/tests/panels-features/history/panels-features-history-panel.spec.ts
@@ -27,7 +27,6 @@ mainTest.beforeEach(async ({ page }) => {
   historyPage = new HistoryPanelPage(page);
   layersPanelPage = new LayersPanelPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
 });

--- a/tests/panels-features/history/panels-features-history-preview-version.spec.ts
+++ b/tests/panels-features/history/panels-features-history-preview-version.spec.ts
@@ -23,7 +23,6 @@ mainTest.beforeEach(async ({ page }) => {
   historyPage = new HistoryPanelPage(page);
   layersPanelPage = new LayersPanelPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
 });

--- a/tests/panels-features/main-menu/panels-features-main-menu-edit.spec.ts
+++ b/tests/panels-features/main-menu/panels-features-main-menu-edit.spec.ts
@@ -20,7 +20,6 @@ mainTest.beforeEach(async ({ page }) => {
   layersPanelPage = new LayersPanelPage(page);
   mainPage = new MainPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.createTextLayerByCoordinates(200, 200, 'Test 1');

--- a/tests/panels-features/main-menu/panels-features-main-menu-file.spec.ts
+++ b/tests/panels-features/main-menu/panels-features-main-menu-file.spec.ts
@@ -19,7 +19,6 @@ mainTest.beforeEach(async ({ page }) => {
   assetsPanelPage = new AssetsPanelPage(page);
   mainPage = new MainPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.clickMoveButton();

--- a/tests/panels-features/main-menu/panels-features-main-menu-view.spec.ts
+++ b/tests/panels-features/main-menu/panels-features-main-menu-view.spec.ts
@@ -26,7 +26,6 @@ mainTest.beforeEach(async ({ page }) => {
   assetsPanelPage = new AssetsPanelPage(page);
   mainPage = new MainPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.clickMoveButton();

--- a/tests/panels-features/panels-features-export.spec.ts
+++ b/tests/panels-features/panels-features-export.spec.ts
@@ -19,7 +19,6 @@ mainTest.beforeEach(async ({ page }) => {
   designPanelPage = new DesignPanelPage(page);
   mainPage = new MainPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
 });

--- a/tests/panels-features/panels-features-fill.spec.ts
+++ b/tests/panels-features/panels-features-fill.spec.ts
@@ -23,7 +23,6 @@ mainTest.beforeEach(async ({ page }) => {
   colorPalettePage = new ColorPalettePage(page);
   mainPage = new MainPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
 });

--- a/tests/panels-features/panels-features-guides.spec.ts
+++ b/tests/panels-features/panels-features-guides.spec.ts
@@ -20,7 +20,6 @@ mainTest.beforeEach(async ({ page }) => {
   designPanelPage = new DesignPanelPage(page);
   mainPage = new MainPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
 });

--- a/tests/panels-features/panels-features-inspect.spec.ts
+++ b/tests/panels-features/panels-features-inspect.spec.ts
@@ -32,7 +32,6 @@ mainTest.beforeEach(
     tokensPage = new TokensPage(page);
 
     await teamPage.createTeam(teamName);
-    await teamPage.isTeamSelected(teamName);
 
     await dashboardPage.createFileViaPlaceholder();
     await mainPage.isMainPageLoaded();

--- a/tests/panels-features/panels-features-pages.spec.ts
+++ b/tests/panels-features/panels-features-pages.spec.ts
@@ -33,7 +33,6 @@ mainTest.beforeEach(async ({ page }) => {
   pagesPanelPage = new PagesPanelPage(page);
 
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
 });

--- a/tests/panels-features/panels-features-prototype.spec.ts
+++ b/tests/panels-features/panels-features-prototype.spec.ts
@@ -23,7 +23,6 @@ mainTest.beforeEach(async ({ page }) => {
   prototypePanelPage = new PrototypePanelPage(page);
   layersPanelPage = new LayersPanelPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.waitForViewportVisible();
   await mainPage.isMainPageLoaded();

--- a/tests/panels-features/panels-features-zoom.spec.ts
+++ b/tests/panels-features/panels-features-zoom.spec.ts
@@ -17,7 +17,6 @@ mainTest.beforeEach(async ({ page }) => {
   teamPage = new TeamPage(page);
   dashboardPage = new DashboardPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.clickMoveButton();

--- a/tests/panels-features/stroke/panels-features-stroke.spec.ts
+++ b/tests/panels-features/stroke/panels-features-stroke.spec.ts
@@ -24,7 +24,6 @@ mainTest.beforeEach(async ({ page }) => {
   layersPanelPage = new LayersPanelPage(page);
 
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
 });

--- a/tests/plugins/plugins.spec.ts
+++ b/tests/plugins/plugins.spec.ts
@@ -16,7 +16,6 @@ mainTest.beforeEach(async ({ page }) => {
   dashboardPage = new DashboardPage(page);
   pluginsPage = new PluginsPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await pluginsPage.isMainPageLoaded();
 });

--- a/tests/subscription-plans/end-trial-behavior.spec.ts
+++ b/tests/subscription-plans/end-trial-behavior.spec.ts
@@ -31,7 +31,6 @@ registerTest.beforeEach(async ({ page, name, email }) => {
   testClockId = customerData.testClockId;
 
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
 });
 
 registerTest(

--- a/tests/subscription-plans/plan-labels.spec.ts
+++ b/tests/subscription-plans/plan-labels.spec.ts
@@ -28,7 +28,6 @@ registerTest.beforeEach(async ({ page }) => {
   stripePage = new StripePage(page);
 
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
 });
 
 registerTest(

--- a/tests/subscription-plans/plan-switching-logic.spec.ts
+++ b/tests/subscription-plans/plan-switching-logic.spec.ts
@@ -27,7 +27,6 @@ registerTest.beforeEach(async ({ page }) => {
   stripePage = new StripePage(page);
 
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
 });
 
 registerTest(

--- a/tests/subscription-plans/stripe-specific-tests.spec.ts
+++ b/tests/subscription-plans/stripe-specific-tests.spec.ts
@@ -36,7 +36,6 @@ registerTest.describe(() => {
     testClockId = customerData.testClockId;
 
     await teamPage.createTeam(teamName);
-    await teamPage.isTeamSelected(teamName);
   });
 
   registerTest.afterEach(async () => {

--- a/tests/subscription-plans/trial-activation.spec.ts
+++ b/tests/subscription-plans/trial-activation.spec.ts
@@ -21,7 +21,6 @@ registerTest.beforeEach(async ({ page }) => {
   stripePage = new StripePage(page);
 
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
 });
 
 registerTest(

--- a/tests/tokens/export.spec.ts
+++ b/tests/tokens/export.spec.ts
@@ -20,7 +20,6 @@ mainTest.beforeEach(async ({ page }) => {
   mainPage = new MainPage(page);
   tokensPage = new TokensPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.isHeaderDisplayed('Projects');
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();

--- a/tests/tokens/import.spec.ts
+++ b/tests/tokens/import.spec.ts
@@ -31,7 +31,6 @@ mainTest.beforeEach(async ({ page }) => {
   layersPanelPage = new LayersPanelPage(page);
 
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.isHeaderDisplayed('Projects');
 });
 

--- a/tests/tokens/object-specific.spec.ts
+++ b/tests/tokens/object-specific.spec.ts
@@ -18,7 +18,6 @@ mainTest.beforeEach(async ({ page }) => {
   dashboardPage = new DashboardPage(page);
   mainPage = new MainPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.isHeaderDisplayed('Projects');
 });
 

--- a/tests/tokens/rename-and-remap.spec.ts
+++ b/tests/tokens/rename-and-remap.spec.ts
@@ -30,7 +30,6 @@ mainTest.beforeEach(async ({ page }) => {
   layersPanelPage = new LayersPanelPage(page);
   designPanelPage = new DesignPanelPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.isHeaderDisplayed('Projects');
 });
 

--- a/tests/tokens/sets.spec.ts
+++ b/tests/tokens/sets.spec.ts
@@ -26,7 +26,6 @@ mainTest.beforeEach(async ({ page }) => {
   tokensPage = new TokensPage(page);
 
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.clickMoveButton();

--- a/tests/tokens/themes.spec.ts
+++ b/tests/tokens/themes.spec.ts
@@ -27,7 +27,6 @@ mainTest.beforeEach(async ({ page }) => {
   designPanelPage = new DesignPanelPage(page);
 
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.clickMoveButton();

--- a/tests/tokens/token-group/token-group-options.spec.ts
+++ b/tests/tokens/token-group/token-group-options.spec.ts
@@ -26,7 +26,6 @@ mainTest.beforeEach(async ({ page }) => {
   tokensPage = new TokensPage(page);
 
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.clickMoveButton();

--- a/tests/tokens/token-group/token-group.spec.ts
+++ b/tests/tokens/token-group/token-group.spec.ts
@@ -26,7 +26,6 @@ mainTest.beforeEach(async ({ page }) => {
   tokensPage = new TokensPage(page);
 
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.clickMoveButton();

--- a/tests/tokens/token-types/border-radius-token.spec.ts
+++ b/tests/tokens/token-types/border-radius-token.spec.ts
@@ -21,7 +21,6 @@ mainTest.beforeEach(async ({ page }) => {
   dashboardPage = new DashboardPage(page);
   mainPage = new MainPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.clickMoveButton();

--- a/tests/tokens/token-types/color-token.spec.ts
+++ b/tests/tokens/token-types/color-token.spec.ts
@@ -24,7 +24,6 @@ mainTest.beforeEach('Create a team and a new file', async ({ page }) => {
   mainPage = new MainPage(page);
 
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.clickMoveButton();

--- a/tests/tokens/token-types/dimensions-token.spec.ts
+++ b/tests/tokens/token-types/dimensions-token.spec.ts
@@ -24,7 +24,6 @@ mainTest.beforeEach(async ({ page }) => {
   tokensPage = new TokensPage(page);
   designPanelPage = new DesignPanelPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.clickMoveButton();

--- a/tests/tokens/token-types/font-family-token.spec.ts
+++ b/tests/tokens/token-types/font-family-token.spec.ts
@@ -28,7 +28,6 @@ mainTest.beforeEach(async ({ page }) => {
   layersPanelPage = new LayersPanelPage(page);
 
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.clickMoveButton();

--- a/tests/tokens/token-types/font-size-token.spec.ts
+++ b/tests/tokens/token-types/font-size-token.spec.ts
@@ -33,7 +33,6 @@ mainTest.beforeEach(async ({ page }) => {
   layersPanelPage = new LayersPanelPage(page);
   colorPalettePage = new ColorPalettePage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.clickMoveButton();

--- a/tests/tokens/token-types/font-weight-token.spec.ts
+++ b/tests/tokens/token-types/font-weight-token.spec.ts
@@ -21,7 +21,6 @@ mainTest.beforeEach(async ({ page }) => {
   dashboardPage = new DashboardPage(page);
   mainPage = new MainPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.clickMoveButton();

--- a/tests/tokens/token-types/letter-spacing-token.spec.ts
+++ b/tests/tokens/token-types/letter-spacing-token.spec.ts
@@ -23,7 +23,6 @@ mainTest.beforeEach(async ({ page }) => {
   mainPage = new MainPage(page);
   tokensPage = new TokensPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.clickMoveButton();

--- a/tests/tokens/token-types/number-token.spec.ts
+++ b/tests/tokens/token-types/number-token.spec.ts
@@ -24,7 +24,6 @@ mainTest.beforeEach(async ({ page }) => {
   tokensPage = new TokensPage(page);
   designPanelPage = new DesignPanelPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.clickMoveButton();

--- a/tests/tokens/token-types/opacity-token.spec.ts
+++ b/tests/tokens/token-types/opacity-token.spec.ts
@@ -22,7 +22,6 @@ mainTest.beforeEach(async ({ page }) => {
   mainPage = new MainPage(page);
   tokensPage = new TokensPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.clickMoveButton();

--- a/tests/tokens/token-types/rotation-token.spec.ts
+++ b/tests/tokens/token-types/rotation-token.spec.ts
@@ -25,7 +25,6 @@ mainTest.beforeEach(async ({ page }) => {
   tokensPage = new TokensPage(page);
   designPanelPage = new DesignPanelPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.clickMoveButton();

--- a/tests/tokens/token-types/shadow-token.spec.ts
+++ b/tests/tokens/token-types/shadow-token.spec.ts
@@ -26,7 +26,6 @@ mainTest.beforeEach('Create a team and a file', async ({ page }) => {
   designPanelPage = new DesignPanelPage(page);
 
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.clickMoveButton();

--- a/tests/tokens/token-types/sizing-token.spec.ts
+++ b/tests/tokens/token-types/sizing-token.spec.ts
@@ -29,7 +29,6 @@ mainTest.beforeEach(async ({ page }) => {
   layersPanelPage = new LayersPanelPage(page);
 
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.clickMoveButton();

--- a/tests/tokens/token-types/spacing-token.spec.ts
+++ b/tests/tokens/token-types/spacing-token.spec.ts
@@ -25,7 +25,6 @@ mainTest.beforeEach(async ({ page }) => {
   tokensPage = new TokensPage(page);
   designPanelPage = new DesignPanelPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.clickMoveButton();

--- a/tests/tokens/token-types/stroke-width-token.spec.ts
+++ b/tests/tokens/token-types/stroke-width-token.spec.ts
@@ -25,7 +25,6 @@ mainTest.beforeEach(async ({ page }) => {
   tokensPage = new TokensPage(page);
   designPanelPage = new DesignPanelPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.clickMoveButton();

--- a/tests/tokens/token-types/text-case-token.spec.ts
+++ b/tests/tokens/token-types/text-case-token.spec.ts
@@ -27,7 +27,6 @@ mainTest.beforeEach(async ({ page }) => {
   designPanelPage = new DesignPanelPage(page);
   assetsPanelPage = new AssetsPanelPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.clickMoveButton();

--- a/tests/tokens/token-types/text-decoration-token.spec.ts
+++ b/tests/tokens/token-types/text-decoration-token.spec.ts
@@ -25,7 +25,6 @@ mainTest.beforeEach(async ({ page }) => {
   designPanelPage = new DesignPanelPage(page);
 
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.clickMoveButton();

--- a/tests/tokens/token-types/typography-tokens.spec.ts
+++ b/tests/tokens/token-types/typography-tokens.spec.ts
@@ -24,7 +24,6 @@ mainTest.beforeEach(async ({ page }) => {
   dashboardPage = new DashboardPage(page);
 
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.clickMoveButton();

--- a/tests/tokens/tokens-autocomplete-combobox.spec.ts
+++ b/tests/tokens/tokens-autocomplete-combobox.spec.ts
@@ -22,7 +22,6 @@ mainTest.beforeEach(async ({ page }) => {
   mainPage = new MainPage(page);
   tokensPage = new TokensPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await tokensPage.clickTokensTab();

--- a/tests/tokens/tokens-in-design-tab.spec.ts
+++ b/tests/tokens/tokens-in-design-tab.spec.ts
@@ -29,7 +29,6 @@ mainTest.beforeEach(async ({ page }) => {
   designPanelPage = new DesignPanelPage(page);
   layersPanelPage = new LayersPanelPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.isHeaderDisplayed('Projects');
 });
 

--- a/tests/tokens/tokens-management.spec.ts
+++ b/tests/tokens/tokens-management.spec.ts
@@ -24,7 +24,6 @@ mainTest.beforeEach(async ({ page }) => {
   tokensPage = new TokensPage(page);
   designPanelPage = new DesignPanelPage(page);
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.isMainPageLoaded();
   await mainPage.clickMoveButton();

--- a/tests/ui-theme/ui-theme-features-light-mode.spec.ts
+++ b/tests/ui-theme/ui-theme-features-light-mode.spec.ts
@@ -18,7 +18,6 @@ registerTest(
     let mainPage: MainPage = new MainPage(page);
 
     await teamPage.createTeam(teamName);
-    await teamPage.isTeamSelected(teamName);
     await profilePage.openYourAccountPage();
     await profilePage.openSettingsTab();
     await profilePage.selectLightTheme();

--- a/tests/view-mode/view-mode-comments.spec.ts
+++ b/tests/view-mode/view-mode-comments.spec.ts
@@ -22,7 +22,6 @@ mainTest.beforeEach(async ({ page }) => {
   viewModePage = new ViewModePage(page);
   await mainTest.slow();
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.waitForViewportVisible();
   await mainPage.isMainPageLoaded();

--- a/tests/view-mode/view-mode-inspect.spec.ts
+++ b/tests/view-mode/view-mode-inspect.spec.ts
@@ -28,7 +28,6 @@ mainTest.beforeEach(async ({ page }) => {
   layersPanelPage = new LayersPanelPage(page);
   await mainTest.slow();
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.waitForViewportVisible();
   await mainPage.isMainPageLoaded();

--- a/tests/view-mode/view-mode-navigation.spec.ts
+++ b/tests/view-mode/view-mode-navigation.spec.ts
@@ -30,7 +30,6 @@ mainTest.beforeEach(async ({ page }) => {
   designPanelPage = new DesignPanelPage(page);
   await mainTest.slow();
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.waitForViewportVisible();
   await mainPage.isMainPageLoaded();

--- a/tests/view-mode/view-mode-share.spec.ts
+++ b/tests/view-mode/view-mode-share.spec.ts
@@ -41,7 +41,6 @@ mainTest.beforeEach(async ({ page }) => {
   registerPage = new RegisterPage(page);
   await mainTest.slow();
   await teamPage.createTeam(teamName);
-  await teamPage.isTeamSelected(teamName);
   await dashboardPage.createFileViaPlaceholder();
   await mainPage.waitForViewportVisible();
   await mainPage.isMainPageLoaded();


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/task/2348

## Description

This PR resolves flaky tests (Qase IDs: 2430, 2450, 2441, 2444) failing because they didn't wait for the team to be explicitly created before operating on the dashboard. This may lead to the dashboard being re-rendered (when the team is finally created) and trying to click on elements detached from the DOM.

It also introduces a fix in PR #817 with an uncommitted change adding `Promise.all([waitForEvent, click])`  to the `clickExportElementButton` method.

## Solution

* Add `teamPage.isTeamSelected(teamName)` into the `createTeam()` POM method, so it can't be forgotten
* Remove  `teamPage.isTeamSelected(teamName)` line from the tests, as it's no longer required

```js
async createTeam(teamName) {
  await this.openTeamsListIfClosed();
  await this.createNewTeamMenuItem.click();
  await this.teamNameInput.fill(teamName);
  await this.createNewTeamButton.click();
  await this.waitForCreateNewTeamButtonToBeHidden(30000);
  await this.isTeamSelected(teamName); // new
}
```

## How to test
- [X] Check the code
- [X] Update the test case in Qase (Automation Status field or steps changed)
- [X] It complies with the test conventions
- [X] There are no missing snapshots
- [X] The tests run OK — validated the full set of 470 tests across all 93 touched spec files (436 passed, 34 failed on unrelated pre-existing flakiness: Gmail API races, Stripe/subscription API, visual snapshot noise); separately re-verified Qase 717 in isolation, now passing.

## Screenshots 📸 (optional)

Running x10 times the 4 tests locally, they pass 39/40, with just a failure on the 1444 test (and not related to the bug in the report):

<img width="1014" height="617" alt="image" src="https://github.com/user-attachments/assets/009ff29d-5f85-461f-8866-3eea20ef94c5" />

Original report error (fixed in this PR):

<img width="903" height="368" alt="image" src="https://github.com/user-attachments/assets/44d45136-a1df-41d8-9c3e-f3c01a82b010" />
