### PR TITLE
feat(dashboard): add list view test and fixture for demo account 

### DIFF
--- a/fixtures.ts
+++ b/fixtures.ts
@@ -53,7 +53,9 @@ export const registerTest = test.extend<RegisterTestFixtures>({
   },
 });
 
-export const demoTest = test.extend({
+// Fixture for demo account, used for tests that require a new account bypassing the registration process.
+// This fixture will create a demo account and log in to it before each test.
+export const demoAccountFixture = test.extend({
   page: async ({ page }, use) => {
     const loginPage = new LoginPage(page);
     const registerPage = new RegisterPage(page);

--- a/fixtures.ts
+++ b/fixtures.ts
@@ -5,6 +5,11 @@ import { RegisterPage } from '@pages/register-page';
 import { random } from './helpers/string-generator';
 import { waitMessage } from './helpers/gmail';
 
+type RegisterTestFixtures = {
+  name: string;
+  email: string;
+};
+
 export const mainTest = test.extend({
   page: async ({ page }, use) => {
     const loginPage = new LoginPage(page);
@@ -21,11 +26,6 @@ export const mainTest = test.extend({
     await use(page);
   },
 });
-
-type RegisterTestFixtures = {
-  name: string;
-  email: string;
-};
 
 export const registerTest = test.extend<RegisterTestFixtures>({
   name: async ({}, use) => {
@@ -49,6 +49,23 @@ export const registerTest = test.extend<RegisterTestFixtures>({
     const invite = await waitMessage(page, email, 40);
     await page.goto(invite!.inviteUrl);
     await dashboardPage.fillOnboardingQuestions();
+    await use(page);
+  },
+});
+
+export const demoTest = test.extend({
+  page: async ({ page }, use) => {
+    const loginPage = new LoginPage(page);
+    const registerPage = new RegisterPage(page);
+    const dashboardPage = new DashboardPage(page);
+
+    await loginPage.goto();
+    await loginPage.acceptCookie();
+    await loginPage.clickOnCreateAccount();
+    await registerPage.isRegisterPageOpened();
+    await registerPage.clickOnCreateDemoAccountButton();
+    await dashboardPage.fillOnboardingQuestions();
+    await dashboardPage.isHeaderDisplayed('Projects');
     await use(page);
   },
 });

--- a/pages/dashboard/dashboard-page.js
+++ b/pages/dashboard/dashboard-page.js
@@ -82,6 +82,7 @@ exports.DashboardPage = class DashboardPage extends BasePage {
     this.fileOptionsMenuButton = this.fileTile
       .first()
       .getByRole('button', { name: 'Options' });
+    this.fileOptionsMenu = page.getByRole('menu');
     this.headerOptionsMenuButton = page.locator(
       'div[title="Options"] svg[class*="files__menu-icon"]',
     );
@@ -937,7 +938,10 @@ exports.DashboardPage = class DashboardPage extends BasePage {
 
   async isFileVisibleByName(name) {
     const elem = this.page.getByRole('button', { name: name });
-    await expect(elem.first()).toBeVisible();
+    await expect(
+      elem.first(),
+      `File with name ${name} should be visible`,
+    ).toBeVisible();
   }
 
   async deleteFileWithNameViaRightClick(name) {
@@ -1469,10 +1473,14 @@ exports.DashboardPage = class DashboardPage extends BasePage {
     ).toBeVisible();
   }
 
-  async isFileOptionsMenuVisible() {
+  async isFileOptionsMenuButtonVisible() {
     await expect(
       this.fileOptionsMenuButton,
-      `File options menu is visible`,
+      `File options menu button is visible`,
     ).toBeVisible();
+  }
+
+  async isFileOptionsMenuVisible() {
+    await expect(this.fileOptionsMenu, `File options menu is visible`).toBeVisible();
   }
 };

--- a/pages/dashboard/dashboard-page.js
+++ b/pages/dashboard/dashboard-page.js
@@ -12,6 +12,10 @@ exports.DashboardPage = class DashboardPage extends BasePage {
     this.addProjectButton = page.getByRole('button', { name: 'New project' });
     this.alertMessage = page.getByRole('alert');
 
+    // Dashboard Header > Layout View
+    this.layoutListViewButton = page.getByRole('button', { name: 'List view' });
+    this.layoutGridViewButton = page.getByRole('button', { name: 'Grid view' });
+
     // Deleted Navigation
     this.recentTab = page.getByTestId('recent-tab');
     this.deletedTab = page.getByTestId('deleted-tab');
@@ -75,12 +79,13 @@ exports.DashboardPage = class DashboardPage extends BasePage {
       .getByRole('button', { name: 'Close' })
       .getByText('Close', { exact: true });
     this.fileNameInput = page.locator('div[class*="edit-wrapper"]');
-    this.fileOptionsMenuButton = page
-      .locator('li[class*="grid-item"]')
+    this.fileOptionsMenuButton = this.fileTile
+      .first()
       .getByRole('button', { name: 'Options' });
     this.headerOptionsMenuButton = page.locator(
       'div[title="Options"] svg[class*="files__menu-icon"]',
     );
+    this.dashboardFilesItemDate = page.locator('[class*="list-item-date"]');
 
     // Projects Section
     this.projectsContainer = page.locator(
@@ -1437,5 +1442,37 @@ exports.DashboardPage = class DashboardPage extends BasePage {
     }
 
     await this.page.keyboard.up('Shift');
+  }
+
+  // Layout view option is saved per browser session and across teams
+  async switchLayoutView(viewType) {
+    switch (viewType) {
+      case 'List View':
+        await this.layoutListViewButton.click();
+        break;
+      case 'Grid View':
+        await this.layoutGridViewButton.click();
+        break;
+    }
+  }
+
+  async hasFileTileListClass() {
+    await expect(this.fileTile.first(), `File item has list view class`).toHaveClass(
+      /list-item/,
+    );
+  }
+
+  async isFileItemDateVisible() {
+    await expect(
+      this.dashboardFilesItemDate.first(),
+      `File item date is visible`,
+    ).toBeVisible();
+  }
+
+  async isFileOptionsMenuVisible() {
+    await expect(
+      this.fileOptionsMenuButton,
+      `File options menu is visible`,
+    ).toBeVisible();
   }
 };

--- a/tests/dashboard/dashboard-view.spec.ts
+++ b/tests/dashboard/dashboard-view.spec.ts
@@ -1,0 +1,47 @@
+import { MainPage } from '@pages/workspace/main-page';
+import { DashboardPage } from '@pages/dashboard/dashboard-page';
+import { TeamPage } from '@pages/dashboard/team-page';
+import { demoTest, mainTest, registerTest } from 'fixtures';
+import { qase } from 'playwright-qase-reporter/playwright';
+import { createTeamName } from 'helpers/teams/create-team-name';
+
+const teamName = createTeamName();
+
+let teamPage: TeamPage;
+let dashboardPage: DashboardPage;
+let mainPage: MainPage;
+
+demoTest.beforeEach(async ({ page }) => {
+  teamPage = new TeamPage(page);
+  dashboardPage = new DashboardPage(page);
+  mainPage = new MainPage(page);
+
+  await teamPage.createTeam(teamName);
+  await dashboardPage.isHeaderDisplayed('Projects');
+  await dashboardPage.hideLibrariesAndTemplatesCarrousel();
+});
+
+demoTest.describe('List View', () => {
+  demoTest.beforeEach(async () => {
+    await dashboardPage.clickAddProjectButton();
+    await dashboardPage.setProjectName('Test Project');
+    await dashboardPage.isProjectTitleDisplayed('Test Project');
+    await dashboardPage.createFileViaProjectPlaceholder();
+    await mainPage.clickPencilBoxButton();
+    await dashboardPage.checkNumberOfFiles('1 file');
+  });
+
+  demoTest(
+    qase(
+      [3463, 3466, 3468],
+      'Toggle from grid view to list view on dashboard, assert last modification time is visible and options menu',
+    ),
+    async () => {
+      await dashboardPage.switchLayoutView('List View');
+      await dashboardPage.isFileVisibleByName('New File 1');
+      await dashboardPage.hasFileTileListClass();
+      await dashboardPage.isFileItemDateVisible();
+      await dashboardPage.isFileOptionsMenuVisible();
+    },
+  );
+});

--- a/tests/dashboard/dashboard-view.spec.ts
+++ b/tests/dashboard/dashboard-view.spec.ts
@@ -1,28 +1,16 @@
 import { MainPage } from '@pages/workspace/main-page';
 import { DashboardPage } from '@pages/dashboard/dashboard-page';
-import { TeamPage } from '@pages/dashboard/team-page';
-import { demoTest, mainTest, registerTest } from 'fixtures';
+import { demoAccountFixture } from 'fixtures';
 import { qase } from 'playwright-qase-reporter/playwright';
-import { createTeamName } from 'helpers/teams/create-team-name';
 
-const teamName = createTeamName();
-
-let teamPage: TeamPage;
 let dashboardPage: DashboardPage;
 let mainPage: MainPage;
 
-demoTest.beforeEach(async ({ page }) => {
-  teamPage = new TeamPage(page);
-  dashboardPage = new DashboardPage(page);
-  mainPage = new MainPage(page);
+demoAccountFixture.describe('List View', () => {
+  demoAccountFixture.beforeEach(async ({ page }) => {
+    dashboardPage = new DashboardPage(page);
+    mainPage = new MainPage(page);
 
-  await teamPage.createTeam(teamName);
-  await dashboardPage.isHeaderDisplayed('Projects');
-  await dashboardPage.hideLibrariesAndTemplatesCarrousel();
-});
-
-demoTest.describe('List View', () => {
-  demoTest.beforeEach(async () => {
     await dashboardPage.clickAddProjectButton();
     await dashboardPage.setProjectName('Test Project');
     await dashboardPage.isProjectTitleDisplayed('Test Project');
@@ -31,7 +19,7 @@ demoTest.describe('List View', () => {
     await dashboardPage.checkNumberOfFiles('1 file');
   });
 
-  demoTest(
+  demoAccountFixture(
     qase(
       [3463, 3466, 3468],
       'Toggle from grid view to list view on dashboard, assert last modification time is visible and options menu',
@@ -41,6 +29,8 @@ demoTest.describe('List View', () => {
       await dashboardPage.isFileVisibleByName('New File 1');
       await dashboardPage.hasFileTileListClass();
       await dashboardPage.isFileItemDateVisible();
+      await dashboardPage.isFileOptionsMenuButtonVisible();
+      await dashboardPage.clickOnFileOptions();
       await dashboardPage.isFileOptionsMenuVisible();
     },
   );


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/task/2373

## Description

Add test coverage for the dashboard list view functionality (Qase IDs 3463, 3466, 3468), including a new demo account fixture for streamlined testing.

## Solution

- Added a new dashboard-view.spec.ts spec file to cover Qase IDs 3463, 3466, 3468
- Added demoAccountFixture that automatically creates and logs into a demo account and simplifies setup for tests requiring a fresh account without going through registration
- Added new locators and methods

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots
- [ ] The tests run OK

## Test Execution Results in CI

<img width="1007" height="254" alt="image" src="https://github.com/user-attachments/assets/81add890-db88-41bb-aafd-d7d9c62c6ad5" />

