### PR TITLE
fix(view-mode): add promiseAll for requests in view-mode

### DIFF
--- a/tests/dashboard/teams/teams-bad-url.spec.ts
+++ b/tests/dashboard/teams/teams-bad-url.spec.ts
@@ -88,7 +88,21 @@ mainTest.describe('Validate bad URL logged as SECOND_EMAIL', () => {
       });
 
       await mainTest.step('Go to bad URL and validate error message', async () => {
-        await page.goto(badURL);
+        // Wait for the specific responses to occur, but don't fail if they don't happen
+        await Promise.all([
+          page.waitForResponse(
+            (response) =>
+              response.url().includes('get-view-only-bundle') &&
+              response.status() === 404,
+          ),
+          page.waitForResponse(
+            (response) =>
+              response.url().includes('get-file-info') && response.status() === 404,
+          ),
+        ]).catch(() => {});
+
+        await page.goto(badURL, { waitUntil: 'networkidle' });
+
         await teamPage.isInviteMessageDisplayed('Oops!');
         await teamPage.isErrorMessageDisplayed("This page doesn't exist");
         await teamPage.isGoToPenpotButtonVisible();

--- a/tests/dashboard/teams/teams-request-access.spec.ts
+++ b/tests/dashboard/teams/teams-request-access.spec.ts
@@ -120,7 +120,7 @@ registerTest(
 
     // Login as SECOND_EMAIL and navigate to URL
     await profilePage.logout();
-    await loginAs(setup, secondAccountEmail);
+    await loginAs(setup, secondAccountEmail!);
     await page.goto(currentURL);
 
     // Request access as SECOND_EMAIL from dialog and return home
@@ -173,7 +173,7 @@ registerTest(
 
     // Login as SECOND_EMAIL and navigate to Dashboard URL
     await profilePage.logout();
-    await loginAs(setup, secondAccountEmail);
+    await loginAs(setup, secondAccountEmail!);
     await page.goto(currentURL);
 
     // Request access as SECOND_EMAIL from dialog and return home
@@ -218,7 +218,7 @@ registerTest(
 
     // Login as SECOND_EMAIL
     await profilePage.logout();
-    await loginAs(setup, secondAccountEmail);
+    await loginAs(setup, secondAccountEmail!);
 
     // Navigate to Workspace URL
     await page.goto(currentURL);
@@ -274,8 +274,23 @@ registerTest(
     await profilePage.logout();
 
     // Login as SECOND_EMAIL
-    await loginAs(setup, secondAccountEmail);
-    await page.goto(currentURL);
+    await loginAs(setup, secondAccountEmail!);
+
+    // Navigate to View Mode URL
+    // Wait for the specific responses to occur, but don't fail if they don't happen
+    await Promise.all([
+      page.waitForResponse(
+        (response) =>
+          response.url().includes('get-view-only-bundle') &&
+          response.status() === 404,
+      ),
+      page.waitForResponse(
+        (response) =>
+          response.url().includes('get-file-info') && response.status() === 404,
+      ),
+    ]).catch(() => {});
+
+    await page.goto(currentURL, { waitUntil: 'networkidle' });
 
     // Request access as SECOND_EMAIL from dialog and return home
     await teamPage.isRequestFileAccessDialogVisible();

--- a/tests/view-mode/view-mode-navigation.spec.ts
+++ b/tests/view-mode/view-mode-navigation.spec.ts
@@ -433,8 +433,8 @@ mainTest(qase([705], 'Edit file'), async ({ page }) => {
       await page.close();
       await viewModePage.clickEditButton();
       const oldPage = await viewModePage.clickEditButton(false);
-      mainPage = new MainPage(oldPage);
-      teamPage = new TeamPage(oldPage);
+      mainPage = new MainPage(oldPage!);
+      teamPage = new TeamPage(oldPage!);
       await mainPage.waitForViewportVisible();
     },
   );

--- a/tests/view-mode/view-mode-share.spec.ts
+++ b/tests/view-mode/view-mode-share.spec.ts
@@ -192,21 +192,34 @@ mainTest.describe(() => {
             { mask: [viewModePage.copyLinkField] },
           );
           await newPage.close();
+          await mainPage.clickPencilBoxButton();
+          await profilePage.logout();
         },
       );
 
       await mainTest.step(
         'Log in as the second user and open the shared link',
         async () => {
-          await mainPage.clickPencilBoxButton();
-          await profilePage.logout();
           await page.context().clearCookies();
-          await loginPage.isLoginPageOpened();
-          await loginPage.enterEmailAndClickOnContinue(process.env.SECOND_EMAIL);
-          await loginPage.enterPwd(process.env.LOGIN_PWD);
-          await loginPage.clickLoginButton();
-          await dashboardPage.isDashboardOpenedAfterLogin();
-          await profilePage.gotoLink(shareLink);
+          await loginAsSecondUser(page);
+
+          // Navigate to View Mode URL
+          // Wait for the specific responses to occur, but don't fail if they don't happen
+          await Promise.all([
+            page.waitForResponse(
+              (response) =>
+                response.url().includes('get-view-only-bundle') &&
+                response.status() === 200,
+            ),
+            page.waitForResponse(
+              (response) =>
+                response.url().includes('get-comments-threads') &&
+                response.status() === 200,
+            ),
+          ]).catch(() => {});
+
+          await page.goto(shareLink, { waitUntil: 'networkidle' });
+
           viewModePage = new ViewModePage(page);
           await viewModePage.isViewerSectionVisible();
         },

--- a/tests/view-mode/view-mode-share.spec.ts
+++ b/tests/view-mode/view-mode-share.spec.ts
@@ -17,6 +17,7 @@ import {
 } from 'helpers/gmail';
 import { random } from 'helpers/string-generator';
 import { createTeamName } from 'helpers/teams/create-team-name';
+import { loginAsSecondUser } from 'helpers/user-flows';
 import { qase } from 'playwright-qase-reporter/playwright';
 
 const teamName = createTeamName();
@@ -115,20 +116,33 @@ mainTest.describe(() => {
             { mask: [viewModePage.copyLinkField] },
           );
           await newPage.close();
+          await mainPage.clickPencilBoxButton();
+          await profilePage.logout();
         },
       );
 
       await mainTest.step(
         'Log in as the second user and open the shared link',
         async () => {
-          await mainPage.clickPencilBoxButton();
-          await profilePage.logout();
-          await loginPage.isLoginPageOpened();
-          await loginPage.enterEmailAndClickOnContinue(process.env.SECOND_EMAIL);
-          await loginPage.enterPwd(process.env.LOGIN_PWD);
-          await loginPage.clickLoginButton();
-          await dashboardPage.isDashboardOpenedAfterLogin();
-          await profilePage.gotoLink(shareLink);
+          await loginAsSecondUser(page);
+
+          // Navigate to View Mode URL
+          // Wait for the specific responses to occur, but don't fail if they don't happen
+          await Promise.all([
+            page.waitForResponse(
+              (response) =>
+                response.url().includes('get-view-only-bundle') &&
+                response.status() === 200,
+            ),
+            page.waitForResponse(
+              (response) =>
+                response.url().includes('get-comments-threads') &&
+                response.status() === 200,
+            ),
+          ]).catch(() => {});
+
+          await page.goto(shareLink, { waitUntil: 'networkidle' });
+
           viewModePage = new ViewModePage(page);
           await viewModePage.isViewerSectionVisible();
         },
@@ -264,7 +278,7 @@ mainTest.describe(() => {
       await mainTest.step('Register the invited admin account', async () => {
         await profilePage.logout();
         await loginPage.isLoginPageOpened();
-        await page.goto(firstInvite.inviteUrl);
+        await page.goto(firstInvite!.inviteUrl);
         await registerPage.registerAccount(
           firstAdmin,
           firstEmail,


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/task/2352
https://tree.taiga.io/project/kaleidos-qa/task/2355
https://tree.taiga.io/project/kaleidos-qa/task/2363

Issue filed: https://github.com/penpot/penpot/issues/11224

## Description

1831, 1824, 696, 697 Qase ID tests were failing because the page wasn't fully loaded when critical API responses (particularly 404 and 200 status codes) occurred. Without explicitly waiting for these responses, tests would proceed prematurely or encounter race conditions, leading to unpredictable failures.

## Solution

**1. Explicit API Response Handling**

- Wrapped page navigation with Promise.all to wait for specific API responses:
- Bad URL scenarios: Wait for 404 responses from get-view-only-bundle and get-file-info
- Valid access scenarios: Wait for 200 responses from get-view-only-bundle and get-comments-threads
- Added .catch(() => {}) to gracefully handle cases where responses may not occur
- Changed waitUntil: 'networkidle' to ensure page fully stabilizes after response handling

**2. TypeScript Type Safety**

- Added non-null assertions (!) to variables that could be undefined:
- secondAccountEmail! - for email parameter type safety
- oldPage! - for page reference in view-mode tests
- firstInvite!.inviteUrl - for invite URL access

**3. Code Refactoring**

- Replaced inline login logic with loginAsSecondUser() helper function in view-mode share tests
- Improves maintainability and reduces code duplication

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots
- [ ] The tests run OK

## Screenshots 📸 (optional)

<img width="573" height="282" alt="image" src="https://github.com/user-attachments/assets/0ab4d487-1292-43cf-bf2d-f7ae17e94348" />

<img width="730" height="112" alt="image" src="https://github.com/user-attachments/assets/5bebf1e6-174a-4384-919e-6d74d4871185" />

<img width="729" height="135" alt="image" src="https://github.com/user-attachments/assets/14874902-7272-43b0-bc4d-a851c71ea97c" />





