### PR TITLE
fix(variants): update 2450 to wait for changes saved

### DIFF
--- a/tests/components/variants/variants-property.spec.ts
+++ b/tests/components/variants/variants-property.spec.ts
@@ -162,6 +162,7 @@ mainTest.describe(() => {
     await layersPanelPage.selectLayerByName('Ellipse, Green');
     await designPanelPage.clickOnComponentMenuButton();
     await designPanelPage.clickOnAddNewPropertyOption();
+    await assetsPanelPage.waitForChangeIsSaved();
     await layersPanelPage.selectLayerByName('Arrow, Blue, Value 1');
     await designPanelPage.checkVariantPropertyValue('Property 3', 'Value 1');
 
@@ -169,10 +170,12 @@ mainTest.describe(() => {
     await layersPanelPage.typeNameCreatedLayerAndEnter(
       'Property 1=Rectangle, Property 2=Blue, Property 3=Value 1, Test=TestValue',
     );
+    await assetsPanelPage.waitForChangeIsSaved();
     await designPanelPage.checkVariantPropertyValue('Test', 'TestValue');
 
     await layersPanelPage.selectLayerByName('Ellipse, Green');
     await designPanelPage.enterVariantPropertyValue('Test', 'TestValue2');
+    await assetsPanelPage.waitForChangeIsSaved();
     await designPanelPage.checkVariantPropertyValue('Test', 'TestValue2');
     await layersPanelPage.isLayerWithNameSelected(
       'Ellipse, Green, Value 1, TestValue2',


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/task/2397

## Description

Adds wait for changes are saved in test to wait values for variants are added.

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots
- [ ] The tests run OK

## Test Execution Results (local)

<img width="1908" height="873" alt="image" src="https://github.com/user-attachments/assets/b49b148d-7bc7-440e-b98a-1722f4949a1a" />

