### PR TITLE
feat(color-tokens): add PENPOT-3547 to validate tokens are displayed in reverse active set order

### DIFF
--- a/pages/workspace/design-panel-page.js
+++ b/pages/workspace/design-panel-page.js
@@ -95,6 +95,11 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
     });
     this.colorPickerTokensButton =
       this.colorPickerContainer.getByTestId('opt-token-color');
+
+    this.colorPickerTogglePanelSetButtons = this.colorPickerContainer.getByRole(
+      'button',
+      { name: 'Toggle panel' },
+    );
     this.selectedColors = this.designTabpanel.locator(
       '[class*="color_selection__element-set"]',
     );
@@ -726,6 +731,24 @@ exports.DesignPanelPage = class DesignPanelPage extends BasePage {
       this.searchByTokenNameInput,
       'Search by token name input is not visible (Colors mode is active)',
     ).not.toBeVisible();
+  }
+
+  getTogglePanelSetButtonByIndex(index) {
+    return this.colorPickerTogglePanelSetButtons.nth(index);
+  }
+
+  async isTogglePanelSetButtonsCount(count) {
+    await expect(
+      this.colorPickerTogglePanelSetButtons,
+      `Toggle panel set buttons count is ${count}`,
+    ).toHaveCount(count);
+  }
+
+  async isTogglePanelSetButtonTextByIndex(index, text) {
+    await expect(
+      this.getTogglePanelSetButtonByIndex(index),
+      `Toggle panel set button at index ${index} should contain text "${text}"`,
+    ).toContainText(text);
   }
 
   async clickAddFillButton() {

--- a/tests/tokens/token-types/color-token.spec.ts
+++ b/tests/tokens/token-types/color-token.spec.ts
@@ -17,11 +17,15 @@ const sampleData = new SampleData();
 let teamPage: TeamPage;
 let dashboardPage: DashboardPage;
 let mainPage: MainPage;
+let tokensPage: TokensPage;
+let designPanelPage: DesignPanelPage;
 
 mainTest.beforeEach('Create a team and a new file', async ({ page }) => {
   teamPage = new TeamPage(page);
   dashboardPage = new DashboardPage(page);
   mainPage = new MainPage(page);
+  tokensPage = new TokensPage(page);
+  designPanelPage = new DesignPanelPage(page);
 
   await teamPage.createTeam(teamName);
   await dashboardPage.createFileViaPlaceholder();
@@ -30,10 +34,6 @@ mainTest.beforeEach('Create a team and a new file', async ({ page }) => {
 });
 
 mainTest.describe(() => {
-  let mainPage: MainPage;
-  let tokensPage: TokensPage;
-  let designPanelPage: DesignPanelPage;
-
   const colorToken: MainToken<TokenClass> = {
     class: TokenClass.Color,
     name: 'color',
@@ -43,10 +43,6 @@ mainTest.describe(() => {
   mainTest.beforeEach(
     `Create a default board and a color token: "${colorToken.name}"`,
     async ({ page }) => {
-      mainPage = new MainPage(page);
-      tokensPage = new TokensPage(page);
-      designPanelPage = new DesignPanelPage(page);
-
       await mainPage.createDefaultBoardByCoordinates(320, 210);
       await tokensPage.clickTokensTab();
       await tokensPage.tokensComp.createTokenViaAddButtonAndEnter(colorToken);
@@ -185,6 +181,48 @@ mainTest.describe(() => {
           await designPanelPage.clickColorTokenButton(secondColorToken.name);
           await mainPage.waitForChangeIsSaved();
           await tokensPage.tokensComp.isTokenAppliedWithName(secondColorToken.name);
+        },
+      );
+    },
+  );
+});
+
+mainTest.describe(() => {
+  const globalColorSetName = 'global (color)';
+  const aliasColorDarkSetName = 'alias (color-dark)';
+
+  mainTest(
+    qase([3547], 'Color tokens are displayed only from the active sets'),
+    async () => {
+      await mainTest.step(
+        'Create a default rectangle with default fill color',
+        async () => {
+          await mainPage.clickCreateRectangleButton();
+          await mainPage.clickViewportTwice();
+          await mainPage.waitForChangeIsSaved();
+        },
+      );
+
+      await mainTest.step('Import the token test file', async () => {
+        await tokensPage.clickTokensTab();
+        await tokensPage.toolsComp.clickOnTokenToolsButton();
+        await tokensPage.toolsComp.importTokens('documents/tokens-example.json');
+      });
+
+      await mainTest.step(
+        'Open color picker for rectangle and assert token sets are listed in reverse order',
+        async () => {
+          await designPanelPage.clickFillColorIcon();
+          await designPanelPage.clickColorPickerTokensButton();
+          await designPanelPage.isTogglePanelSetButtonsCount(2);
+          await designPanelPage.isTogglePanelSetButtonTextByIndex(
+            0,
+            aliasColorDarkSetName,
+          );
+          await designPanelPage.isTogglePanelSetButtonTextByIndex(
+            1,
+            globalColorSetName,
+          );
         },
       );
     },


### PR DESCRIPTION
![gif](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExb3h2NGEyZnRyODZ1eXk5ejA3a3FmbDVyYzRmMnVlMDlvNW0yOHVhZiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/PH8gHFw2YJPaM/giphy.gif)

# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/task/2380

## Description

This PR adds a new [PENPOT-3547](https://app.qase.io/case/PENPOT-3547) test validating that only the color tokens from active sets are displayed in the color picker (in reverse order).

## Solution

* Add a new locator to retrieve the list of toggle color set buttons.
* Add methods to retrieve toggle buttons by index
* Add expect methods to check their names

## How to test

- [x] Check the code
- [x] Update the test case in Qase (Automation Status field or steps changed)
- [x] It complies with the test conventions
- [x] There are no missing snapshots
- [x] The tests run OK

## Screenshots 📸 (optional)

x5 remote passed runs
<img width="913" height="494" alt="image" src="https://github.com/user-attachments/assets/444efda0-dd21-4a79-9c9b-0a3dc2610225" />
