### PR TITLE
chore(subscription-plans): skip trial-ending test pending Nitrate rework

### DIFF
--- a/tests/subscription-plans/end-trial-behavior.spec.ts
+++ b/tests/subscription-plans/end-trial-behavior.spec.ts
@@ -33,7 +33,9 @@ registerTest.beforeEach(async ({ page, name, email }) => {
   await teamPage.createTeam(teamName);
 });
 
-registerTest(
+// TODO: Re-do with the new Enterprise subscription flow (nitrate)
+// A payment method is now required to start the trial.
+registerTest.skip(
   qase(
     2301,
     'Trial ends, no payment method ever added → switch to Professional (CANCELLED)',

--- a/tests/subscription-plans/end-trial-behavior.spec.ts
+++ b/tests/subscription-plans/end-trial-behavior.spec.ts
@@ -34,7 +34,6 @@ registerTest.beforeEach(async ({ page, name, email }) => {
 });
 
 // TODO: Re-do with the new Enterprise subscription flow (nitrate)
-// A payment method is now required to start the trial.
 registerTest.skip(
   qase(
     2301,


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

[Taiga Ticket: 2435](https://tree.taiga.io/project/kaleidos-qa/task/2435)

## Description

This PR resolves the failing test 2301 (`Trial ends, no payment method ever added → switch to Professional (CANCELLED)`) by skipping it.

Skipped the test with `registerTest.skip` and left a TODO comment explaining it needs to be rebuilt for the new Nitrate (Enterprise) subscription flows.

## How to test

- [x] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [x] It complies with the test conventions
- [ ] There are no missing snapshots
- [ ] The tests run OK
