### PR TITLE
fix(teams-request-access): update locator for invite team form

### DIFF
--- a/pages/dashboard/team-page.js
+++ b/pages/dashboard/team-page.js
@@ -49,6 +49,9 @@ exports.TeamPage = class TeamPage extends BasePage {
     this.membersMenuItem = page.getByRole('menuitem', { name: 'Members' });
 
     //Invitations
+    this.teamModalContainer = page.locator(
+      '.main_ui_dashboard_team__modal-team-container',
+    );
     this.invitationsMenuItem = page.getByRole('menuitem', { name: 'Invitations' });
     this.inviteMembersToTeamButton = page.getByTestId('invite-member');
     this.inviteMembersPopUpHeader = page.getByRole('heading', {
@@ -115,7 +118,6 @@ exports.TeamPage = class TeamPage extends BasePage {
     this.requestAccessDialog = page.locator('.main_ui_static__dialog').first();
     this.requestAccessButton = page.getByRole('button', { name: 'REQUEST ACCESS' });
     this.returnHomeButton = page.getByRole('button', { name: 'GO TO YOUR PENPOT' });
-    this.firstInvitedEmail = page.locator('span[class*="forms__text"]').first();
     this.requestSentCorrectlyText = this.requestAccessDialog.getByText(
       'Your request has been sent correctly!',
     );
@@ -606,7 +608,9 @@ exports.TeamPage = class TeamPage extends BasePage {
   }
 
   async checkFirstInvitedEmail(email) {
-    await expect(this.firstInvitedEmail).toHaveText(email);
+    await expect(
+      this.teamModalContainer.getByText(email, { exact: true }),
+    ).toBeVisible();
   }
 
   async waitForInvitationButtonEnabled(timeout) {


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/task/2356

## Description

Updates locator for invited user in modal form to fix Qase ID 1833.

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots
- [ ] The tests run OK

## Test Execution Results in CI

**Non related error**

<img width="1023" height="227" alt="image" src="https://github.com/user-attachments/assets/91565409-799f-4eff-a132-7e14d3f6b03e" />
