### PR TITLE
feat(pages): add multi page selection and deletion tests (3599, 3600, 3602, 3604)

### DIFF
--- a/pages/base-page.js
+++ b/pages/base-page.js
@@ -501,6 +501,10 @@ exports.BasePage = class BasePage {
     return url.replace(/(file-id=).../, '$1555');
   }
 
+  async getUrlParam(url, param) {
+    return new URLSearchParams(url.split('?')[1]).get(param) ?? '';
+  }
+
   async makeBadDashboardUrl(url) {
     return url.replace(/(\?team-id=).../, '$1555');
   }

--- a/pages/workspace/panels-features/pages-panel-page.ts
+++ b/pages/workspace/panels-features/pages-panel-page.ts
@@ -12,10 +12,14 @@ export class PagesPanelPage extends MainPage {
   readonly secondPageListItem: Locator;
   readonly getPageListItemByName: (name: string, index?: number | null) => Locator;
   readonly selectedPage: Locator;
+  readonly selectedPageItems: Locator;
   readonly pageNameInput: Locator;
+  readonly contextMenu: Locator;
   readonly renamePageMenuItem: Locator;
   readonly duplicatePageMenuItem: Locator;
   readonly deletePageMenuItem: Locator;
+  readonly deletePagesMenuItem: Locator;
+  readonly deletePagesDialogTitle: Locator;
   readonly collapseExpandPagesButton: Locator;
   readonly pageTrashIcon: Locator;
   readonly deletePageOkButton: Locator;
@@ -38,7 +42,11 @@ export class PagesPanelPage extends MainPage {
     };
     this.secondPageListItem = this.pagesList.filter({ hasText: /^Page 2$/ });
     this.selectedPage = page.locator('.main_ui_workspace_sidebar_sitemap__selected');
+    this.selectedPageItems = this.pagesBlock
+      .getByRole('listitem')
+      .filter({ has: this.selectedPage });
     this.pageNameInput = this.pagesBlock.getByRole('textbox');
+    this.contextMenu = page.getByTestId('context-menu');
     this.renamePageMenuItem = page
       .getByRole('listitem')
       .filter({ hasText: 'Rename' });
@@ -48,6 +56,12 @@ export class PagesPanelPage extends MainPage {
     this.deletePageMenuItem = page
       .getByRole('listitem')
       .filter({ hasText: 'Delete' });
+    this.deletePagesMenuItem = this.contextMenu
+      .getByRole('listitem')
+      .filter({ hasText: 'Delete pages' });
+    this.deletePagesDialogTitle = page.getByRole('heading', {
+      name: 'Delete pages',
+    });
     this.collapseExpandPagesButton = page.getByRole('button', {
       name: 'Pages',
       exact: true,
@@ -90,6 +104,44 @@ export class PagesPanelPage extends MainPage {
     displayed
       ? await expect(this.getPageListItemByName(name, 1)).toBeVisible()
       : await expect(this.getPageListItemByName(name)).not.toBeVisible();
+  }
+
+  async shiftClickPageByName(name: string) {
+    await this.getPageListItemByName(name).click({ modifiers: ['Shift'] });
+  }
+
+  async ctrlClickPageByName(name: string) {
+    await this.getPageListItemByName(name).click({ modifiers: ['ControlOrMeta'] });
+  }
+
+  async checkSelectedPagesCountIs(number: number) {
+    await expect(
+      this.selectedPageItems,
+      `Selected pages count should be ${number}`,
+    ).toHaveCount(number);
+  }
+
+  async getCurrentPageId(): Promise<string> {
+    return this.getUrlParam(await this.getUrl(), 'page-id');
+  }
+
+  async isBulkDeleteContextMenuVisible() {
+    await expect(
+      this.contextMenu.getByRole('listitem'),
+      'Context menu should show a single option',
+    ).toHaveCount(1);
+    await expect(
+      this.deletePagesMenuItem,
+      '"Delete pages" option should be visible',
+    ).toBeVisible();
+  }
+
+  async deleteSelectedPagesViaRightClick(pageNameToRightClick: string) {
+    await this.getPageListItemByName(pageNameToRightClick).click({
+      button: 'right',
+    });
+    await this.deletePagesMenuItem.click();
+    await this.deletePageOkButton.click();
   }
 
   async isPageRightClickMenuVisible(visible = true) {

--- a/tests/panels-features/panels-features-pages.spec.ts
+++ b/tests/panels-features/panels-features-pages.spec.ts
@@ -381,3 +381,210 @@ mainAccountFileTest(
     );
   },
 );
+
+mainAccountFileTest(
+  qase(
+    [3599, 3602, 3600, 3604],
+    'Multi-select pages via Shift/Ctrl+click and bulk-delete them',
+  ),
+  async ({ mainPage }) => {
+    let initialPageId: string;
+
+    await mainAccountFileTest.step(
+      '3599, Select a range of pages using Shift+click',
+      async () => {
+        await mainAccountFileTest.step(
+          'Create 3 extra pages (4 total)',
+          async () => {
+            await pagesPanelPage.clickAddPageButton();
+            await pagesPanelPage.clickAddPageButton();
+            await pagesPanelPage.clickAddPageButton();
+            await mainPage.waitForChangeIsSaved();
+          },
+        );
+
+        await mainAccountFileTest.step(
+          'Click on Page 1, it opens and is the only page selected',
+          async () => {
+            await pagesPanelPage.getPageListItemByName('Page 1').click();
+            initialPageId = await pagesPanelPage.getCurrentPageId();
+            await pagesPanelPage.isPageNameSelected('Page 1');
+            await pagesPanelPage.checkSelectedPagesCountIs(1);
+          },
+        );
+
+        await mainAccountFileTest.step(
+          'Shift+click on Page 3 to select the range without changing the current workspace page',
+          async () => {
+            await pagesPanelPage.shiftClickPageByName('Page 3');
+            await pagesPanelPage.isPageNameSelected('Page 1');
+            await pagesPanelPage.isPageNameSelected('Page 2');
+            await pagesPanelPage.isPageNameSelected('Page 3');
+            await pagesPanelPage.isPageNameSelected('Page 4', false);
+            await pagesPanelPage.checkSelectedPagesCountIs(3);
+            expect(
+              await pagesPanelPage.getCurrentPageId(),
+              'Workspace should stay on the originally opened page',
+            ).toBe(initialPageId);
+          },
+        );
+
+        await mainAccountFileTest.step(
+          'Shift+click on Page 4 to extend the range without changing the current workspace page',
+          async () => {
+            await pagesPanelPage.shiftClickPageByName('Page 4');
+            await pagesPanelPage.isPageNameSelected('Page 1');
+            await pagesPanelPage.isPageNameSelected('Page 2');
+            await pagesPanelPage.isPageNameSelected('Page 3');
+            await pagesPanelPage.isPageNameSelected('Page 4');
+            await pagesPanelPage.checkSelectedPagesCountIs(4);
+            expect(
+              await pagesPanelPage.getCurrentPageId(),
+              'Workspace should stay on the originally opened page',
+            ).toBe(initialPageId);
+          },
+        );
+      },
+    );
+
+    await mainAccountFileTest.step(
+      '3602, Delete multiple selected pages at once and undo the bulk delete',
+      async () => {
+        await mainAccountFileTest.step(
+          'Narrow the range from 3599 down to Page 1 through Page 3 with one more Shift+click',
+          async () => {
+            await pagesPanelPage.shiftClickPageByName('Page 3');
+            await pagesPanelPage.isPageNameSelected('Page 1');
+            await pagesPanelPage.isPageNameSelected('Page 2');
+            await pagesPanelPage.isPageNameSelected('Page 3');
+            await pagesPanelPage.isPageNameSelected('Page 4', false);
+            await pagesPanelPage.checkSelectedPagesCountIs(3);
+          },
+        );
+
+        await mainAccountFileTest.step(
+          'Right-click a selected page and verify only "Delete pages" is offered',
+          async () => {
+            await pagesPanelPage
+              .getPageListItemByName('Page 3')
+              .click({ button: 'right' });
+            await pagesPanelPage.isBulkDeleteContextMenuVisible();
+          },
+        );
+
+        await mainAccountFileTest.step(
+          'Click "Delete pages" and confirm the dialog',
+          async () => {
+            await pagesPanelPage.deletePagesMenuItem.click();
+            await expect(
+              pagesPanelPage.deletePagesDialogTitle,
+              '"Delete pages" confirmation dialog should be visible',
+            ).toBeVisible();
+            await pagesPanelPage.deletePageOkButton.click();
+            await mainPage.waitForChangeIsSaved();
+          },
+        );
+
+        await mainAccountFileTest.step(
+          'Verify Page 1, Page 2 and Page 3 were removed in a single action',
+          async () => {
+            await pagesPanelPage.checkNamedPagesCountIs(1);
+            await pagesPanelPage.isFirstPageNameDisplayed('Page 4');
+          },
+        );
+
+        await mainAccountFileTest.step(
+          'Undo and verify all pages are restored at once, in order',
+          async () => {
+            await pagesPanelPage.clickShortcutCtrlZ();
+            await pagesPanelPage.checkNamedPagesCountIs(4);
+            await pagesPanelPage.isFirstPageNameDisplayed('Page 1');
+            await pagesPanelPage.isSecondPageNameDisplayed('Page 2');
+          },
+        );
+      },
+    );
+
+    await mainAccountFileTest.step(
+      '3600, Toggle individual page selection using Ctrl/Cmd+click',
+      async () => {
+        await mainAccountFileTest.step(
+          'Click on Page 1, it opens and is the only page selected',
+          async () => {
+            await pagesPanelPage.getPageListItemByName('Page 1').click();
+            initialPageId = await pagesPanelPage.getCurrentPageId();
+            await pagesPanelPage.checkSelectedPagesCountIs(1);
+          },
+        );
+
+        await mainAccountFileTest.step(
+          'Ctrl/Cmd+click on Page 2 adds it to the selection without changing the current workspace page',
+          async () => {
+            await pagesPanelPage.ctrlClickPageByName('Page 2');
+            await pagesPanelPage.isPageNameSelected('Page 1');
+            await pagesPanelPage.isPageNameSelected('Page 2');
+            await pagesPanelPage.checkSelectedPagesCountIs(2);
+            expect(
+              await pagesPanelPage.getCurrentPageId(),
+              'Workspace should stay on the originally opened page',
+            ).toBe(initialPageId);
+          },
+        );
+
+        await mainAccountFileTest.step(
+          'Ctrl/Cmd+click on Page 4 adds it to the selection',
+          async () => {
+            await pagesPanelPage.ctrlClickPageByName('Page 4');
+            await pagesPanelPage.isPageNameSelected('Page 1');
+            await pagesPanelPage.isPageNameSelected('Page 2');
+            await pagesPanelPage.isPageNameSelected('Page 4');
+            await pagesPanelPage.isPageNameSelected('Page 3', false);
+            await pagesPanelPage.checkSelectedPagesCountIs(3);
+          },
+        );
+
+        await mainAccountFileTest.step(
+          'Ctrl/Cmd+click on Page 2 again removes it from the selection',
+          async () => {
+            await pagesPanelPage.ctrlClickPageByName('Page 2');
+            await pagesPanelPage.isPageNameSelected('Page 2', false);
+            await pagesPanelPage.isPageNameSelected('Page 1');
+            await pagesPanelPage.isPageNameSelected('Page 4');
+            await pagesPanelPage.checkSelectedPagesCountIs(2);
+          },
+        );
+      },
+    );
+
+    await mainAccountFileTest.step(
+      '3604, Delete all pages while keeping at least one page in the file',
+      async () => {
+        await mainAccountFileTest.step(
+          'Select all 4 pages using Shift+click',
+          async () => {
+            await pagesPanelPage.getPageListItemByName('Page 1').click();
+            await pagesPanelPage.shiftClickPageByName('Page 4');
+            await pagesPanelPage.checkSelectedPagesCountIs(4);
+          },
+        );
+
+        await mainAccountFileTest.step(
+          'Delete the selected pages and confirm the dialog',
+          async () => {
+            await pagesPanelPage.deleteSelectedPagesViaRightClick('Page 2');
+            await mainPage.waitForChangeIsSaved();
+          },
+        );
+
+        await mainAccountFileTest.step(
+          'Verify exactly one page remains: Page 1, with no error shown',
+          async () => {
+            await pagesPanelPage.checkNamedPagesCountIs(1);
+            await pagesPanelPage.isFirstPageNameDisplayed('Page 1');
+            await pagesPanelPage.isPageNameSelected('Page 1');
+          },
+        );
+      },
+    );
+  },
+);


### PR DESCRIPTION
![gif](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExNmU1eDJhbmYwYjRueml3MW4wN2lkdXU3Z284ankyZWtxZjEyaGI4cyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/wvPcxKARYQFnCYVU79/giphy.gif)

# Done Definition Checks

## Taiga URL (optional)

https://tree.taiga.io/project/kaleidos-qa/task/2377

## Description

This PR adds four new tests to verify the new multi-page selection and deletion features.
* [PENPOT-3599](https://app.qase.io/case/PENPOT-3599) Select a range of pages using Shift+click
* [PENPOT-3600](https://app.qase.io/case/PENPOT-3600) Toggle individual page selection using Ctrl/Cmd+click
* [PENPOT-3602](https://app.qase.io/case/PENPOT-3602) Delete multiple selected pages at once and undo the bulk delete
* [PENPOT-3604](https://app.qase.io/case/PENPOT-3604) Delete all pages while keeping at least one page in the file

## Solution

* Create a unique test that shares the same 4-page data test context in every test
* Each test is coded as a shared test step, sequentially
* Add a new `getUrlParam` to BasePage POM to verify the navigation doesn't change by recovering the `page-id`. This method is located there in case other tests need to get other URL parameters.
* Include expect messages to clarify the failure reasons.

## How to test

- [x] Check the code
- [x] Update the test case in Qase (Automation Status field or steps changed)
- [x] It complies with the test conventions
- [x] There are no missing snapshots
- [x] The tests run OK

## Screenshots 📸 (optional)

x5 remote passed runs
<img width="1089" height="491" alt="image" src="https://github.com/user-attachments/assets/8d04f894-d3ca-47f2-b7fe-966dace88fa6" />