### PR TITLE
fix(teams): remove unnecessary teams delection

### DIFF
--- a/tests/dashboard/teams/teams-management.spec.ts
+++ b/tests/dashboard/teams/teams-management.spec.ts
@@ -21,8 +21,4 @@ mainTest(qase([1163], 'Team.Switch between teams'), async () => {
     await teamPage.switchTeam(team1);
     await teamPage.switchTeam(team2);
   });
-
-  await mainTest.step('Delete both teams', async () => {
-    await teamPage.deleteTeams([team1, team2]);
-  });
 });


### PR DESCRIPTION
# Done Definition Checks

## Description

This PR fix a test failure removing unnecessay teams delection (not present in the Qase test case)

## How to test

- [ ] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [ ] It complies with the test conventions
- [ ] There are no missing snapshots
- [ ] The tests run OK

## Screenshots 📸 
<img width="698" height="174" alt="team" src="https://github.com/user-attachments/assets/2057d9f1-2273-4f76-8f76-cab593b7af3d" />
