### PR TITLE
fix(dashboard): update outdated Your Penpot/My Files copy in team tests

### DIFF
--- a/helpers/gmail.js
+++ b/helpers/gmail.js
@@ -262,7 +262,7 @@ async function checkYourPenpotConfirmAccessText(text, name, email) {
     '\r\n' +
     `${name} (${email.toLowerCase()}) has requested access to the file named “New File 1”.\r\n` +
     '\r\n' +
-    "Please note that the file is currently in Your Penpot 's team, so direct access cannot be granted. However, you have two options to provide the requested access:\r\n" +
+    'Please note that the file is currently in Personal Projects, so direct access cannot be granted. However, you have two options to provide the requested access:\r\n' +
     '\r\n' +
     `- Move the File to Another Team:\r\n` +
     '\r\n' +
@@ -299,7 +299,7 @@ async function checkYourPenpotViewModeConfirmAccessText(
     '\r\n' +
     `${name} (${email.toLowerCase()}) wants to have view-only access to the file named “New File 1”.\r\n` +
     '\r\n' +
-    `Since this file is in your Penpot team, you can provide access by sending a view-only link. This will allow ${name} to view the content without making any changes.\r\n` +
+    `Since this file is in your Personal Projects, you can provide access by sending a view-only link. This will allow ${name} to view the content without making any changes.\r\n` +
     '\r\n' +
     'To proceed, please click the link below to generate and send the view-only link:\r\n' +
     '\r\n' +

--- a/pages/dashboard/team-page.js
+++ b/pages/dashboard/team-page.js
@@ -211,7 +211,9 @@ exports.TeamPage = class TeamPage extends BasePage {
   }
 
   async isTeamDeleted(teamName) {
-    await expect(this.page.getByText('My Files')).toBeVisible({ timeout: 8000 });
+    await expect(this.page.getByText('Personal Projects')).toBeVisible({
+      timeout: 8000,
+    });
     await this.openTeamsListIfClosed();
     for (const el of await this.teamCurrentNameDiv.elementHandles()) {
       const text = (await el.innerText()).valueOf();
@@ -457,7 +459,7 @@ exports.TeamPage = class TeamPage extends BasePage {
       ? await this.selectMember(name)
       : await this.clickOnLeaveTeamButton();
     await expect(this.teamCurrentBtn).not.toHaveText(teamName);
-    await expect(this.teamCurrentBtn).toHaveText('My Files');
+    await expect(this.teamCurrentBtn).toHaveText('Personal Projects');
   }
 
   /**

--- a/pages/dashboard/team-page.js
+++ b/pages/dashboard/team-page.js
@@ -111,13 +111,15 @@ exports.TeamPage = class TeamPage extends BasePage {
     this.inviteMessage = page.locator('div[class*="main-message"]');
     this.errorMessage = page.locator('div[class*="desc-message"]').last();
     this.goToYourPenpotButton = page.getByRole('button', {
-      name: 'Go to your Penpot',
+      name: 'Go to Personal Projects',
     });
 
     // Request Access dialog Locators
     this.requestAccessDialog = page.locator('.main_ui_static__dialog').first();
     this.requestAccessButton = page.getByRole('button', { name: 'REQUEST ACCESS' });
-    this.returnHomeButton = page.getByRole('button', { name: 'GO TO YOUR PENPOT' });
+    this.returnHomeButton = page.getByRole('button', {
+      name: 'Go to Personal Projects',
+    });
     this.requestSentCorrectlyText = this.requestAccessDialog.getByText(
       'Your request has been sent correctly!',
     );


### PR DESCRIPTION
# Done Definition Checks

## Taiga URL (optional)

[Taiga Ticket: 2433](https://tree.taiga.io/project/kaleidos-qa/task/2433)

## Description

This PR resolves outdated locators and expected texts left broken by the "My Files" → "Personal Projects" and "Your Penpot" rename (Taiga #26767).

Several dashboard/team tests were failing because they still referenced the old copy:

- The "Go to your Penpot" / "GO TO YOUR PENPOT" button (shown on the request-access and no-access dialogs) is now labeled "Go to Personal Projects".
- The request-access confirmation emails referenced "Your Penpot('s team)" instead of "Personal Projects".
- The current-team button and the post-team-deletion state showed "My Files" instead of "Personal Projects".

## Solution

Updated the affected locators and expected strings in `pages/dashboard/team-page.js` and `helpers/gmail.js` to match the new "Personal Projects" copy, fixing Qase cases 1827, 1829, 1830, 1831, 1197 and 1198.

## How to test

- [x] Check the code
- [ ] Update the test case in Qase (Automation Status field or steps changed)
- [x] It complies with the test conventions
- [ ] There are no missing snapshots
- [x] The tests run OK

## Screenshots (optional)
<img width="1002" height="632" alt="image" src="https://github.com/user-attachments/assets/f24f1fa7-3200-4010-b416-88b11172a441" />
<img width="1002" height="632" alt="image" src="https://github.com/user-attachments/assets/e2d12cc3-179d-431a-a072-749f9762227b" />
<img width="1002" height="307" alt="image" src="https://github.com/user-attachments/assets/d475b3df-8d6c-495b-ad89-da78b08b11d1" />
<img width="1006" height="405" alt="image" src="https://github.com/user-attachments/assets/c8fe8285-a206-4c37-a7b9-b89b576b00b1" />
<img width="1004" height="700" alt="image" src="https://github.com/user-attachments/assets/0fab1eef-7598-476e-a5b3-35ca9499bee1" />
<img width="1033" height="401" alt="image" src="https://github.com/user-attachments/assets/d66848f6-d32d-4902-9465-6dd3f9e92f86" />
<img width="1014" height="288" alt="image" src="https://github.com/user-attachments/assets/33874c23-434f-4dba-b4d4-aaeddc06132a" />
