### PR TITLE
fix(view-mode): remove redundant clickEditButton call in edit file test

### DIFF
--- a/tests/view-mode/view-mode-navigation.spec.ts
+++ b/tests/view-mode/view-mode-navigation.spec.ts
@@ -431,7 +431,6 @@ mainTest(qase([705], 'Edit file'), async ({ page }) => {
     'Close workspace tab and reopen it from view mode',
     async () => {
       await page.close();
-      await viewModePage.clickEditButton();
       const oldPage = await viewModePage.clickEditButton(false);
       mainPage = new MainPage(oldPage!);
       teamPage = new TeamPage(oldPage!);


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

[Taiga Ticket: 2424](https://tree.taiga.io/project/kaleidos-qa/task/2424)

## Description

This PR resolves a flaky failure in `view-mode/view-mode-navigation.spec.ts` (Qase ID 705, "Edit file").

The "Close workspace tab and reopen it from view mode" step called `viewModePage.clickEditButton()` twice in a row:

1. `clickEditButton()` (default `first = true`, no popup wait) — but since the workspace tab had just been closed, this click is exactly what spawns the new popup tab. The test discarded it.
2. `clickEditButton(false)` — arms `page.waitForEvent('popup')` and clicks Edit again. Since the workspace tab is already open from the first click, this second click just refocuses it instead of opening a new one, so no `popup` event ever fires, causing a 15s `TimeoutError`.

## Solution

Removed the redundant first `clickEditButton()` call. Only one click is needed after the workspace tab is closed, and it must be the popup-waiting variant (`clickEditButton(false)`) so the newly opened workspace popup is captured correctly.

## How to test

- [x] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [x] It complies with the test conventions
- [ ] There are no missing snapshots
- [ ] The tests run OK

## Screenshots 📸 (optional)

<img width="1662" height="360" alt="image" src="https://github.com/user-attachments/assets/e8d5e625-b86c-4d66-bea9-51925425a61d" />

