### PR TITLE
fix(subscription-plans): fix subscription name locator and remove duplicate Enterprise test

### DIFF
--- a/pages/dashboard/dashboard-page.js
+++ b/pages/dashboard/dashboard-page.js
@@ -296,7 +296,9 @@ exports.DashboardPage = class DashboardPage extends BasePage {
       'Marked all notifications as read',
       { exact: true },
     );
-    this.subscriptionName = page.getByTestId('subscription-name');
+    this.subscriptionName = page
+      .locator('[class*="nitrate-current-plan"]')
+      .getByRole('button');
   }
 
   getFileButtonByName(fileName) {

--- a/tests/subscription-plans/end-trial-behavior.spec.ts
+++ b/tests/subscription-plans/end-trial-behavior.spec.ts
@@ -57,6 +57,6 @@ registerTest(
 
     await profilePage.checkSubscriptionName(defaultPlan);
     await profilePage.backToDashboardFromAccount();
-    await dashboardPage.checkSubscriptionName(defaultPlan + ' plan');
+    await dashboardPage.checkSubscriptionName(defaultPlan);
   },
 );

--- a/tests/subscription-plans/plan-labels.spec.ts
+++ b/tests/subscription-plans/plan-labels.spec.ts
@@ -34,7 +34,7 @@ registerTest(qase(2283, 'Display & Info for Professional Plan'), async () => {
   await profilePage.openSubscriptionTab();
   await profilePage.checkSubscriptionName(currentPlan);
   await profilePage.backToDashboardFromAccount();
-  await dashboardPage.checkSubscriptionName(currentPlan + ' plan');
+  await dashboardPage.checkSubscriptionName(currentPlan);
   await teamPage.isSubscriptionIconNotVisible();
   await teamPage.isSubscriptionIconVisibleInTeamDropdown(false);
   await teamPage.openTeamSettingsPageViaOptionsMenu();

--- a/tests/subscription-plans/plan-labels.spec.ts
+++ b/tests/subscription-plans/plan-labels.spec.ts
@@ -1,5 +1,4 @@
-import { mainTest, registerTest } from 'fixtures';
-import { test } from '@playwright/test';
+import { registerTest } from 'fixtures';
 import { TeamPage } from '@pages/dashboard/team-page';
 import { DashboardPage } from '@pages/dashboard/dashboard-page';
 import { qase } from 'playwright-qase-reporter/playwright';
@@ -7,7 +6,6 @@ import { ProfilePage } from '@pages/profile-page';
 import { LoginPage } from '@pages/login-page';
 import { RegisterPage } from '@pages/register-page';
 import { StripePage } from '@pages/dashboard/stripe-page';
-import { addPaymentMethodForCustomerByCustomerEmail } from 'helpers/stripe';
 import { createTeamName } from 'helpers/teams/create-team-name';
 
 const teamName = createTeamName();
@@ -29,47 +27,6 @@ registerTest.beforeEach(async ({ page }) => {
 
   await teamPage.createTeam(teamName);
 });
-
-registerTest(
-  qase(
-    [2281, 2348],
-    'Display & Info for Enterprise Plan. Enterprise badge visible immediately',
-  ),
-  async ({ page, email }) => {
-    const trialPlan = 'Unlimited';
-    const currentPlan = 'Enterprise';
-
-    await test.step(`Subscribe for ${trialPlan} plan trial`, async () => {
-      await profilePage.tryTrialForPlan(trialPlan);
-    });
-
-    await test.step(`From Subscriptions page, add payment method for ${trialPlan}`, async () => {
-      await profilePage.openYourAccountPage();
-      await profilePage.openSubscriptionTab();
-      await profilePage.clickOnAddPaymentMethodButton();
-      await addPaymentMethodForCustomerByCustomerEmail(page, email);
-      await stripePage.reloadPage();
-      await stripePage.isVisaCardAdded(true);
-    });
-
-    await test.step(`Change from ${trialPlan} to ${currentPlan} and return to Penpot`, async () => {
-      await stripePage.changeSubscription();
-      await stripePage.checkCurrentSubscription(currentPlan);
-      await stripePage.clickOnReturnToPenpotButton();
-    });
-
-    await test.step(`Validate ${currentPlan} subscription name and icon`, async () => {
-      await profilePage.reloadPage();
-      await profilePage.checkSubscriptionName(currentPlan);
-      await profilePage.backToDashboardFromAccount();
-      await dashboardPage.checkSubscriptionName(currentPlan + ' plan');
-      await teamPage.isSubscriptionIconVisible(currentPlan);
-      await teamPage.isSubscriptionIconVisibleInTeamDropdown(true);
-      await teamPage.openTeamSettingsPageViaOptionsMenu();
-      await teamPage.checkSubscriptionName(currentPlan);
-    });
-  },
-);
 
 registerTest(qase(2283, 'Display & Info for Professional Plan'), async () => {
   const currentPlan = 'Professional';

--- a/tests/subscription-plans/plan-switching-logic.spec.ts
+++ b/tests/subscription-plans/plan-switching-logic.spec.ts
@@ -53,7 +53,7 @@ registerTest(
     await stripePage.clickOnReturnToPenpotButton();
     await profilePage.checkSubscriptionName(newPlan);
     await profilePage.backToDashboardFromAccount();
-    await dashboardPage.checkSubscriptionName(newPlan + ' plan');
+    await dashboardPage.checkSubscriptionName(newPlan);
   },
 );
 
@@ -93,6 +93,6 @@ registerTest(
 
     await profilePage.checkSubscriptionName(defaultPlan);
     await profilePage.backToDashboardFromAccount();
-    await dashboardPage.checkSubscriptionName(defaultPlan + ' plan');
+    await dashboardPage.checkSubscriptionName(defaultPlan);
   },
 );

--- a/tests/subscription-plans/trial-activation.spec.ts
+++ b/tests/subscription-plans/trial-activation.spec.ts
@@ -23,7 +23,9 @@ registerTest.beforeEach(async ({ page }) => {
   await teamPage.createTeam(teamName);
 });
 
-registerTest(
+// TODO: Re-do with the new Enterprise subscription flow (nitrate)
+// A payment method is now required to start the trial.
+registerTest.skip(
   qase(2294, 'Verify Trial Label Behavior (for the Enterprise plan)'),
   async ({ page, email }) => {
     const currentPlan = 'Enterprise';

--- a/tests/subscription-plans/trial-activation.spec.ts
+++ b/tests/subscription-plans/trial-activation.spec.ts
@@ -34,7 +34,7 @@ registerTest(
     await profilePage.checkSubscriptionName(currentPlan + ' (trial)');
     await updateSubscriptionTrialEnd(page, email);
     await profilePage.backToDashboardFromAccount();
-    await dashboardPage.checkSubscriptionName(currentPlan + ' plan (trial)');
+    await dashboardPage.checkSubscriptionName(currentPlan + ' (trial)');
     await profilePage.openYourAccountPage();
     await profilePage.openSubscriptionTab();
     await profilePage.checkSubscriptionName(currentPlan + ' (trial)');


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

[Taiga Ticket: 2425](https://tree.taiga.io/project/kaleidos-qa/task/2425)

## Description

This PR resolves obsolete tests and a broken locator in the subscription-plans suite.

_What problem are you trying to solve?_

`plan-labels.spec.ts` had two Enterprise plan tests (qase 2281/2348) that were no longer adapted to the new "nitrate" subscription flow, so they were removed — they'll need to be rewritten from scratch for that flow in a future PR/ticket.

After removing them, the remaining test in that spec (`Display & Info for Professional Plan`, qase 2283) was run on its own and it failed with `element(s) not found` on `getByTestId('subscription-name')` — the dashboard's current-plan button no longer carries that test id. That surfaced a second, unrelated problem also fixed here.

## Solution

- Removed the two obsolete Enterprise Plan tests (qase 2281/2348) from `plan-labels.spec.ts`, not adapted to the new nitrate flow — **to be re-implemented for nitrate in a follow-up**, and cleaned up now-unused imports.
- Fixed `DashboardPage.subscriptionName` locator to target the actual DOM (`[class*="nitrate-current-plan"] button`) instead of the stale `getByTestId('subscription-name')`, which is what made 2283 fail.
- Updated all `dashboardPage.checkSubscriptionName(...)` call sites to stop appending a `' plan'` suffix that no longer matches the current UI text (dashboard button now shows just the plan name, e.g. `Professional`, or `Professional (trial)`).
- Skipped `trial-activation.spec.ts` (qase 2294, `Verify Trial Label Behavior (for the Enterprise plan)`) with a `TODO` comment: with the new nitrate flow this test needs to be re-done from scratch, it doesn't make sense as it's currently written (it assumed the Enterprise trial could start without a payment method).

## How to test

- [x] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [x] It complies with the test conventions
- [ ] There are no missing snapshots
- [ ] The tests run OK

## Screenshots 📸 (optional)

<img width="1057" height="225" alt="image" src="https://github.com/user-attachments/assets/faae8238-990d-40bd-bf4c-37364d140966" />



