### PR TITLE
refactor(subscription-plans): remove obsolete test for switching from Enterprise to Unlimited

### DIFF
--- a/tests/subscription-plans/plan-switching-logic.spec.ts
+++ b/tests/subscription-plans/plan-switching-logic.spec.ts
@@ -9,7 +9,6 @@ import {
   skipSubscriptionByDays,
   getProfileIdByEmail,
   addPaymentMethodForCustomer,
-  addPaymentMethodForCustomerByCustomerEmail,
 } from 'helpers/stripe';
 import { createTeamName } from 'helpers/teams/create-team-name';
 
@@ -28,34 +27,6 @@ registerTest.beforeEach(async ({ page }) => {
 
   await teamPage.createTeam(teamName);
 });
-
-registerTest(
-  qase(2303, 'Switch from Enterprise → Unlimited'),
-  async ({ page, email }) => {
-    const currentPlan = 'Enterprise';
-    const newPlan = 'Unlimited';
-
-    await profilePage.tryTrialForPlan(newPlan);
-    await profilePage.openYourAccountPage();
-    await profilePage.openSubscriptionTab();
-    await profilePage.clickOnAddPaymentMethodButton();
-    await addPaymentMethodForCustomerByCustomerEmail(page, email);
-    await stripePage.reloadPage();
-    await stripePage.isVisaCardAdded(true);
-    await stripePage.changeSubscription();
-    await stripePage.checkCurrentSubscription(currentPlan);
-
-    await stripePage.waitTrialEndsDisappear();
-    await stripePage.changeSubscription();
-    await stripePage.checkCurrentSubscription(newPlan);
-    await stripePage.checkLastInvoiceName(`Penpot ${newPlan}`);
-    await stripePage.checkLastInvoiceAmount(`$0.00`);
-    await stripePage.clickOnReturnToPenpotButton();
-    await profilePage.checkSubscriptionName(newPlan);
-    await profilePage.backToDashboardFromAccount();
-    await dashboardPage.checkSubscriptionName(newPlan);
-  },
-);
 
 // TODO: Re-do following the updated test case in Qase
 registerTest.skip(


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

[Taiga Ticket: 2428](https://tree.taiga.io/project/kaleidos-qa/task/2428)

## Description

This PR resolves the removal of an obsolete subscription test.

_What problem are you trying to solve?_

As part of the ongoing cleanup of the subscriptions tests, test 2303 ("Switch from Enterprise → Unlimited") is being removed.

## How to test

- [x] Check the code
- [x] Update the test case in Qase (Automation Status field or steps changed)
- [x] It complies with the test conventions
- [ ] There are no missing snapshots
- [ ] The tests run OK