### PR TITLE
fix(typography): update font selection to use role-based locators

### DIFF
--- a/pages/workspace/assets-panel-page.js
+++ b/pages/workspace/assets-panel-page.js
@@ -379,9 +379,8 @@ exports.AssetsPanelPage = class AssetsPanelPage extends BasePage {
     await this.fontSelector.click();
     await this.fontSelectorSearchInput.fill(fontName);
     await this.page
-      .locator('div[class*="fonts-list"]')
-      .getByText(fontName, { exact: true })
-      .first()
+      .getByRole('grid')
+      .getByRole('img', { name: fontName, exact: true })
       .click();
   }
 

--- a/pages/workspace/design-panel-page.js
+++ b/pages/workspace/design-panel-page.js
@@ -387,9 +387,7 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
     });
     this.textFontSelector = page.locator('div[class*="typography__font-option"]');
     this.textFontSelectorSearchInput = page.getByPlaceholder('Search font');
-    this.textFontItemResult = page.locator(
-      '.main_ui_workspace_sidebar_options_menus_typography__font-item',
-    );
+    this.textFontItemResult = page.getByRole('grid');
     this.textFontStyleSelector = page.locator(
       'div[class*="typography__font-variant-options"]',
     );
@@ -1039,13 +1037,13 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
 
   async isTypographyFontItemVisible(fontName) {
     await expect(
-      this.textFontItemResult.getByText(fontName, { exact: true }),
+      this.textFontItemResult.getByRole('img', { name: fontName, exact: true }),
     ).toBeVisible();
   }
 
   async isTypographyFontItemNotVisible(fontName) {
     await expect(
-      this.textFontItemResult.getByText(fontName, { exact: true }),
+      this.textFontItemResult.getByRole('img', { name: fontName, exact: true }),
     ).not.toBeVisible();
   }
 
@@ -1053,9 +1051,8 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
     await this.openTypographyFontDropdown();
     await this.searchTypographyFontFromSearch(fontName);
     await this.page
-      .locator('div[class*="fonts-list"]')
-      .getByText(fontName, { exact: true })
-      .first()
+      .getByRole('grid')
+      .getByRole('img', { name: fontName, exact: true })
       .click();
     await expect(this.textFontSelector).toBeVisible();
   }


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

[Taiga Ticket: 2419](https://tree.taiga.io/project/kaleidos-qa/us/2419)
[Taiga Ticket: 2420](https://tree.taiga.io/project/kaleidos-qa/us/2420)
[Taiga Ticket: 2421](https://tree.taiga.io/project/kaleidos-qa/us/2421)
[Taiga Ticket: 2422](https://tree.taiga.io/project/kaleidos-qa/us/2422)
[Taiga Ticket: 2423](https://tree.taiga.io/project/kaleidos-qa/us/2423)

## Description

This PR resolves the font selector tests breaking after the markup changes shipped in [penpot/penpot#10403](https://github.com/penpot/penpot/issues/10403).

The font list dropdown (used both from the Design panel's text options and from the Assets panel's typography editor) no longer exposes the font name as visible text. It is now rendered as a virtualized `role="grid"`, where a `role="row"` can bundle several font results together as sibling `<img>` elements, and each font's name only lives in that image's accessible name (`alt`). Our existing locators relied on `div[class*="fonts-list"]` + `getByText(fontName, { exact: true })`, which stopped matching anything, and an intermediate `getByRole('row', { name: fontName })` attempt also failed as soon as a search returned more than one font sharing the same row.

## Solution

Updated the font-list locators in `pages/workspace/design-panel-page.js` and `pages/workspace/assets-panel-page.js` to target the font directly via `page.getByRole('grid').getByRole('img', { name: fontName, exact: true })`, which is robust regardless of how many font results are grouped into the same row.

## Folders and specs affected: 

- tests/composition/text
- tests/action-menu
- tests/components
- tests/tokens/token-types
- tests/assets/assets-typographies.spec.ts

## How to test

- [x] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [x] It complies with the test conventions
- [ ] There are no missing snapshots
- [ ] The tests run OK

## Screenshots 📸 (optional)

<img width="1635" height="1111" alt="image" src="https://github.com/user-attachments/assets/2beef26e-9649-41b9-ba0f-6f1b10b05fac" />
<img width="1710" height="1169" alt="image" src="https://github.com/user-attachments/assets/107287f7-d303-4a95-b083-f6172cd222b2" />
<img width="1652" height="1161" alt="image" src="https://github.com/user-attachments/assets/0efaecc3-9301-4346-afe6-11a685397b50" />
<img width="1652" height="1161" alt="image" src="https://github.com/user-attachments/assets/6ee7e17e-e8ca-4e9f-bc2d-d70b8186e706" />
<img width="1652" height="1161" alt="image" src="https://github.com/user-attachments/assets/a4cf7148-161e-4f4d-99b1-f996d38a5b54" />


