### PR TITLE
fix(test): avoid waiting a resend invitation performed within the 5 minutes (717)

### DIFF
--- a/tests/dashboard/teams/teams-permissions.spec.ts
+++ b/tests/dashboard/teams/teams-permissions.spec.ts
@@ -86,8 +86,7 @@ mainTest.describe('Roles permissions (Owner, Admin, Editor)', () => {
       await teamPage.resendInvitation(secondEmail);
       await teamPage.isSuccessMessageDisplayed('Invitation sent successfully');
 
-      await waitSecondMessage(page, secondEmail, 40);
-      await checkMessagesCount(secondEmail, 2);
+      await checkMessagesCount(secondEmail, 1);
     },
   );
 


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/task/2354

## Description

This PR resolves [1177](https://app.qase.io/case/PENPOT-1177) test due to a [change in 2.18](https://chat.kaleidos.net/kaleidos/pl/ftz1yp4mhib1ipns6o8ojxhugw).

Users now WON'T receive another invitation in their email if invitations or resends (to the same person and team) occur within 5 minutes. 

## Solution

* Don't wait for the second resent invitation, just for the first one.

## How to test

- [x] Check the code
- [x] Update the test case in Qase (Automation Status field or steps changed)
- [x] It complies with the test conventions
- [x] There are no missing snapshots
- [x] The tests run OK

## Screenshots 📸 (optional)

<img width="902" height="418" alt="image" src="https://github.com/user-attachments/assets/13a0179b-14e9-4fec-9abc-16182843353d" />
